### PR TITLE
Draft: support MLA context parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
+.agents/
+.dbg/
+.trae/
 # Environments
 .env
 .venv

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -21,7 +21,14 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.flashinfer_backend import (
     create_flashinfer_kv_indices_triton,
 )
-from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.layers.dp_attention import get_attention_cp_rank, get_attention_tp_size
+from sglang.srt.layers.utils.cp_utils import (
+    cp_all_gather_rerange_kv_cache,
+    cp_allgather_and_save_kv_cache,
+    cp_attn_forward_extend,
+    cp_use_prefill,
+    is_prefill_cp_round_robin_split,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.speculative.spec_info import SpecInput
@@ -538,6 +545,10 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         cache_loc = forward_batch.out_cache_loc
         logits_soft_cap = layer.logit_cap
         prefill_wrapper_paged = self.forward_metadata.prefill_wrapper
+        use_prefill_cp = cp_use_prefill(forward_batch)
+        cp_size = get_global_server_args().attn_cp_size
+        full_k_for_cp = None
+        full_v_for_cp = None
 
         # Save kv cache
         if save_kv_cache and k is not None:
@@ -547,6 +558,8 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                     forward_batch.token_to_kv_pool.set_mla_kv_buffer(
                         layer, cache_loc, k, k_rope
                     )
+                elif use_prefill_cp:
+                    cp_allgather_and_save_kv_cache(forward_batch, layer, k, v, cp_size)
                 else:
                     forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
         if q_rope is not None:
@@ -557,19 +570,121 @@ class FlashInferMLAAttnBackend(AttentionBackend):
 
         if self.forward_metadata.use_ragged:
             # ragged prefill
-            if q_rope is not None:
-                q = torch.cat([q, q_rope], dim=-1)
-            qall = q.view(-1, layer.tp_q_head_num, layer.head_dim)
-            if k_rope is not None:
-                k = torch.cat([k, k_rope], dim=-1)
-            o = self.prefill_wrapper_ragged.forward(
-                qall,
-                k.view(-1, layer.tp_k_head_num, layer.head_dim).to(q.dtype),
-                v.view(-1, layer.tp_k_head_num, layer.v_head_dim).to(q.dtype),
-                causal=True,
-                sm_scale=layer.scaling,
-                logits_soft_cap=logits_soft_cap,
-            )
+            if use_prefill_cp and q_rope is None and not is_prefill_cp_round_robin_split():
+                assert k is not None and v is not None
+                full_k_for_cp = cp_all_gather_rerange_kv_cache(
+                    k.contiguous(), cp_size, forward_batch, torch.cuda.current_stream()
+                )
+                full_v_for_cp = cp_all_gather_rerange_kv_cache(
+                    v.contiguous(), cp_size, forward_batch, torch.cuda.current_stream()
+                )
+
+                def _cp_ragged_mha_attn(
+                    q_chunk, _cu_seqlens_q_cp, cache_seqlens_cp, _max_seqlen_q_cp
+                ):
+                    kv_len = int(cache_seqlens_cp[0].item())
+                    qo_indptr = torch.tensor(
+                        [0, q_chunk.shape[0]], device=q_chunk.device, dtype=torch.int32
+                    )
+                    kv_indptr = torch.tensor(
+                        [0, kv_len], device=q_chunk.device, dtype=torch.int32
+                    )
+                    self.prefill_wrapper_ragged.begin_forward(
+                        qo_indptr=qo_indptr,
+                        kv_indptr=kv_indptr,
+                        num_qo_heads=layer.tp_q_head_num,
+                        num_kv_heads=layer.tp_k_head_num,
+                        head_dim_qk=layer.head_dim,
+                        head_dim_vo=layer.v_head_dim,
+                        q_data_type=q_chunk.dtype,
+                        causal=True,
+                    )
+                    return self.prefill_wrapper_ragged.forward(
+                        q_chunk.view(-1, layer.tp_q_head_num, layer.head_dim),
+                        full_k_for_cp[:kv_len]
+                        .view(-1, layer.tp_k_head_num, layer.head_dim)
+                        .to(q_chunk.dtype),
+                        full_v_for_cp[:kv_len]
+                        .view(-1, layer.tp_k_head_num, layer.v_head_dim)
+                        .to(q_chunk.dtype),
+                        causal=True,
+                        sm_scale=layer.scaling,
+                        logits_soft_cap=logits_soft_cap,
+                    )
+
+                o = cp_attn_forward_extend(
+                    forward_batch,
+                    q,
+                    q.device,
+                    _cp_ragged_mha_attn,
+                )
+            elif use_prefill_cp and q_rope is None and is_prefill_cp_round_robin_split():
+                assert k is not None and v is not None
+                full_k_for_cp = cp_all_gather_rerange_kv_cache(
+                    k.contiguous(), cp_size, forward_batch, torch.cuda.current_stream()
+                )
+                full_v_for_cp = cp_all_gather_rerange_kv_cache(
+                    v.contiguous(), cp_size, forward_batch, torch.cuda.current_stream()
+                )
+                q_all = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+                prefix_len = 0
+                if (
+                    forward_batch.seq_lens_cpu is not None
+                    and len(forward_batch.seq_lens_cpu) == 1
+                ):
+                    prefix_len = max(
+                        int(forward_batch.seq_lens_cpu[0]) - int(full_k_for_cp.shape[0]),
+                        0,
+                    )
+                cp_rank = get_attention_cp_rank()
+                outputs = []
+                for token_idx in range(q_all.shape[0]):
+                    kv_len = prefix_len + cp_rank + token_idx * cp_size + 1
+                    qo_indptr = torch.tensor(
+                        [0, 1], device=q_all.device, dtype=torch.int32
+                    )
+                    kv_indptr = torch.tensor(
+                        [0, kv_len], device=q_all.device, dtype=torch.int32
+                    )
+                    self.prefill_wrapper_ragged.begin_forward(
+                        qo_indptr=qo_indptr,
+                        kv_indptr=kv_indptr,
+                        num_qo_heads=layer.tp_q_head_num,
+                        num_kv_heads=layer.tp_k_head_num,
+                        head_dim_qk=layer.head_dim,
+                        head_dim_vo=layer.v_head_dim,
+                        q_data_type=q_all.dtype,
+                        causal=True,
+                    )
+                    outputs.append(
+                        self.prefill_wrapper_ragged.forward(
+                            q_all[token_idx : token_idx + 1],
+                            full_k_for_cp[:kv_len]
+                            .view(-1, layer.tp_k_head_num, layer.head_dim)
+                            .to(q_all.dtype),
+                            full_v_for_cp[:kv_len]
+                            .view(-1, layer.tp_k_head_num, layer.v_head_dim)
+                            .to(q_all.dtype),
+                            causal=True,
+                            sm_scale=layer.scaling,
+                            logits_soft_cap=logits_soft_cap,
+                        )
+                    )
+                o = torch.cat(outputs, dim=0)
+            else:
+                if q_rope is not None:
+                    q = torch.cat([q, q_rope], dim=-1)
+                qall = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+                if k_rope is not None:
+                    k = torch.cat([k, k_rope], dim=-1)
+                o = self.prefill_wrapper_ragged.forward(
+                    qall,
+                    k.view(-1, layer.tp_k_head_num, layer.head_dim).to(q.dtype),
+                    v.view(-1, layer.tp_k_head_num, layer.v_head_dim).to(q.dtype),
+                    causal=True,
+                    sm_scale=layer.scaling,
+                    logits_soft_cap=logits_soft_cap,
+                )
         else:
             # mla paged prefill
             k_buf = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id).to(

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -339,6 +339,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 prefix_lens,
                 prefill_wrapper_paged=self.prefill_wrapper_paged,
                 use_ragged=use_ragged,
+                padded_qo_len=forward_batch.extend_num_tokens if use_ragged else None,
             )
             self.forward_metadata = PrefillMetadata(
                 self.prefill_wrapper_paged, use_ragged
@@ -953,6 +954,7 @@ class FlashInferMLAIndicesUpdaterPrefill:
         prefix_lens: torch.Tensor,
         prefill_wrapper_paged: BatchMLAPagedAttentionWrapper,
         use_ragged: bool,
+        padded_qo_len: Optional[int] = None,
         spec_info: Optional[SpecInput] = None,
     ):
         if use_ragged:
@@ -973,6 +975,7 @@ class FlashInferMLAIndicesUpdaterPrefill:
             self.kv_indptr,
             self.qo_indptr,
             use_ragged,
+            padded_qo_len,
             spec_info,
         )
 
@@ -988,6 +991,7 @@ class FlashInferMLAIndicesUpdaterPrefill:
         kv_indptr: torch.Tensor,
         qo_indptr: torch.Tensor,
         use_ragged: bool,
+        padded_qo_len: Optional[int] = None,
         spec_info: Optional[SpecInput] = None,
     ):
         bs = len(seq_lens)
@@ -1026,6 +1030,15 @@ class FlashInferMLAIndicesUpdaterPrefill:
                 )
             )
 
+        if use_ragged and padded_qo_len is not None:
+            actual_qo_tokens = int(qo_indptr[-1].item())
+            if padded_qo_len > actual_qo_tokens:
+                # DP/TP sync may pad extend tokens (e.g. 44 -> 48). Append one dummy
+                # request for the padded tail so flashinfer's shape check matches q.shape[0].
+                qo_indptr = torch.cat(
+                    [qo_indptr, qo_indptr.new_tensor([padded_qo_len])]
+                )
+
         # #region debug-point A:prefill-metadata
         try:
             import json
@@ -1060,6 +1073,7 @@ class FlashInferMLAIndicesUpdaterPrefill:
                                 "paged_kernel_lens": [
                                     int(x) for x in paged_kernel_lens.tolist()
                                 ],
+                                "padded_qo_len": padded_qo_len,
                                 "qo_indptr": [int(x) for x in qo_indptr.tolist()],
                                 "kv_indptr": [int(x) for x in kv_indptr.tolist()],
                             },

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -23,8 +23,6 @@ from sglang.srt.layers.attention.flashinfer_backend import (
 )
 from sglang.srt.layers.dp_attention import get_attention_cp_rank, get_attention_tp_size
 from sglang.srt.layers.utils.cp_utils import (
-    cp_all_gather_rerange_kv_cache,
-    cp_allgather_and_save_kv_cache,
     cp_attn_forward_extend,
     cp_use_prefill,
     is_prefill_cp_round_robin_split,
@@ -534,6 +532,10 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         q_rope: Optional[torch.Tensor] = None,
         k_rope: Optional[torch.Tensor] = None,
     ):
+        # CP contract:
+        # When `cp_use_prefill(forward_batch)` is true, callers must provide `k/v` that
+        # are already all-gathered and reranked into the global token order expected
+        # by the CP metadata. This backend will not re-allgather/rerank the input KV.
         if forward_batch.attn_attend_prefix_cache is not None and any(
             forward_batch.extend_prefix_lens_cpu
         ):  # MHA Chunk
@@ -547,21 +549,16 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         prefill_wrapper_paged = self.forward_metadata.prefill_wrapper
         use_prefill_cp = cp_use_prefill(forward_batch)
         cp_size = get_global_server_args().attn_cp_size
-        full_k_for_cp = None
-        full_v_for_cp = None
 
         # Save kv cache
         if save_kv_cache and k is not None:
             assert v is not None
-            if save_kv_cache:
-                if k_rope is not None:
-                    forward_batch.token_to_kv_pool.set_mla_kv_buffer(
-                        layer, cache_loc, k, k_rope
-                    )
-                elif use_prefill_cp:
-                    cp_allgather_and_save_kv_cache(forward_batch, layer, k, v, cp_size)
-                else:
-                    forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
+            if k_rope is not None:
+                forward_batch.token_to_kv_pool.set_mla_kv_buffer(
+                    layer, cache_loc, k, k_rope
+                )
+            else:
+                forward_batch.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
         if q_rope is not None:
             q = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
             q_rope = q_rope.view(
@@ -572,12 +569,8 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             # ragged prefill
             if use_prefill_cp and q_rope is None and not is_prefill_cp_round_robin_split():
                 assert k is not None and v is not None
-                full_k_for_cp = cp_all_gather_rerange_kv_cache(
-                    k.contiguous(), cp_size, forward_batch, torch.cuda.current_stream()
-                )
-                full_v_for_cp = cp_all_gather_rerange_kv_cache(
-                    v.contiguous(), cp_size, forward_batch, torch.cuda.current_stream()
-                )
+                k_all = k.to(q.dtype).view(-1, layer.tp_k_head_num, layer.head_dim)
+                v_all = v.to(q.dtype).view(-1, layer.tp_k_head_num, layer.v_head_dim)
 
                 def _cp_ragged_mha_attn(
                     q_chunk, _cu_seqlens_q_cp, cache_seqlens_cp, _max_seqlen_q_cp
@@ -601,12 +594,8 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                     )
                     return self.prefill_wrapper_ragged.forward(
                         q_chunk.view(-1, layer.tp_q_head_num, layer.head_dim),
-                        full_k_for_cp[:kv_len]
-                        .view(-1, layer.tp_k_head_num, layer.head_dim)
-                        .to(q_chunk.dtype),
-                        full_v_for_cp[:kv_len]
-                        .view(-1, layer.tp_k_head_num, layer.v_head_dim)
-                        .to(q_chunk.dtype),
+                        k_all[:kv_len],
+                        v_all[:kv_len],
                         causal=True,
                         sm_scale=layer.scaling,
                         logits_soft_cap=logits_soft_cap,
@@ -620,20 +609,16 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 )
             elif use_prefill_cp and q_rope is None and is_prefill_cp_round_robin_split():
                 assert k is not None and v is not None
-                full_k_for_cp = cp_all_gather_rerange_kv_cache(
-                    k.contiguous(), cp_size, forward_batch, torch.cuda.current_stream()
-                )
-                full_v_for_cp = cp_all_gather_rerange_kv_cache(
-                    v.contiguous(), cp_size, forward_batch, torch.cuda.current_stream()
-                )
                 q_all = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+                k_all = k.to(q.dtype).view(-1, layer.tp_k_head_num, layer.head_dim)
+                v_all = v.to(q.dtype).view(-1, layer.tp_k_head_num, layer.v_head_dim)
                 prefix_len = 0
                 if (
                     forward_batch.seq_lens_cpu is not None
                     and len(forward_batch.seq_lens_cpu) == 1
                 ):
                     prefix_len = max(
-                        int(forward_batch.seq_lens_cpu[0]) - int(full_k_for_cp.shape[0]),
+                        int(forward_batch.seq_lens_cpu[0]) - int(k_all.shape[0]),
                         0,
                     )
                 cp_rank = get_attention_cp_rank()
@@ -659,12 +644,8 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                     outputs.append(
                         self.prefill_wrapper_ragged.forward(
                             q_all[token_idx : token_idx + 1],
-                            full_k_for_cp[:kv_len]
-                            .view(-1, layer.tp_k_head_num, layer.head_dim)
-                            .to(q_all.dtype),
-                            full_v_for_cp[:kv_len]
-                            .view(-1, layer.tp_k_head_num, layer.v_head_dim)
-                            .to(q_all.dtype),
+                            k_all[:kv_len],
+                            v_all[:kv_len],
                             causal=True,
                             sm_scale=layer.scaling,
                             logits_soft_cap=logits_soft_cap,
@@ -674,13 +655,15 @@ class FlashInferMLAAttnBackend(AttentionBackend):
             else:
                 if q_rope is not None:
                     q = torch.cat([q, q_rope], dim=-1)
-                qall = q.view(-1, layer.tp_q_head_num, layer.head_dim)
                 if k_rope is not None:
                     k = torch.cat([k, k_rope], dim=-1)
+                qall = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+                k_all = k.to(q.dtype).view(-1, layer.tp_k_head_num, layer.head_dim)
+                v_all = v.to(q.dtype).view(-1, layer.tp_k_head_num, layer.v_head_dim)
                 o = self.prefill_wrapper_ragged.forward(
                     qall,
-                    k.view(-1, layer.tp_k_head_num, layer.head_dim).to(q.dtype),
-                    v.view(-1, layer.tp_k_head_num, layer.v_head_dim).to(q.dtype),
+                    k_all,
+                    v_all,
                     causal=True,
                     sm_scale=layer.scaling,
                     logits_soft_cap=logits_soft_cap,

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -660,6 +660,70 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 qall = q.view(-1, layer.tp_q_head_num, layer.head_dim)
                 k_all = k.to(q.dtype).view(-1, layer.tp_k_head_num, layer.head_dim)
                 v_all = v.to(q.dtype).view(-1, layer.tp_k_head_num, layer.v_head_dim)
+                # #region debug-point B:ragged-forward-shapes
+                try:
+                    import json
+                    import os
+                    import time
+
+                    _log_path = ".dbg/trae-debug-log-ragged-qo-mismatch.ndjson"
+                    os.makedirs(os.path.dirname(_log_path), exist_ok=True)
+                    with open(_log_path, "a", encoding="utf-8") as _f:
+                        _f.write(
+                            json.dumps(
+                                {
+                                    "sessionId": "ragged-qo-mismatch",
+                                    "runId": "pre-fix",
+                                    "hypothesisId": "B",
+                                    "ts": int(time.time() * 1000),
+                                    "location": "flashinfer_mla_backend.py:forward_extend",
+                                    "msg": "[DEBUG] ragged forward input shapes",
+                                    "data": {
+                                        "use_prefill_cp": bool(use_prefill_cp),
+                                        "piecewise_cuda_graph": bool(
+                                            is_in_piecewise_cuda_graph()
+                                        ),
+                                        "batch_size": int(forward_batch.batch_size),
+                                        "mha_one_shot": bool(
+                                            getattr(forward_batch, "mha_one_shot", False)
+                                        ),
+                                        "q_shape": [int(x) for x in qall.shape],
+                                        "k_shape": [int(x) for x in k_all.shape],
+                                        "v_shape": [int(x) for x in v_all.shape],
+                                        "self_qo_indptr": [
+                                            int(x)
+                                            for x in self.qo_indptr[
+                                                : forward_batch.batch_size + 1
+                                            ].tolist()
+                                        ],
+                                        "self_kv_indptr": [
+                                            int(x)
+                                            for x in self.kv_indptr[
+                                                : forward_batch.batch_size + 1
+                                            ].tolist()
+                                        ],
+                                        "seq_lens_cpu": (
+                                            [int(x) for x in forward_batch.seq_lens_cpu]
+                                            if forward_batch.seq_lens_cpu is not None
+                                            else None
+                                        ),
+                                        "extend_prefix_lens_cpu": (
+                                            [
+                                                int(x)
+                                                for x in forward_batch.extend_prefix_lens_cpu
+                                            ]
+                                            if forward_batch.extend_prefix_lens_cpu
+                                            is not None
+                                            else None
+                                        ),
+                                    },
+                                }
+                            )
+                            + "\n"
+                        )
+                except Exception:
+                    pass
+                # #endregion
                 o = self.prefill_wrapper_ragged.forward(
                     qall,
                     k_all,
@@ -961,6 +1025,51 @@ class FlashInferMLAIndicesUpdaterPrefill:
                     self.req_to_token,
                 )
             )
+
+        # #region debug-point A:prefill-metadata
+        try:
+            import json
+            import os
+            import time
+
+            _log_path = ".dbg/trae-debug-log-ragged-qo-mismatch.ndjson"
+            os.makedirs(os.path.dirname(_log_path), exist_ok=True)
+            with open(_log_path, "a", encoding="utf-8") as _f:
+                _f.write(
+                    json.dumps(
+                        {
+                            "sessionId": "ragged-qo-mismatch",
+                            "runId": "pre-fix",
+                            "hypothesisId": "A",
+                            "ts": int(time.time() * 1000),
+                            "location": "flashinfer_mla_backend.py:call_begin_forward",
+                            "msg": "[DEBUG] prefill metadata prepared",
+                            "data": {
+                                "bs": int(bs),
+                                "use_ragged": bool(use_ragged),
+                                "spec_info": spec_info is not None,
+                                "piecewise_cuda_graph": bool(
+                                    is_in_piecewise_cuda_graph()
+                                ),
+                                "seq_lens": [int(x) for x in seq_lens.tolist()],
+                                "prefix_lens": (
+                                    [int(x) for x in prefix_lens.tolist()]
+                                    if prefix_lens is not None
+                                    else None
+                                ),
+                                "paged_kernel_lens": [
+                                    int(x) for x in paged_kernel_lens.tolist()
+                                ],
+                                "qo_indptr": [int(x) for x in qo_indptr.tolist()],
+                                "kv_indptr": [int(x) for x in kv_indptr.tolist()],
+                            },
+                        }
+                    )
+                    + "\n"
+                )
+        except Exception:
+            pass
+        # #endregion
 
         if use_ragged:
             # ragged prefill

--- a/python/sglang/srt/layers/attention/nsa/utils.py
+++ b/python/sglang/srt/layers/attention/nsa/utils.py
@@ -283,9 +283,12 @@ def nsa_cp_round_robin_split_q_seqs(
 
 def nsa_use_prefill_cp(forward_batch, nsa_enable_prefill_cp=None):
     if nsa_enable_prefill_cp is None:
-        nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
+        nsa_enable_prefill_cp = get_global_server_args().prefill_cp_enabled()
     if (
-        forward_batch.nsa_cp_metadata is not None
+        (
+            forward_batch.nsa_cp_metadata is not None
+            or forward_batch.attn_cp_metadata is not None
+        )
         and nsa_enable_prefill_cp
         and forward_batch.forward_mode.is_context_parallel_extend()
     ):

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -140,7 +140,7 @@ class ScatterMode(Enum):
     @staticmethod
     def model_input_output():
         """The scatter mode for model forward pass input and output data"""
-        if is_nsa_enable_prefill_cp():
+        if get_global_server_args().prefill_cp_enabled():
             return ScatterMode.SCATTERED
 
         return ScatterMode.TP_ATTN_FULL

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from itertools import accumulate
-from typing import Callable, List
+from typing import Callable, List, Tuple
 
 import torch
 import torch.nn.functional as F
 
-from sglang.srt.layers.dp_attention import get_attention_cp_group
+from sglang.srt.layers.dp_attention import get_attention_cp_group, get_attention_cp_size, get_attention_cp_rank
 from sglang.srt.server_args import get_global_server_args
 
 
@@ -32,13 +32,57 @@ class ContextParallelMetadata:
 
 
 def is_prefill_context_parallel_enabled():
-    return get_global_server_args().enable_prefill_context_parallel
+    """Generic CP gating with NSA compatibility fallback."""
+    args = get_global_server_args()
+    return bool(
+        getattr(args, "enable_prefill_context_parallel", False)
+        or getattr(args, "enable_nsa_prefill_context_parallel", False)
+    )
+
+
+def get_prefill_cp_mode() -> str:
+    """Return the CP split mode with backward compatibility to NSA flags."""
+    args = get_global_server_args()
+    mode = getattr(args, "prefill_cp_mode", None)
+    if mode:
+        return mode
+    # fallback to NSA mode if generic mode not set
+    return getattr(args, "nsa_prefill_cp_mode", "in-seq-split")
 
 
 def is_prefill_cp_in_seq_split():
     return (
         is_prefill_context_parallel_enabled()
-        and get_global_server_args().prefill_cp_mode == "in-seq-split"
+        and get_prefill_cp_mode() == "in-seq-split"
+    )
+
+
+def is_prefill_cp_round_robin_split():
+    return (
+        is_prefill_context_parallel_enabled()
+        and get_prefill_cp_mode() == "round-robin-split"
+    )
+
+
+def can_prefill_cp_round_robin_split(forward_batch) -> bool:
+    """Token-level round-robin split feasibility check."""
+    if not forward_batch.forward_mode.is_context_parallel_extend():
+        return False
+    cp_size = get_attention_cp_size()
+    seq_len = sum(forward_batch.extend_seq_lens_cpu) if forward_batch.extend_seq_lens_cpu is not None else 0
+    return (
+        is_prefill_cp_round_robin_split()
+        and seq_len > 0
+        and seq_len >= cp_size
+        and cp_size > 1
+    )
+
+
+def cp_use_prefill(forward_batch) -> bool:
+    return (
+        forward_batch.attn_cp_metadata is not None
+        and is_prefill_context_parallel_enabled()
+        and forward_batch.forward_mode.is_context_parallel_extend()
     )
 
 
@@ -60,23 +104,20 @@ def can_cp_split(seq_len: int, cp_size: int, forward_batch):
 
 
 def cp_split_and_rebuild_data(forward_batch, input_: torch.Tensor):
-    input_list = list(
-        torch.split(input_, forward_batch.attn_cp_metadata.split_list, dim=0)
+    if is_prefill_cp_round_robin_split():
+        return cp_round_robin_split_data(input_)
+    input_list = list(torch.split(input_, forward_batch.attn_cp_metadata.split_list, dim=0))
+    result = torch.cat([input_list[i] for i in forward_batch.attn_cp_metadata.zigzag_index], dim=0).view(
+        -1, input_.shape[-1]
     )
-    result = torch.cat(
-        [input_list[i] for i in forward_batch.attn_cp_metadata.zigzag_index], dim=0
-    ).view(-1, input_.shape[-1])
     return result
 
 
 def cp_split_and_rebuild_position(forward_batch, positions: torch.Tensor):
-    position_id_list = list(
-        torch.split(positions, forward_batch.attn_cp_metadata.split_list, dim=-1)
-    )
-    positions = torch.cat(
-        [position_id_list[i] for i in forward_batch.attn_cp_metadata.zigzag_index],
-        dim=-1,
-    )
+    if is_prefill_cp_round_robin_split():
+        return cp_round_robin_split_data(positions)
+    position_id_list = list(torch.split(positions, forward_batch.attn_cp_metadata.split_list, dim=-1))
+    positions = torch.cat([position_id_list[i] for i in forward_batch.attn_cp_metadata.zigzag_index], dim=-1)
     return positions
 
 
@@ -187,24 +228,23 @@ def cp_all_gather_rerange_output(input_tensor, cp_size, forward_batch, stream):
     |   +-------------------------+
     """
 
-    # TODO: Do we need to remove the padding here?
-    bs_seq_len, hidden_size = input_tensor.shape
-    output_tensor = cp_all_gather_reorganized_into_tensor(
-        input_tensor,
-        forward_batch.attn_cp_metadata.total_seq_lens,
-        cp_size,
-        forward_batch,
-        stream,
-    )
-    outputs_list = list(
-        torch.split(
-            output_tensor, forward_batch.attn_cp_metadata.reverse_split_len, dim=0
+    if is_prefill_cp_round_robin_split():
+        # equal-width token interleave/disinterleave across cp ranks
+        # shape-preserving: gather then transpose/rearrange to original token order
+        output_tensor = input_tensor.new_empty(
+            (input_tensor.shape[0] * cp_size, *input_tensor.shape[1:])
         )
+        get_attention_cp_group().cp_all_gather_into_tensor_async(output_tensor, input_tensor, stream)
+        out_shape = output_tensor.shape
+        output_tensor = output_tensor.view(cp_size, -1, *out_shape[1:]).transpose(0, 1).reshape(out_shape)
+        return output_tensor
+    # in-seq-split path (zigzag)
+    hidden_size = input_tensor.shape[1] if input_tensor.dim() == 2 else input_tensor.shape[-1]
+    output_tensor = cp_all_gather_reorganized_into_tensor(
+        input_tensor, forward_batch.attn_cp_metadata.total_seq_lens, cp_size, forward_batch, stream
     )
-    output_tensor = torch.cat(
-        [outputs_list[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index],
-        dim=0,
-    )
+    outputs_list = list(torch.split(output_tensor, forward_batch.attn_cp_metadata.reverse_split_len, dim=0))
+    output_tensor = torch.cat([outputs_list[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index], dim=0)
     output_tensor = output_tensor.view(-1, hidden_size)
     return output_tensor
 
@@ -227,6 +267,17 @@ def cp_all_gather_rerange_kv_cache(input_tensor, cp_size, forward_batch, stream)
     | block0 | block1 | block2 | block3 | block4 | block5 | block6 | block7 |
     |   +-------------------------+
     """
+    if is_prefill_cp_round_robin_split():
+        output_tensor = input_tensor.new_empty(
+            (input_tensor.shape[0] * cp_size, *input_tensor.shape[1:])
+        )
+        get_attention_cp_group().cp_all_gather_into_tensor_async(
+            output_tensor, input_tensor, stream
+        )
+        out_shape = output_tensor.shape
+        return output_tensor.view(cp_size, -1, *out_shape[1:]).transpose(0, 1).reshape(
+            out_shape
+        )
     output_tensor = cp_all_gather_reorganized_into_tensor_kv_cache(
         input_tensor,
         forward_batch.attn_cp_metadata.total_seq_lens,
@@ -278,6 +329,34 @@ def cp_allgather_and_save_kv_cache(forward_batch, layer, k, v, cp_size):
     )
 
 
+def cp_allgather_and_save_mla_kv_cache(forward_batch, layer, k_nope, k_rope, cp_size):
+    """
+    Allgather MLA KV (k_nope, k_rope) from all CP ranks and write the full result
+    into each rank's local memory pool via set_mla_kv_buffer.
+    """
+    cache_loc = (
+        forward_batch.out_cache_loc
+        if not layer.is_cross_attention
+        else forward_batch.encoder_out_cache_loc
+    )
+    k_nope = k_nope.contiguous()
+    k_rope = k_rope.contiguous()
+
+    k_nope_full = cp_all_gather_rerange_kv_cache(
+        k_nope, cp_size, forward_batch, torch.cuda.current_stream()
+    )
+    k_rope_full = cp_all_gather_rerange_kv_cache(
+        k_rope, cp_size, forward_batch, torch.cuda.current_stream()
+    )
+
+    forward_batch.token_to_kv_pool.set_mla_kv_buffer(  # type: ignore
+        layer,
+        cache_loc,
+        k_nope_full,
+        k_rope_full,
+    )
+
+
 def cp_attn_forward_extend(
     forward_batch,
     q: torch.Tensor,
@@ -321,7 +400,7 @@ def prepare_context_parallel_metadata(
     cp_size,
     seqs_len,
 ):
-    """prepare_input_dp_with_cp_dsa-zigzag index
+    """prepare_input_dp_with_cp_dsa-zigzag index（in-seq-split）
     Example (DP_ATTENT_TP == CP_SIZE == 4):
     Description:
     1. Start with a full-length request.
@@ -458,3 +537,42 @@ def prepare_context_parallel_metadata(
         total_seq_lens=kv_len_origin,
     )
     return attn_cp_metadata
+
+
+# ========== Round-robin split (generic) ==========
+def cp_round_robin_split_data(input_: torch.Tensor):
+    """Token-level round-robin split: token_i -> cp_rank = i % cp_size."""
+    cp_size = get_attention_cp_size()
+    cp_rank = get_attention_cp_rank()
+    if input_.shape[0] % cp_size != 0:
+        cur_len = input_.shape[0] // cp_size + (input_.shape[0] % cp_size > cp_rank)
+        if cur_len == 0:
+            return input_.new_empty(0, *input_.shape[1:])
+        indices = torch.arange(cp_rank, input_.shape[0], cp_size, device=input_.device)
+        return input_[indices]
+    return input_.view(-1, cp_size, *input_.shape[1:])[:, cp_rank].contiguous()
+
+
+def cp_round_robin_split_q_seqs_cpu(extend_seqs_cpu: List[int]) -> Tuple[List[int], List[int]]:
+    """CPU 版 round-robin 分配后的每条序列分段长度与被选中的序列下标（长度>0）。"""
+    cp_size = get_attention_cp_size()
+    cp_rank = get_attention_cp_rank()
+    extra_seq = 0
+    q_seqs = []
+    for cur_len in extend_seqs_cpu:
+        cur_len += extra_seq
+        cur_seq = cur_len // cp_size + int(cur_len % cp_size > cp_rank)
+        q_seqs.append(cur_seq)
+        extra_seq = cur_len - cur_seq * cp_size
+    bs_idx = [i for i, x in enumerate(q_seqs) if x > 0]
+    q_seqs = [q_len for q_len in q_seqs if q_len > 0]
+    return q_seqs, bs_idx
+
+
+def prepare_round_robin_context_parallel_metadata(kv_len, _cp_rank, _cp_size, _seqs_len):
+    """
+    Round-robin mode does not need zigzag metadata. We still return a metadata object
+    so callers can use a unified `attn_cp_metadata is not None` contract.
+    """
+    _ = (_cp_rank, _cp_size, _seqs_len)
+    return ContextParallelMetadata(total_seq_lens=torch.tensor(kv_len))

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -17,6 +17,9 @@ class ContextParallelMetadata:
     per_rank_actual_token: List[int] = None
     reverse_split_len: List[int] = None
     cp_reverse_index: List[int] = None
+    rebuild_index_tensor: torch.Tensor = None
+    restore_index_tensor: torch.Tensor = None
+    gathered_index_tensor: torch.Tensor = None
 
     # metadata for attention
     kv_len_prev: int = -1
@@ -27,6 +30,8 @@ class ContextParallelMetadata:
     kv_len_next_tensor: torch.Tensor = None
     actual_seq_q_prev_tensor: torch.Tensor = None
     actual_seq_q_next_tensor: torch.Tensor = None
+    cu_seqlens_q_prev_tensor: torch.Tensor = None
+    cu_seqlens_q_next_tensor: torch.Tensor = None
 
     total_seq_lens: torch.Tensor = None
 
@@ -106,19 +111,15 @@ def can_cp_split(seq_len: int, cp_size: int, forward_batch):
 def cp_split_and_rebuild_data(forward_batch, input_: torch.Tensor):
     if is_prefill_cp_round_robin_split():
         return cp_round_robin_split_data(input_)
-    input_list = list(torch.split(input_, forward_batch.attn_cp_metadata.split_list, dim=0))
-    result = torch.cat([input_list[i] for i in forward_batch.attn_cp_metadata.zigzag_index], dim=0).view(
-        -1, input_.shape[-1]
-    )
-    return result
+    return input_.index_select(0, forward_batch.attn_cp_metadata.rebuild_index_tensor)
 
 
 def cp_split_and_rebuild_position(forward_batch, positions: torch.Tensor):
     if is_prefill_cp_round_robin_split():
         return cp_round_robin_split_data(positions)
-    position_id_list = list(torch.split(positions, forward_batch.attn_cp_metadata.split_list, dim=-1))
-    positions = torch.cat([position_id_list[i] for i in forward_batch.attn_cp_metadata.zigzag_index], dim=-1)
-    return positions
+    return positions.index_select(
+        positions.dim() - 1, forward_batch.attn_cp_metadata.rebuild_index_tensor
+    )
 
 
 def cp_all_gather_reorganized_into_tensor(
@@ -146,23 +147,9 @@ def cp_all_gather_reorganized_into_tensor(
     get_attention_cp_group().cp_all_gather_into_tensor_async(
         input_tensor_full, input_tensor, stream
     )
-
-    outputs_list_max = list(
-        torch.split(
-            input_tensor_full, forward_batch.attn_cp_metadata.max_rank_len, dim=0
-        )
+    return input_tensor_full.index_select(
+        0, forward_batch.attn_cp_metadata.gathered_index_tensor
     )
-    outputs = torch.cat(
-        [
-            outputs_list_max[index][:per_rank_len]
-            for index, per_rank_len in enumerate(
-                forward_batch.attn_cp_metadata.per_rank_actual_token
-            )
-        ],
-        dim=0,
-    )
-
-    return outputs
 
 
 def cp_all_gather_reorganized_into_tensor_kv_cache(
@@ -192,23 +179,9 @@ def cp_all_gather_reorganized_into_tensor_kv_cache(
     get_attention_cp_group().cp_all_gather_into_tensor_async(
         input_tensor_full, input_tensor, stream
     )
-
-    outputs_list_max = list(
-        torch.split(
-            input_tensor_full, forward_batch.attn_cp_metadata.max_rank_len, dim=0
-        )
+    return input_tensor_full.index_select(
+        0, forward_batch.attn_cp_metadata.gathered_index_tensor
     )
-    outputs = torch.cat(
-        [
-            outputs_list_max[index][:per_rank_len]
-            for index, per_rank_len in enumerate(
-                forward_batch.attn_cp_metadata.per_rank_actual_token
-            )
-        ],
-        dim=0,
-    )
-
-    return outputs
 
 
 def cp_all_gather_rerange_output(input_tensor, cp_size, forward_batch, stream):
@@ -243,8 +216,9 @@ def cp_all_gather_rerange_output(input_tensor, cp_size, forward_batch, stream):
     output_tensor = cp_all_gather_reorganized_into_tensor(
         input_tensor, forward_batch.attn_cp_metadata.total_seq_lens, cp_size, forward_batch, stream
     )
-    outputs_list = list(torch.split(output_tensor, forward_batch.attn_cp_metadata.reverse_split_len, dim=0))
-    output_tensor = torch.cat([outputs_list[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index], dim=0)
+    output_tensor = output_tensor.index_select(
+        0, forward_batch.attn_cp_metadata.restore_index_tensor
+    )
     output_tensor = output_tensor.view(-1, hidden_size)
     return output_tensor
 
@@ -285,14 +259,8 @@ def cp_all_gather_rerange_kv_cache(input_tensor, cp_size, forward_batch, stream)
         forward_batch,
         stream,
     )
-    outputs_list = list(
-        torch.split(
-            output_tensor, forward_batch.attn_cp_metadata.reverse_split_len, dim=0
-        )
-    )
-    output_tensor = torch.cat(
-        [outputs_list[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index],
-        dim=0,
+    output_tensor = output_tensor.index_select(
+        0, forward_batch.attn_cp_metadata.restore_index_tensor
     )
     # No need to reshape - output_tensor already has the correct shape [seq_len, ...]
     return output_tensor
@@ -377,18 +345,18 @@ def cp_attn_forward_extend(
 
     q_prev, q_next = torch.chunk(q, 2, dim=0)
 
-    cu_seqlens_q_prev = torch.tensor(
-        [0, cp_meta.actual_seq_q_prev], device=device, dtype=torch.int32
-    )
     result_prev = attn_fn(
-        q_prev, cu_seqlens_q_prev, cp_meta.kv_len_prev_tensor, cp_meta.actual_seq_q_prev
+        q_prev,
+        cp_meta.cu_seqlens_q_prev_tensor,
+        cp_meta.kv_len_prev_tensor,
+        cp_meta.actual_seq_q_prev,
     )
 
-    cu_seqlens_q_next = torch.tensor(
-        [0, cp_meta.actual_seq_q_next], device=device, dtype=torch.int32
-    )
     result_next = attn_fn(
-        q_next, cu_seqlens_q_next, cp_meta.kv_len_next_tensor, cp_meta.actual_seq_q_next
+        q_next,
+        cp_meta.cu_seqlens_q_next_tensor,
+        cp_meta.kv_len_next_tensor,
+        cp_meta.actual_seq_q_next,
     )
 
     return torch.concat([result_prev, result_next], dim=0)
@@ -466,8 +434,9 @@ def prepare_context_parallel_metadata(
     if remainder > 0:
         split_list[:remainder] = [x + 1 for x in split_list[:remainder]]
 
-    seq_max_rank_len = (kv_len + cp_size - 1) // cp_size
-    max_rank_len = seq_max_rank_len.repeat_interleave(cp_size).int().tolist()
+    seq_max_rank_len_tensor = (kv_len + cp_size - 1) // cp_size
+    seq_max_rank_len = int(seq_max_rank_len_tensor.item())
+    max_rank_len = seq_max_rank_len_tensor.repeat_interleave(cp_size).int().tolist()
     zigzag_index = list(
         range(cp_rank, cp_rank + bs_per_cp_group * cp_segment_num, cp_segment_num)
     ) + list(
@@ -510,13 +479,40 @@ def prepare_context_parallel_metadata(
     actual_seq_q_prev = split_list[cp_rank]
     actual_seq_q_next = split_list[cp_size * 2 - cp_rank - 1]
     # Flash Attention expects cache_seqlens to have shape (batch_size,), not scalar
-    kv_len_prev_tensor = torch.tensor([kv_len_prev], device="cuda", dtype=torch.int32)
-    kv_len_next_tensor = torch.tensor([kv_len_next], device="cuda", dtype=torch.int32)
+    device = torch.device("cuda")
+    kv_len_prev_tensor = torch.tensor([kv_len_prev], device=device, dtype=torch.int32)
+    kv_len_next_tensor = torch.tensor([kv_len_next], device=device, dtype=torch.int32)
     actual_seq_q_prev_tensor = torch.tensor(
-        [actual_seq_q_prev], device="cuda", dtype=torch.int32
+        [actual_seq_q_prev], device=device, dtype=torch.int32
     )
     actual_seq_q_next_tensor = torch.tensor(
-        [actual_seq_q_next], device="cuda", dtype=torch.int32
+        [actual_seq_q_next], device=device, dtype=torch.int32
+    )
+    cu_seqlens_q_prev_tensor = torch.tensor(
+        [0, actual_seq_q_prev], device=device, dtype=torch.int32
+    )
+    cu_seqlens_q_next_tensor = torch.tensor(
+        [0, actual_seq_q_next], device=device, dtype=torch.int32
+    )
+
+    split_offsets = [0] + list(accumulate(split_list))
+    rebuild_indices = []
+    for split_idx in zigzag_index:
+        rebuild_indices.extend(
+            range(split_offsets[split_idx], split_offsets[split_idx + 1])
+        )
+    rebuild_index_tensor = torch.tensor(
+        rebuild_indices, device=device, dtype=torch.long
+    )
+    restore_index_tensor = torch.empty_like(rebuild_index_tensor)
+    restore_index_tensor[rebuild_index_tensor] = torch.arange(
+        rebuild_index_tensor.numel(), device=device, dtype=torch.long
+    )
+    gathered_indices = []
+    for rank_idx, token_count in enumerate(per_rank_actual_token):
+        gathered_indices.extend(range(rank_idx * seq_max_rank_len, rank_idx * seq_max_rank_len + token_count))
+    gathered_index_tensor = torch.tensor(
+        gathered_indices, device=device, dtype=torch.long
     )
 
     attn_cp_metadata = ContextParallelMetadata(
@@ -526,6 +522,9 @@ def prepare_context_parallel_metadata(
         per_rank_actual_token=per_rank_actual_token,
         reverse_split_len=reverse_split_len,
         cp_reverse_index=cp_reverse_index,
+        rebuild_index_tensor=rebuild_index_tensor,
+        restore_index_tensor=restore_index_tensor,
+        gathered_index_tensor=gathered_index_tensor,
         kv_len_prev=kv_len_prev,
         kv_len_next=kv_len_next,
         actual_seq_q_prev=actual_seq_q_prev,
@@ -534,6 +533,8 @@ def prepare_context_parallel_metadata(
         kv_len_next_tensor=kv_len_next_tensor,
         actual_seq_q_prev_tensor=actual_seq_q_prev_tensor,
         actual_seq_q_next_tensor=actual_seq_q_next_tensor,
+        cu_seqlens_q_prev_tensor=cu_seqlens_q_prev_tensor,
+        cu_seqlens_q_next_tensor=cu_seqlens_q_next_tensor,
         total_seq_lens=kv_len_origin,
     )
     return attn_cp_metadata

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -513,9 +513,7 @@ class SchedulerPPMixin:
     def init_pp_loop_state(self: Scheduler):
         self.pp_loop_size: int = self.pp_size + self.server_args.pp_async_batch_depth
         # In CP mode, attention weights are duplicated, eliminating the need for the attention TP all-gather operation.
-        self.require_attn_tp_allgather = (
-            not self.server_args.enable_nsa_prefill_context_parallel
-        )
+        self.require_attn_tp_allgather = not self.server_args.prefill_cp_enabled()
         self.mbs = [None] * self.pp_loop_size
         self.last_mbs = [None] * self.pp_loop_size
         self.running_mbs = [

--- a/python/sglang/srt/model_executor/cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/cuda_graph_runner.py
@@ -537,7 +537,7 @@ class CudaGraphRunner:
 
         self.attn_tp_size = get_attention_tp_size()
         self.attn_tp_rank = get_attention_tp_rank()
-        self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
+        self.nsa_enable_prefill_cp = model_runner.server_args.prefill_cp_enabled()
 
         self.deepep_adapter = DeepEPCudaGraphRunnerAdapter()
 

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2819,7 +2819,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             forward_batch.num_token_non_padded is not None
             and forward_batch.global_num_tokens_gpu is not None
             and require_gathered_buffer(self.server_args)
-            and not is_nsa_enable_prefill_cp()
+            and not self.server_args.prefill_cp_enabled()
         ):
             forward_batch.adjust_num_token_non_padded_for_attn_tp(
                 server_args=self.server_args,

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -358,6 +358,54 @@ class DeepseekMHAForwardMixin:
         forward_batch.mha_return_lse = False
         # Do mha for extended part without prefix
         forward_batch.set_attn_attend_prefix_cache(False)
+        # #region debug-point C:mha-one-shot-inputs
+        try:
+            import json
+            import os
+            import time
+
+            _log_path = ".dbg/trae-debug-log-ragged-qo-mismatch.ndjson"
+            os.makedirs(os.path.dirname(_log_path), exist_ok=True)
+            with open(_log_path, "a", encoding="utf-8") as _f:
+                _f.write(
+                    json.dumps(
+                        {
+                            "sessionId": "ragged-qo-mismatch",
+                            "runId": "pre-fix",
+                            "hypothesisId": "C",
+                            "ts": int(time.time() * 1000),
+                            "location": "forward_mha.py:forward_normal_one_shot_core",
+                            "msg": "[DEBUG] one-shot core inputs",
+                            "data": {
+                                "batch_size": int(forward_batch.batch_size),
+                                "mha_one_shot": bool(
+                                    getattr(forward_batch, "mha_one_shot", False)
+                                ),
+                                "has_extend_prefix": bool(has_extend_prefix),
+                                "q_shape": [int(x) for x in q.shape],
+                                "k_shape": [int(x) for x in k.shape],
+                                "v_shape": [int(x) for x in v.shape],
+                                "seq_lens_cpu": (
+                                    [int(x) for x in forward_batch.seq_lens_cpu]
+                                    if forward_batch.seq_lens_cpu is not None
+                                    else None
+                                ),
+                                "extend_prefix_lens_cpu": (
+                                    [
+                                        int(x)
+                                        for x in forward_batch.extend_prefix_lens_cpu
+                                    ]
+                                    if forward_batch.extend_prefix_lens_cpu is not None
+                                    else None
+                                ),
+                            },
+                        }
+                    )
+                    + "\n"
+                )
+        except Exception:
+            pass
+        # #endregion
         return self.forward_normal_core(q, k, v, forward_batch)
 
     def _chunked_prefix_attn_mha(

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -268,9 +268,14 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
     ) -> torch.Tensor:
         # TODO current just support prefill batch=1 and len(input_ids) > self.cp_size * 2
         if self.nsa_enable_prefill_cp:
-            if can_cp_split(len(input_ids), self.cp_size, self.use_nsa, forward_batch):
+            cp_token_len = (
+                forward_batch.extend_num_tokens
+                if forward_batch.extend_num_tokens is not None
+                else len(input_ids)
+            )
+            if can_cp_split(cp_token_len, self.cp_size, self.use_nsa, forward_batch):
                 forward_batch.nsa_cp_metadata = prepare_input_dp_with_cp_dsa(
-                    len(input_ids),
+                    cp_token_len,
                     self.cp_rank,
                     self.cp_size,
                     forward_batch.seq_lens_cpu.tolist(),

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2228,9 +2228,14 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
         if self.nsa_enable_prefill_cp:
-            if can_cp_split(len(input_ids), self.cp_size, self.use_nsa, forward_batch):
+            cp_token_len = (
+                forward_batch.extend_num_tokens
+                if forward_batch.extend_num_tokens is not None
+                else len(input_ids)
+            )
+            if can_cp_split(cp_token_len, self.cp_size, self.use_nsa, forward_batch):
                 forward_batch.nsa_cp_metadata = prepare_input_dp_with_cp_dsa(
-                    len(input_ids),
+                    cp_token_len,
                     self.cp_rank,
                     self.cp_size,
                     forward_batch.seq_lens_cpu.tolist(),

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -980,9 +980,14 @@ class Qwen3MoeForCausalLM(nn.Module):
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
         if is_prefill_context_parallel_enabled():
-            if can_cp_split(len(input_ids), self.attn_cp_size, forward_batch):
+            cp_token_len = (
+                forward_batch.extend_num_tokens
+                if forward_batch.extend_num_tokens is not None
+                else len(input_ids)
+            )
+            if can_cp_split(cp_token_len, self.attn_cp_size, forward_batch):
                 forward_batch.attn_cp_metadata = prepare_context_parallel_metadata(
-                    len(input_ids),
+                    cp_token_len,
                     self.attn_cp_rank,
                     self.attn_cp_size,
                     forward_batch.seq_lens_cpu.tolist(),

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -162,7 +162,7 @@ RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND = ["fa3", "triton"]
 
 NSA_PREFILL_CP_SPLIT_CHOICES = ["in-seq-split", "round-robin-split"]
 
-PREFILL_CP_SPLIT_CHOICES = ["in-seq-split"]
+PREFILL_CP_SPLIT_CHOICES = ["in-seq-split", "round-robin-split"]
 
 DEFAULT_LORA_EVICTION_POLICY = "lru"
 
@@ -5740,7 +5740,7 @@ class ServerArgs:
             type=str,
             default=ServerArgs.prefill_cp_mode,
             choices=PREFILL_CP_SPLIT_CHOICES,
-            help="Token splitting mode for the prefill phase under context parallelism. Optional values: 'in-seq-split' (default)",
+            help="Token splitting mode for the prefill phase under context parallelism. Optional values: 'in-seq-split' (default), 'round-robin-split'",
         )
         parser.add_argument(
             "--enable-fused-qk-norm-rope",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1541,11 +1541,11 @@ class ServerArgs:
                     logger.info("Use nsa attention backend for DeepSeek with DSA.")
 
                 if not is_npu():  # CUDA or ROCm GPU
-                    if self.enable_nsa_prefill_context_parallel:
+                    if self.prefill_cp_enabled():
                         logger.warning(
                             "Context parallel feature is still under experiment. It has only been verified on Hopper platform."
                         )
-                        if self.nsa_prefill_cp_mode == "in-seq-split":
+                        if self.get_prefill_cp_mode() == "in-seq-split":
                             # TODO Supports moe_dense_tp_size != 1, kv cache dtype = "fp8",moe_a2a_backend non-deepep and cross-machine operation .
                             self.enable_dp_attention = True
                             self.moe_dense_tp_size = 1
@@ -1592,13 +1592,38 @@ class ServerArgs:
                     self._set_default_nsa_kv_cache_dtype(major, self.quantization)
                     self._set_default_nsa_backends(self.kv_cache_dtype, major)
 
-                if self.enable_nsa_prefill_context_parallel:
+                if self.prefill_cp_enabled():
                     assert (
                         self.disaggregation_mode != "decode"
-                    ), "CP is only supported for prefill when PD disaggregation, please remove --enable-nsa-prefill-context-parallel."
+                    ), "CP is only supported for prefill when PD disaggregation, please remove the CP enable flags."
 
             else:
                 # DeepSeek V3/R1/V3.1
+                if self.prefill_cp_enabled():
+                    logger.warning(
+                        "Context parallel feature is still under experiment. It has only been verified on Hopper platform."
+                    )
+                    if self.get_prefill_cp_mode() == "in-seq-split":
+                        self.enable_dp_attention = True
+                        self.moe_dense_tp_size = 1
+                        self.moe_a2a_backend = "deepep"
+                        self.ep_size = self.tp_size
+                        logger.warning(
+                            "For in-seq split mode, we have the following restrictions: moe_dense_tp_size == 1, moe_a2a_backend == deepep, ep_size == tp_size, batch_size == 1"
+                        )
+                    else:
+                        self.enable_dp_attention = True
+                        self.moe_dense_tp_size = 1
+                        assert (
+                            self.dp_size == 1
+                        ), "For round-robin split mode, dp attention is not supported."
+                    assert (
+                        self.tp_size == 8
+                    ), "Current multi-machine CP support suffers from precision issues. So context parallel only support Single machine(tp_size == 8)"
+                    self.attn_cp_size = self.tp_size // self.dp_size
+                    logger.warning(
+                        f"Enable Context Parallel opt for DeepSeek/Kimi MLA, Setting dp_size == {self.dp_size} and moe_dense_tp_size == {self.moe_dense_tp_size}, ep_size == {self.ep_size}, tp_size == {self.tp_size}, kv_cache_dtype == {self.kv_cache_dtype}, moe_a2a_backend {self.moe_a2a_backend} "
+                    )
                 if not self.disable_piecewise_cuda_graph:
                     logger.info("Piecewise CUDA graph is enabled, use MLA for prefill.")
 
@@ -6089,6 +6114,16 @@ class ServerArgs:
 
         model_config = self.get_model_config()
         return model_config.attention_arch == AttentionArch.MLA
+
+    def prefill_cp_enabled(self) -> bool:
+        return self.enable_prefill_context_parallel or self.enable_nsa_prefill_context_parallel
+
+    def get_prefill_cp_mode(self) -> str:
+        if self.enable_prefill_context_parallel:
+            return self.prefill_cp_mode
+        if self.enable_nsa_prefill_context_parallel:
+            return self.nsa_prefill_cp_mode
+        return self.prefill_cp_mode
 
     def is_attention_backend_not_set(self):
         return (


### PR DESCRIPTION
*特性&原则*
- 设计目标：
  - 在保持最小改动的前提下，将 Context Parallel（CP）从仅 NSA 扩展到 FlashInfer MLA 路径，并为 DeepSeek V3 与 Kimi-K2.5 模型接入通用 CP 流程；
  - 通过公共 CP utils 解耦 NSA 与 CP 判断，在不同 backend 中实现对应行为。
- 改动范围：
  - 不重构现有 NSA-CP 路径；
  - 新增/复用通用 CP 元数据与 gating，补齐 FlashInfer MLA 的 CP 前向分支，并在 DeepSeek/Kimi 的 MLA 路径上启用通用 CP。
  - FlashInfer 路径需要同时覆盖 `in-seq-split` 与 `round-robin-split`。
  - CLI/内部逻辑采用“通用 helper/flag 优先，旧 NSA 参数保留兼容”的策略。

*现状分析*
- 通用 CP 基础：`cp_utils.py` 已提供 `ContextParallelMetadata`、`can_cp_split()`、`cp_attn_forward_extend()` 等通用能力，且 `ForwardBatch` 同时支持 `attn_cp_metadata` 与 `nsa_cp_metadata` 两套元数据。
- NSA 专用路径：`nsa/utils.py` 与 `communicator_nsa_cp.py` 持有 NSA-CP 专用逻辑与通讯器，`DeepseekV2` 在 NSA 分支中使用它们；CP gating 广泛使用 `is_nsa_enable_prefill_cp()`。
- 已有通用模型接入样例：`qwen3_moe.py` 在 forward 中基于通用 CP utils 设置 `forward_batch.attn_cp_metadata`，由后端在前向时消费。
- Attention Backend 状态：
  - FlashAttention 后端中已有对 `attn_cp_metadata` 的处理（prefill 阶段分块+聚合 KV）。
  - FlashInfer MLA 系列（`flashinfer_mla_backend.py`、`flashmla_backend.py`、`trtllm_mla_backend.py`）目前未接入 `attn_cp_metadata` 分支。
  - 后端注册：MLA 模型使用 `flashinfer` 时，会被路由到 `FlashInferMLAAttnBackend`。
  - DeepSeek V3 系列在 `deepseek_v2.py` 中。NSA 分支已实现 NSA-CP；非 NSA 的 MLA 分支尚未接入通用 CP。
  - Kimi-K2.5 架构同样在 `deepseek_v2` 路径下由 `model_arch` 分支控制，需在 MLA 分支复用通用 CP。
- ServerArgs：既有 `enable_nsa_prefill_context_parallel`（legacy）与通用 `enable_prefill_context_parallel` 并存，但通用 gating 使用较少；CLI 已暴露 `--attn-cp-size` 与通用 CP 标志位。


*实现方式*
见https://github.com/sgl-project/sglang/commit/340f9b3e8069b8597e1d145a0e938280f85fd2dd