### PR TITLE
Fix DeepSeek V4 PD prefill SWA admission and abort handling

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -49,6 +49,7 @@ from sglang.srt.disaggregation.utils import (
     poll_and_all_reduce_with_staging,
     prepare_abort,
     setup_state_kv_args,
+    supports_swa_tail_prealloc,
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import get_attention_tp_size
@@ -334,10 +335,10 @@ class DecodePreallocQueue:
             )
 
     def _uses_swa_tail_prealloc(self) -> bool:
-        return (
-            isinstance(self.token_to_kv_pool, (SWAKVPool, DeepSeekV4TokenToKVPool))
-            and self.token_to_kv_pool_allocator.page_size > 1
-            and hasattr(self.token_to_kv_pool_allocator, "alloc_extend_swa_tail")
+        return supports_swa_tail_prealloc(
+            self.token_to_kv_pool,
+            self.token_to_kv_pool_allocator,
+            (SWAKVPool, DeepSeekV4TokenToKVPool),
         )
 
     def _swa_tail_len(self, seq_len: int) -> int:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -134,23 +134,47 @@ class PrefillBootstrapQueue:
             )
         self.kv_manager = self._init_kv_manager()
 
-        if (
-            self.scheduler.tp_worker.is_hybrid_swa
-            and not self._uses_dsv4_swa_tail_prealloc()
-        ):
-            # Fallback for SWA allocators that still allocate the SWA pool at
-            # full prompt length.
-            self.max_total_num_tokens = min(
-                self.max_total_num_tokens,
-                self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
-            )
+        if self.scheduler.tp_worker.is_hybrid_swa:
+            if self._can_admit_hybrid_swa_by_full_pool():
+                self.max_total_num_tokens = min(
+                    self.max_total_num_tokens,
+                    self.scheduler.tp_worker.model_runner.full_max_total_num_tokens,
+                )
+            else:
+                # Fallback for SWA allocators that still allocate the SWA pool at
+                # full prompt length.
+                self.max_total_num_tokens = min(
+                    self.max_total_num_tokens,
+                    self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
+                )
 
-    def _uses_dsv4_swa_tail_prealloc(self) -> bool:
+    def _can_admit_hybrid_swa_by_full_pool(self) -> bool:
+        return self._has_dsv4_swa_tail_allocator() or self._uses_chunked_swa_prefill()
+
+    def _has_dsv4_swa_tail_allocator(self) -> bool:
         return supports_swa_tail_prealloc(
             self.token_to_kv_pool,
             self.scheduler.token_to_kv_pool_allocator,
             DeepSeekV4TokenToKVPool,
         )
+
+    def _uses_chunked_swa_prefill(self) -> bool:
+        chunked_prefill_size = self.scheduler.chunked_prefill_size
+        return (
+            chunked_prefill_size is not None
+            and chunked_prefill_size > 0
+            and self._estimated_swa_prefill_peak_tokens()
+            <= self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens
+        )
+
+    def _estimated_swa_prefill_peak_tokens(self) -> int:
+        chunked_prefill_size = self.scheduler.chunked_prefill_size or 0
+        sliding_window_size = self.scheduler.sliding_window_size or 0
+        peak_tokens = max(chunked_prefill_size, sliding_window_size)
+        if peak_tokens <= 0:
+            return 0
+        page_size = self.scheduler.token_to_kv_pool_allocator.page_size
+        return ((peak_tokens + page_size - 1) // page_size + 1) * page_size
 
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -41,6 +41,7 @@ from sglang.srt.disaggregation.utils import (
     poll_and_all_reduce_attn_cp_tp_group,
     prepare_abort,
     setup_state_kv_args,
+    supports_swa_tail_prealloc,
 )
 from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import (
@@ -133,12 +134,23 @@ class PrefillBootstrapQueue:
             )
         self.kv_manager = self._init_kv_manager()
 
-        if self.scheduler.tp_worker.is_hybrid_swa:
-            # FIXME: current SWA allocation allocate full kv cache size in prefill
+        if (
+            self.scheduler.tp_worker.is_hybrid_swa
+            and not self._uses_dsv4_swa_tail_prealloc()
+        ):
+            # Fallback for SWA allocators that still allocate the SWA pool at
+            # full prompt length.
             self.max_total_num_tokens = min(
                 self.max_total_num_tokens,
                 self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
             )
+
+    def _uses_dsv4_swa_tail_prealloc(self) -> bool:
+        return supports_swa_tail_prealloc(
+            self.token_to_kv_pool,
+            self.scheduler.token_to_kv_pool_allocator,
+            DeepSeekV4TokenToKVPool,
+        )
 
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
@@ -516,6 +528,16 @@ class SchedulerDisaggregationPrefillMixin:
         ):
             if req.inflight_middle_chunks <= 0:
                 req.time_stats.set_prefill_finished_time()
+                if isinstance(req.to_finish, FINISH_ABORT):
+                    req.update_finish_state()
+                if isinstance(req.finished_reason, FINISH_ABORT):
+                    if req.req_pool_idx is not None or req.mamba_pool_idx is not None:
+                        release_kv_cache(req, self.tree_cache, is_insert=False)
+                    release_req_to_metadata_buffer(
+                        req, self.req_to_metadata_buffer_idx_allocator
+                    )
+                    self.output_streamer.stream_output([req], req.return_logprob)
+                    continue
 
                 # There is no output_ids for prefill
                 req.output_ids.append(next_token_id)

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -536,6 +536,18 @@ def is_mla_backend(target_kv_pool) -> bool:
     return isinstance(target_kv_pool, (MLATokenToKVPool, DeepSeekV4TokenToKVPool))
 
 
+def supports_swa_tail_prealloc(
+    token_to_kv_pool,
+    token_to_kv_pool_allocator,
+    supported_pool_types,
+) -> bool:
+    return (
+        isinstance(token_to_kv_pool, supported_pool_types)
+        and token_to_kv_pool_allocator.page_size > 1
+        and hasattr(token_to_kv_pool_allocator, "alloc_extend_swa_tail")
+    )
+
+
 def append_state_component(
     kv_args: KVArgs,
     state_type: StateType,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2028,6 +2028,10 @@ class Scheduler(
             self.waiting_queue.append(req)
             req.time_stats.set_wait_queue_entry_time()
         elif self.disaggregation_mode == DisaggregationMode.PREFILL:
+            if isinstance(req.to_finish, FINISH_ABORT):
+                req.update_finish_state()
+                self.output_streamer.stream_output([req], req.return_logprob)
+                return
             self._prefetch_kvcache(req)
             self.disagg_prefill_bootstrap_queue.add(
                 req, self.model_config.num_key_value_heads


### PR DESCRIPTION
## Summary

- Fix PD prefill admission for DeepSeek V4 hybrid SWA so long prompts are not incorrectly capped by `swa_max_total_num_tokens` when the DSV4 allocator supports SWA tail semantics.
- Refine hybrid SWA prefill admission for chunked prefill by allowing full-pool admission only when the estimated SWA working set fits the SWA pool; otherwise keep the conservative SWA cap.
- Prevent pre-queued `FINISH_ABORT` requests from entering PD prefill bootstrap / KV transfer, and add defensive abort handling before prefill inflight/send-kv processing.
- Deduplicate SWA tail-prealloc capability checks through a shared helper used by decode/prefill.

## Verification

- `python3 -m py_compile python/sglang/srt/disaggregation/utils.py python/sglang/srt/disaggregation/decode.py python/sglang/srt/disaggregation/prefill.py python/sglang/srt/managers/scheduler.py`
- `git diff --check iaas/bytedance/deepseek_v4..HEAD`

## Notes

Direct push to `bytedance/deepseek_v4` was rejected by branch protection, so this PR carries the two fix commits on top of the latest remote branch.