### PR TITLE
Fix fp4 integration

### DIFF
--- a/python/sglang/srt/layers/asym_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/compile_utils.py
@@ -76,6 +76,8 @@ class AsymGemmKernelType(IntEnum):
     GROUPED_GEMM_NT_F8F8BF16_CONTIG = auto()
     GROUPED_GEMM_NT_BF16_MASKED = auto()
     GROUPED_GEMM_NT_BF16_CONTIG = auto()
+    GROUPED_GEMM_NT_FP4_MASKED = auto()
+    GROUPED_GEMM_NT_FP4_CONTIG = auto()
 
 
 _INITIALIZATION_DICT: Dict[Tuple[AsymGemmKernelType, int, int, int], bool] = dict()
@@ -185,6 +187,8 @@ class _BaseWarmupExecutor:
             AsymGemmKernelType.GROUPED_GEMM_NT_F8F8BF16_MASKED: _GroupedMaskedWarmupExecutor,
             AsymGemmKernelType.GROUPED_GEMM_NT_BF16_CONTIG: _GroupedContBf16WarmupExecutor,
             AsymGemmKernelType.GROUPED_GEMM_NT_BF16_MASKED: _GroupedMaskedBf16WarmupExecutor,
+            AsymGemmKernelType.GROUPED_GEMM_NT_FP4_CONTIG: _GroupedContFp4WarmupExecutor,
+            AsymGemmKernelType.GROUPED_GEMM_NT_FP4_MASKED: _GroupedMaskedFp4WarmupExecutor,
         }[kernel_type](**kwargs)
 
     @staticmethod
@@ -207,6 +211,26 @@ class _BaseWarmupExecutor:
             return (
                 num_groups * max_m * k * 2
                 + num_groups * n * k * 2
+                + num_groups * 4
+                + num_groups * max_m * n * 2
+            ) / _GB
+        elif kernel_type == AsymGemmKernelType.GROUPED_GEMM_NT_FP4_CONTIG:
+            # FP4 packs two elements per byte (k/2); scales are 1 E4M3 byte per
+            # group_size=16 k-elements.
+            return (
+                max_m * (k // 2)
+                + num_groups * n * (k // 2)
+                + max_m * (k // 16)
+                + num_groups * n * (k // 16)
+                + max_m * 4
+                + max_m * n * 2
+            ) / _GB
+        elif kernel_type == AsymGemmKernelType.GROUPED_GEMM_NT_FP4_MASKED:
+            return (
+                num_groups * max_m * (k // 2)
+                + num_groups * n * (k // 2)
+                + num_groups * max_m * (k // 16)
+                + num_groups * n * (k // 16)
                 + num_groups * 4
                 + num_groups * max_m * n * 2
             ) / _GB
@@ -348,6 +372,45 @@ class _GroupedMaskedBf16WarmupExecutor(_BaseWarmupExecutor):
     #         m,
     #         compiled_dims="nk",
     #     )
+
+
+def _empty_packed_fp4(size):
+    """Allocate a packed-FP4 tensor and matching E4M3 scale tensor.
+
+    Packed layout: last dim holds two FP4 elements per uint8 byte (k_packed = k/2).
+    Scales use group_size=16 along K.
+    """
+    *dims, k = size
+    assert k % 2 == 0
+    group_size = 16
+    assert k % group_size == 0
+    packed = torch.empty((*dims, k // 2), device="cuda", dtype=torch.uint8)
+    scale = torch.empty(
+        (*dims, k // group_size), device="cuda", dtype=torch.float8_e4m3fn
+    )
+    return packed, scale
+
+
+class _GroupedContFp4WarmupExecutor(_BaseWarmupExecutor):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+        self.lhs_q, self.lhs_s = _empty_packed_fp4((max_m, k))
+        self.rhs_q, self.rhs_s = _empty_packed_fp4((num_groups, n, k))
+        self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
+
+    def execute(self, m):
+        return
+
+
+class _GroupedMaskedFp4WarmupExecutor(_BaseWarmupExecutor):
+    def __init__(self, max_m: int, n: int, k: int, num_groups: int):
+        self.lhs_q, self.lhs_s = _empty_packed_fp4((num_groups, max_m, k))
+        self.rhs_q, self.rhs_s = _empty_packed_fp4((num_groups, n, k))
+        self.out = torch.empty(
+            (num_groups, max_m, n), device="cuda", dtype=torch.bfloat16
+        )
+
+    def execute(self, m):
+        return
 
 
 @contextmanager

--- a/python/sglang/srt/layers/asym_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/entrypoint.py
@@ -38,15 +38,6 @@ def grouped_gemm_nt_f8f8bf16_masked(
     _sanity_check_input(lhs)
     _sanity_check_input(rhs)
 
-    # Lazy import to avoid circular dependency with moe_runner.asym_gemm.
-    from sglang.srt.layers.moe.moe_runner.asym_gemm import (
-        build_offsets_experts_from_masked_m,
-    )
-
-    offsets, experts, list_size = build_offsets_experts_from_masked_m(
-        masked_m, num_groups, m
-    )
-
     with compile_utils.asym_gemm_execution_hook(
         expected_m, n, k, num_groups, kernel_type
     ):
@@ -57,9 +48,7 @@ def grouped_gemm_nt_f8f8bf16_masked(
                 lhs,
                 rhs,
                 out,
-                offsets,
-                experts,
-                list_size,
+                masked_m,
                 expected_m,
                 disable_ue8m0_cast=False,
             )

--- a/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
@@ -309,12 +309,16 @@ class AsymGemmRunnerCore(MoeRunnerCore):
         super().__init__(config)
         assert self.config.activation == "silu"
         assert self.config.is_gated
-        # Internal BF16 runner core for dtype-based dispatch
+        # Internal BF16 / FP4 runner cores for dtype-based dispatch
         from sglang.srt.layers.moe.moe_runner.asym_gemm_bf16 import (
             AsymGemmBf16RunnerCore,
         )
+        from sglang.srt.layers.moe.moe_runner.asym_gemm_fp4 import (
+            AsymGemmFp4RunnerCore,
+        )
 
         self._bf16_core = AsymGemmBf16RunnerCore(config)
+        self._fp4_core = AsymGemmFp4RunnerCore(config)
 
     def run(
         self,
@@ -325,10 +329,15 @@ class AsymGemmRunnerCore(MoeRunnerCore):
         from sglang.srt.layers.moe.moe_runner.asym_gemm_bf16 import (
             AsymGemmBf16MoeQuantInfo,
         )
+        from sglang.srt.layers.moe.moe_runner.asym_gemm_fp4 import (
+            AsymGemmFp4MoeQuantInfo,
+        )
 
-        # Dtype-based dispatch: route to BF16 runner core if quant_info is BF16
+        # Dtype-based dispatch: route to BF16 / FP4 runner core by quant_info type
         if isinstance(quant_info, AsymGemmBf16MoeQuantInfo):
             return self._bf16_core.run(runner_input, quant_info, running_state)
+        if isinstance(quant_info, AsymGemmFp4MoeQuantInfo):
+            return self._fp4_core.run(runner_input, quant_info, running_state)
 
         if not runner_input.use_masked_gemm:
             hidden_states = self._run_contiguous_gemm(
@@ -713,10 +722,17 @@ def pre_permute_standard_to_asym_gemm(
     from sglang.srt.layers.moe.moe_runner.asym_gemm_bf16 import (
         AsymGemmBf16MoeQuantInfo,
     )
+    from sglang.srt.layers.moe.moe_runner.asym_gemm_fp4 import (
+        AsymGemmFp4MoeQuantInfo,
+    )
 
     # Dtype-based dispatch
     if isinstance(quant_info, AsymGemmBf16MoeQuantInfo):
         return _pre_permute_standard_to_asym_gemm_bf16(
+            dispatch_output, quant_info, runner_config, running_state
+        )
+    if isinstance(quant_info, AsymGemmFp4MoeQuantInfo):
+        return _pre_permute_standard_to_asym_gemm_fp4(
             dispatch_output, quant_info, runner_config, running_state
         )
 
@@ -866,6 +882,176 @@ def _pre_permute_standard_to_asym_gemm_bf16(
     )
 
 
+def _fill_gateup_input_fp4(
+    hidden_states_fp4: torch.Tensor,
+    hidden_states_scale: torch.Tensor,
+    gateup_input: torch.Tensor,
+    gateup_input_scale: torch.Tensor,
+    src2dst: torch.Tensor,
+    topk_ids: torch.Tensor,
+    top_k: int,
+):
+    """Scatter pre-quantized FP4 tokens + E4M3 scales into the padded buffer."""
+
+    @triton.jit
+    def _fill_gateup_input_fp4_kernel(
+        input_ptr,
+        scale_ptr,
+        gateup_input_ptr,
+        gateup_input_scale_ptr,
+        src2dst_ptr,
+        topk_ids_ptr,
+        topk,
+        packed_size,
+        scale_size,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        src_idx_int32 = tl.program_id(0)
+        src_idx = src_idx_int32.to(tl.int64)
+        src2dst_ptr = src2dst_ptr + src_idx * topk
+        topk_ids_ptr = topk_ids_ptr + src_idx * topk
+        src_ptr = input_ptr + src_idx * packed_size
+        scale_src_ptr = scale_ptr + src_idx * scale_size
+
+        vec = tl.arange(0, BLOCK_SIZE)
+        for idx in range(topk):
+            expert_id = tl.load(topk_ids_ptr + idx)
+            if expert_id >= 0:
+                dst_idx_int32 = tl.load(src2dst_ptr + idx)
+                dst_idx = dst_idx_int32.to(tl.int64)
+                dst_ptr = gateup_input_ptr + dst_idx * packed_size
+                for start_offset in tl.range(0, packed_size, BLOCK_SIZE):
+                    offset = start_offset + vec
+                    mask = offset < packed_size
+                    in_data = tl.load(src_ptr + offset, mask=mask)
+                    tl.store(dst_ptr + offset, in_data, mask=mask)
+                scale_dst_ptr = gateup_input_scale_ptr + dst_idx * scale_size
+                for start_offset in tl.range(0, scale_size, BLOCK_SIZE):
+                    offset = start_offset + vec
+                    mask = offset < scale_size
+                    in_scale = tl.load(scale_src_ptr + offset, mask=mask)
+                    tl.store(scale_dst_ptr + offset, in_scale, mask=mask)
+
+    _fill_gateup_input_fp4_kernel[(hidden_states_fp4.shape[0],)](
+        hidden_states_fp4,
+        hidden_states_scale,
+        gateup_input,
+        gateup_input_scale,
+        src2dst,
+        topk_ids,
+        top_k,
+        hidden_states_fp4.size(1),
+        hidden_states_scale.size(1),
+        BLOCK_SIZE=1024,
+    )
+
+
+def _pre_permute_standard_to_asym_gemm_fp4(
+    dispatch_output: StandardDispatchOutput,
+    quant_info,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+):
+    """Masked pre-permute for NVFP4: quantize tokens to FP4 first, then scatter
+    the packed FP4 + E4M3 scales into the padded (num_experts, m_max, K//2) buffer."""
+    from sglang.srt.layers.moe.ep_moe.kernels import (
+        compute_masked_m_triton_kernel,
+        compute_seg_indptr_triton_kernel,
+        deepgemm_compute_src2dst_triton_kernel,
+    )
+    from sglang.srt.layers.moe.moe_runner.asym_gemm_fp4 import (
+        AsymGemmFp4RunnerInput,
+        _quantize_bf16_to_nvfp4_e4m3,
+    )
+
+    hidden_states, topk_output = (
+        dispatch_output.hidden_states,
+        dispatch_output.topk_output,
+    )
+    topk_weights, topk_ids, _ = topk_output
+
+    hidden_states_shape = hidden_states.shape
+    hidden_states_dtype = hidden_states.dtype
+    hidden_states_device = hidden_states.device
+    hidden_states_ref = hidden_states
+
+    num_local_experts = runner_config.num_local_experts
+    top_k = runner_config.top_k
+
+    reorder_topk_ids, reorder_ids = torch.sort(topk_ids.view(-1), stable=True)
+    seg_indptr = torch.zeros(
+        num_local_experts + 1, device=topk_ids.device, dtype=torch.int64
+    )
+    src2dst = torch.empty(topk_ids.numel(), device=topk_ids.device, dtype=torch.int32)
+    masked_m = torch.empty(
+        num_local_experts, device=topk_ids.device, dtype=torch.int32
+    )
+
+    compute_seg_indptr_triton_kernel[(num_local_experts + 1,)](
+        reorder_topk_ids, seg_indptr, topk_ids.numel()
+    )
+    compute_masked_m_triton_kernel[(num_local_experts,)](seg_indptr, masked_m)
+
+    m_max = (hidden_states.size(0) // 256 + 1) * 256
+    expected_m = (topk_ids.numel() - 1) // num_local_experts + 1
+
+    K = hidden_states.size(1)
+    K_packed = K // 2
+    K_sf = K // 16
+
+    # Quantize only the actual tokens to FP4 (very small for decode)
+    hs_bf16 = hidden_states.to(torch.bfloat16) if hidden_states.dtype != torch.bfloat16 else hidden_states
+    hs_fp4, hs_scale = _quantize_bf16_to_nvfp4_e4m3(hs_bf16)
+
+    grid = lambda meta: (  # noqa: E731
+        triton.cdiv(topk_ids.numel(), meta["BLOCK_SIZE"]),
+    )
+    deepgemm_compute_src2dst_triton_kernel[grid](
+        topk_ids,
+        reorder_ids,
+        seg_indptr,
+        src2dst,
+        m_max,
+        topk_ids.numel(),
+        BLOCK_SIZE=256,
+    )
+
+    # Scatter pre-quantized FP4 tokens into the padded buffer
+    gateup_fp4 = torch.empty(
+        (num_local_experts, m_max, K_packed),
+        device=hidden_states_device,
+        dtype=torch.uint8,
+    )
+    gateup_scale = torch.empty(
+        (num_local_experts, m_max, K_sf),
+        device=hidden_states_device,
+        dtype=torch.float8_e4m3fn,
+    )
+    _fill_gateup_input_fp4(
+        hs_fp4, hs_scale,
+        gateup_fp4, gateup_scale,
+        src2dst, topk_ids, top_k,
+    )
+
+    dispose_tensor(hidden_states_ref)
+    del hs_fp4, hs_scale
+
+    running_state["topk_ids"] = topk_ids
+    running_state["topk_weights"] = topk_weights
+    running_state["hidden_states_shape"] = hidden_states_shape
+    running_state["hidden_states_dtype"] = hidden_states_dtype
+    running_state["hidden_states_device"] = hidden_states_device
+    running_state["src2dst"] = src2dst
+
+    return AsymGemmFp4RunnerInput(
+        hidden_states=gateup_fp4,
+        hidden_states_scale=gateup_scale,
+        use_masked_gemm=True,
+        masked_m=masked_m,
+        expected_m=expected_m,
+    )
+
+
 @register_post_permute("asym_gemm", "standard")
 def post_permute_asym_gemm_to_standard(
     runner_output: AsymGemmRunnerOutput,
@@ -922,6 +1108,11 @@ def pre_permute_deepep_ll_to_asym_gemm(
         AsymGemmBf16MoeQuantInfo,
         AsymGemmBf16RunnerInput,
     )
+    from sglang.srt.layers.moe.moe_runner.asym_gemm_fp4 import (
+        AsymGemmFp4MoeQuantInfo,
+        AsymGemmFp4RunnerInput,
+        _quantize_bf16_to_nvfp4_e4m3,
+    )
 
     hidden_states, hidden_states_scale, topk_ids, topk_weights, masked_m, expected_m = (
         dispatch_output
@@ -943,8 +1134,6 @@ def pre_permute_deepep_ll_to_asym_gemm(
         )
 
     if isinstance(quant_info, AsymGemmFp4MoeQuantInfo):
-        # DeepEP dispatcher may pass BF16 hidden states (no scale) or already
-        # FP4-quantized states. Quantize here only when scales are absent.
         if hidden_states_scale is None:
             hs_fp4, hs_scale = _quantize_bf16_to_nvfp4_e4m3(hidden_states)
             dispose_tensor(hidden_states)

--- a/python/sglang/srt/layers/moe/moe_runner/asym_gemm_fp4.py
+++ b/python/sglang/srt/layers/moe/moe_runner/asym_gemm_fp4.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import torch
+import triton
+import triton.language as tl
 
 from sglang.srt.layers import asym_gemm_wrapper
 from sglang.srt.layers.moe.moe_runner.base import (
@@ -33,6 +35,51 @@ if not (_is_npu or _is_hip) and _is_cuda:
 _NVFP4_GROUP_SIZE = 16
 # E2M1 dynamic range (max |x|) for computing E4M3 scale: sf = amax / 6.0.
 _E2M1_MAX = 6.0
+
+# Fast CUDA path: flashinfer.fp4_quantize with global_scale=1.0 and
+# is_sf_swizzled_layout=False is numerically equivalent to the single-level
+# NVFP4 scheme AsymGEMM consumes (per-group E4M3 scales in row-major
+# (..., K/16) layout, packed uint8 codes of shape (..., K/2)). Falls back to
+# a pure-PyTorch implementation if flashinfer is unavailable.
+try:
+    from flashinfer import fp4_quantize as _flashinfer_fp4_quantize
+except Exception:  # pragma: no cover - fallback path
+    _flashinfer_fp4_quantize = None
+
+
+# Device-local cache for the global_scale=1.0 tensor used by flashinfer's
+# fp4_quantize. Allocating inside the forward would trigger a host->device
+# copy and is not allowed during CUDA graph capture.
+_FP4_GLOBAL_SCALE_ONE_CACHE: dict = {}
+
+
+def _get_fp4_global_scale_one(device: torch.device) -> torch.Tensor:
+    key = str(device)
+    cached = _FP4_GLOBAL_SCALE_ONE_CACHE.get(key)
+    if cached is None:
+        cached = torch.ones(1, device=device, dtype=torch.float32)
+        _FP4_GLOBAL_SCALE_ONE_CACHE[key] = cached
+    return cached
+
+
+# E2M1 magnitude bucket thresholds (midpoints between representable values).
+# Only used by the PyTorch fallback. Cached per device so they aren't
+# re-allocated on every forward; the host-to-device copy inside
+# torch.tensor([...], device=...) is not permitted during CUDA graph capture.
+_E2M1_THRESHOLDS_CACHE: dict = {}
+
+
+def _get_e2m1_thresholds(device: torch.device) -> torch.Tensor:
+    key = (str(device), torch.float32)
+    cached = _E2M1_THRESHOLDS_CACHE.get(key)
+    if cached is None:
+        cached = torch.tensor(
+            [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0],
+            device=device,
+            dtype=torch.float32,
+        )
+        _E2M1_THRESHOLDS_CACHE[key] = cached
+    return cached
 
 
 @dataclass
@@ -85,13 +132,48 @@ def _quantize_bf16_to_nvfp4_e4m3(
     ``tests/test_nvfp4.py``: returns ``(packed_u8[M, K//2], scale_e4m3[M, K/16])``.
     The AsymGEMM kernel handles the TMA-aligned uint32 repack internally.
 
-    Inputs are reshaped to 2D (M, K) before quantization; 3D inputs
-    (num_groups, M, K) are flattened over the leading dims and reshaped back.
+    Inputs are reshaped to 2D (M, K) before quantization; higher-rank inputs
+    (e.g. ``(num_groups, M, K)``) are flattened over the leading dims and
+    reshaped back before returning.
     """
     assert x.is_cuda
     assert x.dtype in (torch.bfloat16, torch.float16, torch.float32)
     assert x.shape[-1] % group_size == 0
 
+    leading = x.shape[:-1]
+    k = x.shape[-1]
+    x2d = x.reshape(-1, k)
+    sf_k = k // group_size
+
+    if _flashinfer_fp4_quantize is not None and group_size == _NVFP4_GROUP_SIZE:
+        # Single-level NVFP4 (global_scale = 1.0) with un-swizzled per-group
+        # E4M3 scales: byte-for-byte the layout AsymGEMM's grouped FP4 kernel
+        # consumes, and >80x faster than the pure-PyTorch encoder on
+        # decode-sized tensors.
+        if x.dtype != torch.bfloat16:
+            x2d = x2d.to(torch.bfloat16)
+        gs = _get_fp4_global_scale_one(x.device)
+        packed, sf = _flashinfer_fp4_quantize(
+            x2d,
+            gs,
+            sf_vec_size=group_size,
+            is_sf_swizzled_layout=False,
+        )
+        # flashinfer returns the scale buffer as raw uint8; reinterpret as
+        # float8_e4m3fn (zero-copy view) so AsymGEMM sees the expected dtype.
+        if sf.dtype != torch.float8_e4m3fn:
+            sf = sf.view(torch.float8_e4m3fn)
+        packed = packed.reshape(*leading, k // 2)
+        sf = sf.reshape(*leading, sf_k)
+        return packed, sf
+
+    return _quantize_bf16_to_nvfp4_e4m3_pytorch(x, group_size=group_size)
+
+
+def _quantize_bf16_to_nvfp4_e4m3_pytorch(
+    x: torch.Tensor, group_size: int = _NVFP4_GROUP_SIZE
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch fallback encoder used when flashinfer is unavailable."""
     leading = x.shape[:-1]
     k = x.shape[-1]
     x2d = x.reshape(-1, k)
@@ -110,11 +192,7 @@ def _quantize_bf16_to_nvfp4_e4m3(
     sign_bits = (x_scaled < 0).to(torch.uint8) << 3
     ax = x_scaled.abs().clamp_max_(_E2M1_MAX)
     # Magnitude thresholds (midpoints between E2M1 values).
-    thresholds = torch.tensor(
-        [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0],
-        device=x.device,
-        dtype=torch.float32,
-    )
+    thresholds = _get_e2m1_thresholds(x.device)
     mag_idx = torch.bucketize(ax, thresholds).to(torch.uint8)
     # Zero is encoded as +0 (no sign bit) to mirror the reference encoder.
     sign_bits = torch.where(mag_idx == 0, torch.zeros_like(sign_bits), sign_bits)
@@ -128,6 +206,168 @@ def _quantize_bf16_to_nvfp4_e4m3(
     packed = packed.view(*leading, k // 2)
     sf_e4m3 = sf_e4m3.view(*leading, sf_k)
     return packed, sf_e4m3
+
+
+@triton.jit
+def _masked_silu_and_mul_kernel(
+    gateup_ptr,   # (G*m, N) bf16
+    out_ptr,      # (G*m, N//2) bf16
+    masked_m_ptr, # (G,) int32
+    m,            # int — rows per group
+    N,            # int — gateup width
+    HALF_N,       # int — N // 2
+    BLOCK_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    g = pid // m
+    row = pid % m
+    active = tl.load(masked_m_ptr + g)
+    if row >= active:
+        return
+
+    row_off = pid.to(tl.int64) * N
+    out_off = pid.to(tl.int64) * HALF_N
+    for start in tl.range(0, HALF_N, BLOCK_K):
+        k = start + tl.arange(0, BLOCK_K)
+        mask = k < HALF_N
+        gate = tl.load(gateup_ptr + row_off + k, mask=mask, other=0.0).to(tl.float32)
+        up = tl.load(gateup_ptr + row_off + HALF_N + k, mask=mask, other=0.0).to(tl.float32)
+        val = (gate * tl.sigmoid(gate) * up).to(tl.bfloat16)
+        tl.store(out_ptr + out_off + k, val, mask=mask)
+
+
+@triton.jit
+def _masked_fp4_quant_kernel(
+    input_ptr,    # (G*m, K) bf16
+    packed_ptr,   # (G*m, K//2) uint8
+    scale_ptr,    # (G*m, K//GROUP_SIZE) float8_e4m3fn
+    masked_m_ptr, # (G,) int32
+    m,            # int — rows per group
+    K,            # int — last dim of input
+    GROUP_SIZE: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_GRP: tl.constexpr,     # == BLOCK_K // GROUP_SIZE
+    HALF_BK: tl.constexpr,     # == BLOCK_K // 2
+):
+    pid = tl.program_id(0)
+    g = pid // m
+    row = pid % m
+    active = tl.load(masked_m_ptr + g)
+    if row >= active:
+        return
+
+    row_off = pid.to(tl.int64) * K
+    pack_off = pid.to(tl.int64) * (K // 2)
+    sf_off = pid.to(tl.int64) * (K // GROUP_SIZE)
+
+    E2M1_MAX: tl.constexpr = 6.0
+
+    for start in tl.range(0, K, BLOCK_K):
+        k = start + tl.arange(0, BLOCK_K)
+        mask = k < K
+        vals = tl.load(input_ptr + row_off + k, mask=mask, other=0.0).to(tl.float32)
+
+        vals_g = tl.reshape(vals, [NUM_GRP, GROUP_SIZE])
+        amax = tl.max(tl.abs(vals_g), axis=1)
+        amax = tl.maximum(amax, 1e-4)
+        sf_f32 = amax / E2M1_MAX
+        sf_e4m3 = sf_f32.to(tl.float8e4nv)
+        sf_dec = tl.maximum(sf_e4m3.to(tl.float32), 1e-12)
+
+        scaled = vals_g / sf_dec[:, None]
+        ax = tl.minimum(tl.abs(scaled), E2M1_MAX)
+
+        codes = tl.zeros([NUM_GRP, GROUP_SIZE], dtype=tl.uint8)
+        codes = tl.where(ax >= 0.25, codes + 1, codes)
+        codes = tl.where(ax >= 0.75, codes + 1, codes)
+        codes = tl.where(ax >= 1.25, codes + 1, codes)
+        codes = tl.where(ax >= 1.75, codes + 1, codes)
+        codes = tl.where(ax >= 2.5, codes + 1, codes)
+        codes = tl.where(ax >= 3.5, codes + 1, codes)
+        codes = tl.where(ax >= 5.0, codes + 1, codes)
+
+        neg = scaled < 0
+        sign = tl.where(neg, tl.full([NUM_GRP, GROUP_SIZE], 8, dtype=tl.uint8),
+                        tl.zeros([NUM_GRP, GROUP_SIZE], dtype=tl.uint8))
+        sign = tl.where(codes == 0, tl.zeros([NUM_GRP, GROUP_SIZE], dtype=tl.uint8), sign)
+        codes = codes | sign
+        codes_flat = tl.reshape(codes, [BLOCK_K])
+
+        codes_pairs = tl.reshape(codes_flat, [HALF_BK, 2])
+        weights = tl.where(tl.arange(0, 2) == 0, 1, 16).to(tl.int32)
+        packed = tl.sum(codes_pairs.to(tl.int32) * weights[None, :], axis=1).to(tl.uint8)
+
+        pk = start // 2 + tl.arange(0, HALF_BK)
+        pk_mask = pk < (K // 2)
+        tl.store(packed_ptr + pack_off + pk, packed, mask=pk_mask)
+
+        sk = start // GROUP_SIZE + tl.arange(0, NUM_GRP)
+        sk_mask = sk < (K // GROUP_SIZE)
+        tl.store(scale_ptr + sf_off + sk, sf_e4m3, mask=sk_mask)
+
+
+def _silu_mul_and_fp4_quant_masked(
+    gateup_output: torch.Tensor,
+    masked_m: torch.Tensor,
+    group_size: int = _NVFP4_GROUP_SIZE,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Masked SiLU-and-Mul + NVFP4 quantization, skipping inactive expert groups.
+
+    Processes only rows where masked_m[g] > 0, avoiding memory traffic for the
+    vast majority of padding rows (critical for decode where ~10 of 512 groups
+    are active).
+    """
+    num_groups, m, n = gateup_output.shape
+    half_n = n // 2
+    k_packed = half_n // 2
+    sf_k = half_n // group_size
+    device = gateup_output.device
+
+    down_in_bf16 = torch.empty(
+        (num_groups * m, half_n),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    _masked_silu_and_mul_kernel[(num_groups * m,)](
+        gateup_output.view(-1, n),
+        down_in_bf16,
+        masked_m,
+        m,
+        n,
+        half_n,
+        BLOCK_K=1024,
+    )
+
+    packed_out = torch.empty(
+        (num_groups, m, k_packed),
+        device=device,
+        dtype=torch.uint8,
+    )
+    scale_out = torch.empty(
+        (num_groups, m, sf_k),
+        device=device,
+        dtype=torch.float8_e4m3fn,
+    )
+
+    block_k = min(half_n, 1024)
+    assert block_k % group_size == 0
+    assert block_k % 2 == 0
+
+    _masked_fp4_quant_kernel[(num_groups * m,)](
+        down_in_bf16,
+        packed_out.view(-1, k_packed),
+        scale_out.view(-1, sf_k),
+        masked_m,
+        m,
+        half_n,
+        GROUP_SIZE=group_size,
+        BLOCK_K=block_k,
+        NUM_GRP=block_k // group_size,
+        HALF_BK=block_k // 2,
+    )
+
+    return packed_out, scale_out
 
 
 class AsymGemmFp4RunnerCore(MoeRunnerCore):
@@ -250,28 +490,12 @@ class AsymGemmFp4RunnerCore(MoeRunnerCore):
         dispose_tensor(hidden_states)
         dispose_tensor(hidden_states_scale)
 
-        # SiLU-and-mul over the whole padded buffer; padding rows are dropped
-        # by the masked downstream GEMM, so masked_m isn't needed here and
-        # avoiding ``masked_m[i].item()`` keeps CUDA-graph capture working.
-        down_in_bf16 = torch.empty(
-            (
-                gateup_output.shape[0] * gateup_output.shape[1],
-                gateup_output.shape[2] // 2,
-            ),
-            device=hidden_states_device,
-            dtype=torch.bfloat16,
-        )
-        silu_and_mul(
-            gateup_output.view(-1, gateup_output.shape[2]),
-            down_in_bf16,
-        )
-        down_in_bf16 = down_in_bf16.view(
-            gateup_output.shape[0], gateup_output.shape[1], gateup_output.shape[2] // 2
+        # Fused masked SiLU-and-Mul + NVFP4 quantization: only processes rows
+        # where masked_m[g] > 0, skipping inactive expert groups entirely.
+        down_in_fp4, down_in_scale = _silu_mul_and_fp4_quant_masked(
+            gateup_output, masked_m,
         )
         del gateup_output
-
-        down_in_fp4, down_in_scale = _quantize_bf16_to_nvfp4_e4m3(down_in_bf16)
-        del down_in_bf16
 
         n2 = w2_weight.shape[1]
         down_output = torch.empty(

--- a/python/sglang/srt/layers/moe/moe_runner/asym_gemm_fp4.py
+++ b/python/sglang/srt/layers/moe/moe_runner/asym_gemm_fp4.py
@@ -306,38 +306,96 @@ def _masked_fp4_quant_kernel(
         tl.store(scale_ptr + sf_off + sk, sf_e4m3, mask=sk_mask)
 
 
+@triton.jit
+def _fused_masked_silu_mul_fp4_quant_kernel(
+    gateup_ptr,   # (G*m, N) bf16 — gate in [0, N/2), up in [N/2, N)
+    packed_ptr,   # (G*m, N/4) uint8
+    scale_ptr,    # (G*m, N/2/GROUP_SIZE) float8_e4m3fn
+    masked_m_ptr, # (G,) int32
+    m,            # rows per group
+    N,            # gateup width (2 * output_dim)
+    HALF_N,       # N // 2 (output dim)
+    GROUP_SIZE: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_GRP: tl.constexpr,     # == BLOCK_K // GROUP_SIZE
+    HALF_BK: tl.constexpr,     # == BLOCK_K // 2
+):
+    pid = tl.program_id(0)
+    g = pid // m
+    row = pid % m
+    active = tl.load(masked_m_ptr + g)
+    if row >= active:
+        return
+
+    row_off = pid.to(tl.int64) * N
+    pack_off = pid.to(tl.int64) * (HALF_N // 2)
+    sf_off = pid.to(tl.int64) * (HALF_N // GROUP_SIZE)
+
+    E2M1_MAX: tl.constexpr = 6.0
+
+    for start in tl.range(0, HALF_N, BLOCK_K):
+        k = start + tl.arange(0, BLOCK_K)
+        mask = k < HALF_N
+
+        gate = tl.load(gateup_ptr + row_off + k, mask=mask, other=0.0).to(tl.float32)
+        up = tl.load(gateup_ptr + row_off + HALF_N + k, mask=mask, other=0.0).to(tl.float32)
+        vals = gate * tl.sigmoid(gate) * up
+
+        vals_g = tl.reshape(vals, [NUM_GRP, GROUP_SIZE])
+        amax = tl.max(tl.abs(vals_g), axis=1)
+        amax = tl.maximum(amax, 1e-4)
+        sf_f32 = amax / E2M1_MAX
+        sf_e4m3 = sf_f32.to(tl.float8e4nv)
+        sf_dec = tl.maximum(sf_e4m3.to(tl.float32), 1e-12)
+
+        scaled = vals_g / sf_dec[:, None]
+        ax = tl.minimum(tl.abs(scaled), E2M1_MAX)
+
+        codes = tl.zeros([NUM_GRP, GROUP_SIZE], dtype=tl.uint8)
+        codes = tl.where(ax >= 0.25, codes + 1, codes)
+        codes = tl.where(ax >= 0.75, codes + 1, codes)
+        codes = tl.where(ax >= 1.25, codes + 1, codes)
+        codes = tl.where(ax >= 1.75, codes + 1, codes)
+        codes = tl.where(ax >= 2.5, codes + 1, codes)
+        codes = tl.where(ax >= 3.5, codes + 1, codes)
+        codes = tl.where(ax >= 5.0, codes + 1, codes)
+
+        neg = scaled < 0
+        sign = tl.where(neg, tl.full([NUM_GRP, GROUP_SIZE], 8, dtype=tl.uint8),
+                        tl.zeros([NUM_GRP, GROUP_SIZE], dtype=tl.uint8))
+        sign = tl.where(codes == 0, tl.zeros([NUM_GRP, GROUP_SIZE], dtype=tl.uint8), sign)
+        codes = codes | sign
+        codes_flat = tl.reshape(codes, [BLOCK_K])
+
+        codes_pairs = tl.reshape(codes_flat, [HALF_BK, 2])
+        weights = tl.where(tl.arange(0, 2) == 0, 1, 16).to(tl.int32)
+        packed = tl.sum(codes_pairs.to(tl.int32) * weights[None, :], axis=1).to(tl.uint8)
+
+        pk = start // 2 + tl.arange(0, HALF_BK)
+        pk_mask = pk < (HALF_N // 2)
+        tl.store(packed_ptr + pack_off + pk, packed, mask=pk_mask)
+
+        sk = start // GROUP_SIZE + tl.arange(0, NUM_GRP)
+        sk_mask = sk < (HALF_N // GROUP_SIZE)
+        tl.store(scale_ptr + sf_off + sk, sf_e4m3, mask=sk_mask)
+
+
 def _silu_mul_and_fp4_quant_masked(
     gateup_output: torch.Tensor,
     masked_m: torch.Tensor,
     group_size: int = _NVFP4_GROUP_SIZE,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Masked SiLU-and-Mul + NVFP4 quantization, skipping inactive expert groups.
+    """Fused masked SiLU-and-Mul + NVFP4 quantization in a single kernel.
 
-    Processes only rows where masked_m[g] > 0, avoiding memory traffic for the
-    vast majority of padding rows (critical for decode where ~10 of 512 groups
-    are active).
+    Reads the gateup BF16 output once, applies SiLU*Up, quantizes to FP4,
+    and writes packed uint8 + E4M3 scales — no intermediate BF16 buffer.
+    Skips inactive expert groups (masked_m[g] == 0).
     """
     num_groups, m, n = gateup_output.shape
     half_n = n // 2
     k_packed = half_n // 2
     sf_k = half_n // group_size
     device = gateup_output.device
-
-    down_in_bf16 = torch.empty(
-        (num_groups * m, half_n),
-        device=device,
-        dtype=torch.bfloat16,
-    )
-
-    _masked_silu_and_mul_kernel[(num_groups * m,)](
-        gateup_output.view(-1, n),
-        down_in_bf16,
-        masked_m,
-        m,
-        n,
-        half_n,
-        BLOCK_K=1024,
-    )
 
     packed_out = torch.empty(
         (num_groups, m, k_packed),
@@ -354,12 +412,13 @@ def _silu_mul_and_fp4_quant_masked(
     assert block_k % group_size == 0
     assert block_k % 2 == 0
 
-    _masked_fp4_quant_kernel[(num_groups * m,)](
-        down_in_bf16,
+    _fused_masked_silu_mul_fp4_quant_kernel[(num_groups * m,)](
+        gateup_output.view(-1, n),
         packed_out.view(-1, k_packed),
         scale_out.view(-1, sf_k),
         masked_m,
         m,
+        n,
         half_n,
         GROUP_SIZE=group_size,
         BLOCK_K=block_k,

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1907,10 +1907,13 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
-        if get_moe_runner_backend().is_flashinfer_trtllm():
+        moe_runner_backend = get_moe_runner_backend()
+        if moe_runner_backend.is_flashinfer_trtllm():
             self.runner = MoeRunner(
                 MoeRunnerBackend.FLASHINFER_TRTLLM, moe_runner_config
             )
+        elif moe_runner_backend.is_asym_gemm():
+            self.runner = MoeRunner(MoeRunnerBackend.ASYM_GEMM, moe_runner_config)
 
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -1753,6 +1753,13 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         else:
             w13_input_scale = layer.w13_input_scale.max(dim=-1).values.to(torch.float32)
             w2_input_scale = layer.w2_input_scale
+            # w13_input_scale and w2_input_scale are loaded with global experts
+            # (_sglang_require_global_experts=True); slice to this EP rank's local experts.
+            if layer.moe_ep_size > 1:
+                ep_start = layer.moe_ep_rank * layer.num_local_experts
+                ep_end = ep_start + layer.num_local_experts
+                w13_input_scale = w13_input_scale[ep_start:ep_end]
+                w2_input_scale = w2_input_scale[ep_start:ep_end]
 
         # Create shared parameters
         copy_or_rebind_param(


### PR DESCRIPTION
this PR improves the FP4 AsymGemm latency.

python3 -m sglang.bench_serving   --backend sglang   --model  /workspace/models/Qwen3.5-397B-A17B-NVFP4  --dataset-name random  --random-input-len 3500   --random-output-len 30   --num-prompts 1  | tee /workspace/benchmark.log 

============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 not set   
Successful requests:                     1         
Benchmark duration (s):                  1.51      
Total input tokens:                      1062      
Total input text tokens:                 1062      
Total generated tokens:                  12        
Total generated tokens (retokenized):    12        
Request throughput (req/s):              0.66      
Input token throughput (tok/s):          704.41    
Output token throughput (tok/s):         7.96      
Peak output token throughput (tok/s):    6.00      
Peak concurrent requests:                1         
Total token throughput (tok/s):          712.37    
Concurrency:                             0.95      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   1427.99   
Median E2E Latency (ms):                 1427.99   
P90 E2E Latency (ms):                    1427.99   
P99 E2E Latency (ms):                    1427.99   
---------------Time to First Token----------------
Mean TTFT (ms):                          586.44    
Median TTFT (ms):                        586.44    
P99 TTFT (ms):                           586.44    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          76.50     
Median TPOT (ms):                        76.50     
P99 TPOT (ms):                           76.50     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           76.50     
Median ITL (ms):                         76.49     
P95 ITL (ms):                            76.67     
P99 ITL (ms):                            76.74     
Max ITL (ms):                            76.76     
==================================================