### PR TITLE
minimax m2.5 deepep eplb (#424)

### DIFF
--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -66,6 +66,7 @@ from sglang.srt.layers.moe import (
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
+from sglang.srt.layers.moe.utils import filter_moe_weight_param_global_expert
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
@@ -87,6 +88,7 @@ from sglang.srt.server_args import get_global_server_args
 # transformers wrapper then crashes on config.rope_parameters (transformers v5 issue).
 # Other files (custom_all_reduce.py, hf_transformers_utils.py) also use sglang.srt.utils.
 from sglang.srt.utils import (
+    LazyValue,
     BumpAllocator,
     add_prefix,
     get_bool_env_var,
@@ -687,6 +689,15 @@ class MiniMaxM2MoE(nn.Module):
         # MiniMax doesn't have shared experts like DeepSeek, so no need to add them
         state.hidden_states_mlp_output = final_hidden_states
 
+    def get_moe_weights(self):
+        return [
+            x.data
+            for name, x in self.experts.named_parameters()
+            if name not in ["correction_bias"]
+            and filter_moe_weight_param_global_expert(
+                name, x, self.experts.num_local_experts
+            )
+        ]
 
 class MiniMaxM2Attention(nn.Module):
     """MiniMax Attention implementation with QK normalization and partial RoPE."""
@@ -1226,6 +1237,19 @@ class MiniMaxM2ForCausalLM(nn.Module):
 
         # For EAGLE3
         self.capture_aux_hidden_states = False
+
+        if not hasattr(self, "_routed_experts_weights_of_layer"):
+            self._routed_experts_weights_of_layer = LazyValue(
+                lambda: {
+                    layer_id: layer.block_sparse_moe.get_moe_weights()
+                    for layer_id, layer in enumerate(self.model.layers)
+                    if isinstance(layer.block_sparse_moe, MiniMaxM2MoE)
+                }
+            )
+
+    @property
+    def routed_experts_weights_of_layer(self):
+        return self._routed_experts_weights_of_layer.value
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -88,8 +88,8 @@ from sglang.srt.server_args import get_global_server_args
 # transformers wrapper then crashes on config.rope_parameters (transformers v5 issue).
 # Other files (custom_all_reduce.py, hf_transformers_utils.py) also use sglang.srt.utils.
 from sglang.srt.utils import (
-    LazyValue,
     BumpAllocator,
+    LazyValue,
     add_prefix,
     get_bool_env_var,
     get_compiler_backend,

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -82,7 +82,7 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.server_args import get_global_server_args
 
-# get_bool_env_var is defined in sglang.srt.utils.common, not s_routed_experts_weights_of_layer_routed_experts_weights_of_layerglang.srt.distributed.
+# get_bool_env_var is defined in sglang.srt.utils.common, not sglang.srt.distributed.
 # Importing from the wrong module causes this file to fail import, which prevents the
 # native MiniMaxM2ForCausalLM from registering in ModelRegistry. The fallback to the
 # transformers wrapper then crashes on config.rope_parameters (transformers v5 issue).
@@ -698,7 +698,6 @@ class MiniMaxM2MoE(nn.Module):
                 name, x, self.experts.num_local_experts
             )
         ]
-
 
 class MiniMaxM2Attention(nn.Module):
     """MiniMax Attention implementation with QK normalization and partial RoPE."""

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -82,7 +82,7 @@ from sglang.srt.model_loader.weight_utils import (
 )
 from sglang.srt.server_args import get_global_server_args
 
-# get_bool_env_var is defined in sglang.srt.utils.common, not sglang.srt.distributed.
+# get_bool_env_var is defined in sglang.srt.utils.common, not s_routed_experts_weights_of_layer_routed_experts_weights_of_layerglang.srt.distributed.
 # Importing from the wrong module causes this file to fail import, which prevents the
 # native MiniMaxM2ForCausalLM from registering in ModelRegistry. The fallback to the
 # transformers wrapper then crashes on config.rope_parameters (transformers v5 issue).
@@ -698,6 +698,7 @@ class MiniMaxM2MoE(nn.Module):
                 name, x, self.experts.num_local_experts
             )
         ]
+
 
 class MiniMaxM2Attention(nn.Module):
     """MiniMax Attention implementation with QK normalization and partial RoPE."""

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -699,6 +699,7 @@ class MiniMaxM2MoE(nn.Module):
             )
         ]
 
+
 class MiniMaxM2Attention(nn.Module):
     """MiniMax Attention implementation with QK normalization and partial RoPE."""
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2265,6 +2265,13 @@ class ServerArgs:
                         "Use flashinfer_trtllm as MoE runner backend on sm100 for Glm4MoeForCausalLM"
                     )
 
+        elif model_arch in ["MiniMaxM2ForCausalLM"]:
+            if self.moe_a2a_backend == "deepep" or self.disaggregation_mode != "null":
+                # MiniMax M2 requires bf16 activations when DeepEP is used on the decode side.
+                # Under PD disaggregation, prefill and decode must keep the same activation dtype,
+                # so force bf16 on both sides to avoid precision mismatches.
+                self.dtype = "bfloat16"
+
         elif model_arch in [
             "FalconH1ForCausalLM",
             "JetNemotronForCausalLM",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
- add routed expert weight exposure for `MiniMaxM2ForCausalLM`
- enable MiniMax M2.5 to participate in DeepEP / EPLB expert location updates
- force `bfloat16` for MiniMax M2.5 when `deepep` or PD disaggregation is enabled to avoid activation dtype mismatch
<!-- Describe the purpose and goals of this pull request. -->



## Modifications
- update `python/sglang/srt/models/minimax_m2.py`
  - add `get_moe_weights()` for `MiniMaxM2MoE`
  - add lazy `routed_experts_weights_of_layer` for `MiniMaxM2ForCausalLM`
  - reuse `filter_moe_weight_param_global_expert()` to only expose routed expert weights needed by EPLB
- update `python/sglang/srt/server_args.py`
  - force `self.dtype = "bfloat16"` for `MiniMaxM2ForCausalLM` when `moe_a2a_backend == "deepep"` or `disaggregation_mode != "null"`

MiniMax M2.5 was missing the model-side hooks needed by the EPLB expert relocation flow.  
This change aligns MiniMax M2.5 with other MoE models that already expose routed expert weights, and avoids decode/prefill activation dtype mismatch in DeepEP / PD disaggregation scenarios.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
