### PR TITLE
fix align_evict_mask_to_page_size

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -708,19 +708,37 @@ def align_evict_mask_to_page_size(
     num_draft_tokens: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
+    """
+    Aligns eviction mask to ensure final sequence length is page-aligned.
+    Strategy: Calculate target number of tokens to keep, then set eviction mask accordingly.
+    """
     t_range = tl.arange(0, BLOCK_SIZE)
 
     bid = tl.program_id(axis=0)
     seq_len = tl.load(seq_lens + bid)
+
+    # Load current eviction mask
     io_mask = t_range < num_draft_tokens
-    mask_row = tl.load(evict_mask + bid * num_draft_tokens + t_range, mask=io_mask)
+    mask_row = tl.load(
+        evict_mask + bid * num_draft_tokens + t_range, mask=io_mask, other=False
+    )
 
-    num_trues = tl.sum(mask_row)
-    num_false = num_draft_tokens - num_trues
+    # Calculate current tokens we'd keep (False = keep, True = evict)
+    num_to_evict = tl.sum(mask_row.to(tl.int32))
+    current_keep = num_draft_tokens - num_to_evict
+    current_final_len = seq_len + current_keep
 
-    start = (seq_len + num_false - 1) // page_size * page_size - seq_len
-    for i in range(max(start, 0), min(start + page_size, num_draft_tokens)):
-        tl.store(evict_mask + bid * num_draft_tokens + i, False)
+    # Find next page-aligned length >= current_final_len
+    target_final_len = ((current_final_len - 1) // page_size + 1) * page_size
+    target_keep = target_final_len - seq_len
+
+    # Clamp target_keep to valid range
+    target_keep = tl.maximum(0, tl.minimum(target_keep, num_draft_tokens))
+
+    # Simple strategy: keep the first target_keep tokens, evict the rest
+    for i in range(num_draft_tokens):
+        should_keep = i < target_keep
+        tl.store(evict_mask + bid * num_draft_tokens + i, not should_keep)
 
 
 @torch.compile(dynamic=True)


### PR DESCRIPTION
当前align_evict_mask_to_page_size 函数实现存在问题，在开启投机采样且page_size>1会出现内存泄露（与EIC无关），修改后可解决该问题。已提交社区https://github.com/sgl-project/sglang/pull/7112
