### PR TITLE
ci: build nightly dev image from ep_main

### DIFF
--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -95,9 +95,9 @@ jobs:
 
       - name: Build and Push Dev Image
         run: |
-          # Nightly (schedule) installs latest release; manual dispatch builds from checked-out source
+          # Nightly and manual dispatch build from checked-out source
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            SOURCE_ARG="--build-arg USE_LATEST_SGLANG=1"
+            SOURCE_ARG="--build-arg BRANCH_TYPE=local"
           else
             SOURCE_ARG="--build-arg BRANCH_TYPE=local"
           fi


### PR DESCRIPTION
## Summary
- build scheduled dev images from the checked-out repository source instead of cloning upstream latest SGLang
- keep manual dispatch behavior unchanged by continuing to pass `BRANCH_TYPE=local`

## Root Cause
The nightly `schedule` path passed `USE_LATEST_SGLANG=1`, which made the Dockerfile clone `sgl-project/sglang` default branch during the image build. That meant the fork's nightly workflow ran from `ep_main`, but the package installed into the image came from upstream `main`.

## Validation
- `git diff --check`
- parsed `.github/workflows/release-docker-dev.yml` with PyYAML
