### PR TITLE
ci: resolve Volcengine publish target in reusable workflow

### DIFF
--- a/.github/workflows/_docker-build-and-publish.yml
+++ b/.github/workflows/_docker-build-and-publish.yml
@@ -96,6 +96,9 @@ jobs:
       TAG_MODE: ${{ inputs.tag_mode }}
       TAG_VALUE: ${{ inputs.tag_value }}
       VARIANT_SUFFIX: ${{ inputs.variant_suffix }}
+      VOLCENGINE_CR_REGISTRY: ${{ vars.VOLCENGINE_CR_REGISTRY }}
+      VOLCENGINE_CR_NAMESPACE: ${{ vars.VOLCENGINE_CR_NAMESPACE }}
+      VOLCENGINE_CR_REPOSITORY: ${{ vars.VOLCENGINE_CR_REPOSITORY || 'sglang' }}
       VOLCENGINE_CR_USERNAME: ${{ secrets.VOLCENGINE_CR_USERNAME }}
       VOLCENGINE_CR_PASSWORD: ${{ secrets.VOLCENGINE_CR_PASSWORD }}
     steps:
@@ -109,6 +112,31 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref || github.ref }}
+
+      - name: Resolve Volcengine publish target
+        run: |
+          set -euo pipefail
+
+          if [ -z "${IMAGE_REPO}" ]; then
+            if [ -z "${VOLCENGINE_CR_REGISTRY}" ] || [ -z "${VOLCENGINE_CR_NAMESPACE}" ]; then
+              echo "::error::Volcengine CR variables are required: VOLCENGINE_CR_REGISTRY and VOLCENGINE_CR_NAMESPACE"
+              exit 1
+            fi
+            IMAGE_REPO="${VOLCENGINE_CR_REGISTRY}/${VOLCENGINE_CR_NAMESPACE}/${VOLCENGINE_CR_REPOSITORY:-sglang}"
+          fi
+
+          if [ -z "${REGISTRY_HOST}" ] && [ -n "${VOLCENGINE_CR_REGISTRY}" ] && [[ "${IMAGE_REPO}" == "${VOLCENGINE_CR_REGISTRY}/"* ]]; then
+            REGISTRY_HOST="${VOLCENGINE_CR_REGISTRY}"
+          fi
+
+          if [ -z "${IMAGE_REPO}" ] || [[ "${IMAGE_REPO}" == /* ]] || [[ "${IMAGE_REPO}" == *'//'* ]]; then
+            echo "::error::Invalid image repository: '${IMAGE_REPO}'"
+            exit 1
+          fi
+
+          echo "IMAGE_REPO=${IMAGE_REPO}" >> "${GITHUB_ENV}"
+          echo "REGISTRY_HOST=${REGISTRY_HOST}" >> "${GITHUB_ENV}"
+          echo "Resolved image repository ${IMAGE_REPO}"
 
       - name: Resolve Volcengine image tag
         id: image-tag

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -99,8 +99,6 @@ jobs:
       variant_suffix: ${{ matrix.variant_suffix }}
       tag_mode: ${{ github.event_name == 'schedule' && 'nightly' || 'manual' }}
       use_environment: prod
-      registry_host: ${{ vars.VOLCENGINE_CR_REGISTRY }}
-      image_repo: ${{ vars.VOLCENGINE_CR_REGISTRY }}/${{ vars.VOLCENGINE_CR_NAMESPACE }}/${{ vars.VOLCENGINE_CR_REPOSITORY || 'sglang' }}
       artifact_name: ${{ (github.event_name == 'schedule' || inputs.compile_kernel) && matrix.artifact_name || '' }}
       extra_build_args: >-
         --build-arg BRANCH_TYPE=local

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -73,8 +73,6 @@ jobs:
       tag_mode: version
       tag_value: ${{ needs.validate-volcengine-version-tag.outputs.git-tag-value }}
       use_environment: prod
-      registry_host: ${{ vars.VOLCENGINE_CR_REGISTRY }}
-      image_repo: ${{ vars.VOLCENGINE_CR_REGISTRY }}/${{ vars.VOLCENGINE_CR_NAMESPACE }}/${{ vars.VOLCENGINE_CR_REPOSITORY || 'sglang' }}
       extra_build_args: >-
         --build-arg HTTP_PROXY=http://100.68.162.211:3128
         --build-arg HTTPS_PROXY=http://100.68.162.211:3128


### PR DESCRIPTION
## Summary
- resolve Volcengine CR publish target inside the reusable docker workflow after the prod environment is bound
- stop release docker callers from reading environment-level vars in the caller workflow_call input layer
- fail fast on missing or malformed image repository values instead of falling back to Docker Hub

## Root Cause
The daily dev docker workflow called _docker-build-and-publish.yml with registry_host and image_repo built from vars.VOLCENGINE_CR_* in the caller job. Those variables are configured on the prod environment, but the caller workflow_call job is not bound to that environment. The called reusable job is, so the values must be resolved there.

## Verification
- python3 YAML parse for the changed workflow files
- git diff --check
- local shell simulation resolved iaas-gpu-cn-beijing.cr.volces.com/serving/sglang style values from VOLCENGINE_CR_* vars
