### PR TITLE
[FIX] avoid scale reuse between all moe layers

### DIFF
--- a/python/sglang/srt/layers/moe/cutlass_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_moe.py
@@ -182,7 +182,7 @@ def cutlass_moe_fp8(
     #                             problem_sizes2, a_map, c_map, num_experts, n,
     #                             k)
 
-    sgl_per_tensor_quant_fp8(a, a_q, a1_scale, False)
+    sgl_per_tensor_quant_fp8(a, a_q, a1_scale, True)
     get_cutlass_moe_mm_data(
         local_topk_ids,
         expert_offsets,
@@ -213,7 +213,7 @@ def cutlass_moe_fp8(
 
     silu_and_mul(c1, intermediate)
 
-    sgl_per_tensor_quant_fp8(intermediate, intemediate_q, a2_scale, False)
+    sgl_per_tensor_quant_fp8(intermediate, intemediate_q, a2_scale, True)
 
     cutlass_moe_mm(
         c2,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix mismatch caused by scale shared between all moe layers.


```python
a1_scale = moe_ws.a1_scale
a2_scale = moe_ws.a2_scale
#can not reuse scale for maxReduce will load a1_scale
a1_scale = torch.empty(1, dtype = torch.float32, device = "cuda")
a2_scale =  torch.empty(1, dtype = torch.float32, device = "cuda")

-> since a1_scale and a2_scale will be used to compute maxReduce, can not be reused between all layers(former value will affect the result of other  layer)
```
## Test results:

root@iv-ydv3enrklc5i3z3jg1m1:/sgl-workspace/FlashMLA# python3 test_err.py
[2025-06-26 01:31:56] INFO:     127.0.0.1:40748 - "POST /v1/chat/completions HTTP/1.1" 200 OK
Response: ChatCompletion(id='26255b485a854522a79d609230eb32a6', choices=[Choice(finish_reason='length', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=None, reasoning_content="Okay, the user is asking for five countries and their capitals. Let me start by recalling some common ones. First, France comes to mind with Paris as its capital. That's straightforward. Then, Japan's capital is Tokyo. Wait, is that right? I think so, but sometimes people get confused because"), matched_stop=None)], created=1750926716, model='Qwen/Qwen3-235B-A22B-FP8', object='chat.completion', service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=64, prompt_tokens=18, total_tokens=82, completion_tokens_details=None, prompt_tokens_details=None))



## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
