### PR TITLE
fix: docker build failed in icm

### DIFF
--- a/docker/Dockerfile.deepep
+++ b/docker/Dockerfile.deepep
@@ -8,19 +8,19 @@ ARG gdkv_sdk_version=0.0.1
 ARG eic_sdk_version=1.0
 RUN pip config set global.index-url https://mirrors.ivolces.com/pypi/simple/
 
-RUN pip index versions sglang -i https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/
+RUN http_proxy='' pip index versions sglang -i https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/
 
 # sglang 安装
-RUN pip install "sglang[all]==${sglang_version}" --extra-index-url https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/ --extra-index-url https://bytedpypi.byted.org/simple
+RUN http_proxy='' pip install "sglang[all]==${sglang_version}" --extra-index-url https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/ --extra-index-url https://bytedpypi.byted.org/simple
 
 # sgl-kernel安装
-RUN pip install sgl_kernel==${sgl_kernel_version} --extra-index-url https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/ --extra-index-url https://bytedpypi.byted.org/simple
+RUN http_proxy='' pip install sgl_kernel==${sgl_kernel_version} --extra-index-url https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/ --extra-index-url https://bytedpypi.byted.org/simple
 
 # gdkv sdk安装
-RUN pip install hpkv==${gdkv_sdk_version} --extra-index-url https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/ --extra-index-url https://bytedpypi.byted.org/simple
+RUN http_proxy='' pip install hpkv==${gdkv_sdk_version} --extra-index-url https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/ --extra-index-url https://bytedpypi.byted.org/simple
 
 # eic sdk安装
-RUN pip install eic==${eic_sdk_version} --extra-index-url https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/ --extra-index-url https://bytedpypi.byted.org/simple
+RUN http_proxy='' pip install eic==${eic_sdk_version} --extra-index-url https://scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com/simple/ --extra-index-url https://bytedpypi.byted.org/simple
 
 # onion 安装
 RUN curl -fsSL https://mirrors.byted.org/extra-tools/ubuntu/GPG-KEY-system | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/volc-extra-tools.gpg && \
@@ -120,7 +120,7 @@ ENV NVSHMEM_DIR=/sgl-workspace/nvshmem/install
 RUN NVSHMEM_DIR=/sgl-workspace/nvshmem/install pip install .
 
 # Install mooncake
-RUN python3 -m pip install mooncake-transfer-engine
+RUN python3 -m pip install mooncake-transfer-engine --extra-index-url https://bytedpypi.byted.org/simple
 
 # Set workspace
 WORKDIR /sgl-workspace


### PR DESCRIPTION
1、fix mooncake-transfer-engine install failure

```
#51 [build 36/37] RUN python3 -m pip install mooncake-transfer-engine
#51 0.866 Looking in indexes: https://mirrors.ivolces.com/pypi/simple/
#51 0.871 WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7faf39960190>: Failed to establish a new connection: [Errno -2] Name or service not known')': /pypi/simple/mooncake-transfer-engine/
#51 1.374 WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7faf399604c0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /pypi/simple/mooncake-transfer-engine/
#51 2.376 WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7faf39960670>: Failed to establish a new connection: [Errno -2] Name or service not known')': /pypi/simple/mooncake-transfer-engine/
#51 4.380 WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7faf39960820>: Failed to establish a new connection: [Errno -2] Name or service not known')': /pypi/simple/mooncake-transfer-engine/
#51 8.384 WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0x7faf399609d0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /pypi/simple/mooncake-transfer-engine/
#51 8.392 ERROR: Could not find a version that satisfies the requirement mooncake-transfer-engine (from versions: none)
#51 8.443 
```

2、unset http_proxy when pip install wheel
