### PR TITLE
Sync SM90 MegaMoE adaptation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,34 @@
-FROM lmsysorg/sglang:dev
+ARG BASE_IMAGE=lmsysorg/sglang:dev
+
+FROM ${BASE_IMAGE} AS deepgemm_builder
+
+ARG DEEPGEMM_REPO=https://github.com/sgl-project/DeepGEMM.git
+ARG DEEPGEMM_REF=728ddc18efd203dc323c8bdd60e4da3f0635f4f2
+ARG SGL_DEEP_GEMM_VERSION=0.1.0+dev.pr36
+
+USER root
+
+RUN set -eux; \
+    rm -rf /tmp/DeepGEMM; \
+    git clone --no-checkout "${DEEPGEMM_REPO}" /tmp/DeepGEMM; \
+    cd /tmp/DeepGEMM; \
+    git fetch --depth=1 origin refs/pull/36/merge; \
+    git checkout --detach FETCH_HEAD; \
+    test "$(git rev-parse HEAD)" = "${DEEPGEMM_REF}"; \
+    git submodule update --init --recursive; \
+    echo -n "${SGL_DEEP_GEMM_VERSION}" > sgl_deep_gemm/VERSION; \
+    bash build_sgl_deep_gemm.sh
+
+FROM ${BASE_IMAGE}
+
+COPY --from=deepgemm_builder /tmp/DeepGEMM/dist/sgl_deep_gemm-*.whl /tmp/
+
+RUN set -eux; \
+    python3 -m pip uninstall -y sgl-deep-gemm deep-gemm || true; \
+    python3 -m pip install --no-deps --force-reinstall /tmp/sgl_deep_gemm-*.whl; \
+    rm -f /tmp/sgl_deep_gemm-*.whl; \
+    rm -rf /root/.cache/deep_gemm; \
+    python3 -c 'import deep_gemm, importlib.metadata as md; print("sgl-deep-gemm:", md.version("sgl-deep-gemm")); print("deep_gemm:", deep_gemm.__file__)'
 
 # Create non-root user with specified UID and GID
 # NOTE: Replace with your own UID and GID. This is a workaround from https://github.com/microsoft/vscode-remote-release/issues/49#issuecomment-489060908.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=lmsysorg/sglang:dev
 FROM ${BASE_IMAGE} AS deepgemm_builder
 
 ARG DEEPGEMM_REPO=https://github.com/sgl-project/DeepGEMM.git
-ARG DEEPGEMM_REF=728ddc18efd203dc323c8bdd60e4da3f0635f4f2
+ARG DEEPGEMM_REF=1554ec1d52010e49cdd18b75f57c4d04fee838c7
 ARG SGL_DEEP_GEMM_VERSION=0.1.0+dev.pr36
 
 USER root

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux; \
     git checkout --detach FETCH_HEAD; \
     test "$(git rev-parse HEAD)" = "${DEEPGEMM_REF}"; \
     git submodule update --init --recursive; \
+    python3 -c 'from pathlib import Path; p = Path("deep_gemm/__init__.py"); text = p.read_text(); needle = "    mega_moe_pre_dispatch,\n)"; replacement = "    mega_moe_pre_dispatch,\n    transform_weights_for_mega_moe_sm90,\n    fp8_mega_moe,\n)"; assert needle in text; p.write_text(text.replace(needle, replacement))'; \
     echo -n "${SGL_DEEP_GEMM_VERSION}" > sgl_deep_gemm/VERSION; \
     bash build_sgl_deep_gemm.sh
 
@@ -28,7 +29,7 @@ RUN set -eux; \
     python3 -m pip install --no-deps --force-reinstall /tmp/sgl_deep_gemm-*.whl; \
     rm -f /tmp/sgl_deep_gemm-*.whl; \
     rm -rf /root/.cache/deep_gemm; \
-    python3 -c 'import deep_gemm, importlib.metadata as md; print("sgl-deep-gemm:", md.version("sgl-deep-gemm")); print("deep_gemm:", deep_gemm.__file__)'
+    python3 -c 'import deep_gemm, importlib.metadata as md; required = ("fp8_mega_moe", "fp8_fp4_mega_moe", "mega_moe_pre_dispatch", "transform_weights_for_mega_moe_sm90"); missing = [name for name in required if not hasattr(deep_gemm, name)]; assert not missing, missing; print("sgl-deep-gemm:", md.version("sgl-deep-gemm")); print("deep_gemm:", deep_gemm.__file__)'
 
 # Create non-root user with specified UID and GID
 # NOTE: Replace with your own UID and GID. This is a workaround from https://github.com/microsoft/vscode-remote-release/issues/49#issuecomment-489060908.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,19 +2,21 @@ ARG BASE_IMAGE=lmsysorg/sglang:dev
 
 FROM ${BASE_IMAGE} AS deepgemm_builder
 
-ARG DEEPGEMM_REPO=https://github.com/sgl-project/DeepGEMM.git
-ARG DEEPGEMM_REF=1554ec1d52010e49cdd18b75f57c4d04fee838c7
-ARG SGL_DEEP_GEMM_VERSION=0.1.0+dev.pr36
+ARG DEEPGEMM_REPO=https://github.com/qiushixiaoyu/DeepGEMM.git
+ARG DEEPGEMM_REF=refs/heads/main
+ARG DEEPGEMM_CACHE_BUST=manual
+ARG SGL_DEEP_GEMM_VERSION=0.1.0+qiushixiaoyu.main
 
 USER root
 
 RUN set -eux; \
+    echo "${DEEPGEMM_CACHE_BUST}"; \
     rm -rf /tmp/DeepGEMM; \
     git clone --no-checkout "${DEEPGEMM_REPO}" /tmp/DeepGEMM; \
     cd /tmp/DeepGEMM; \
-    git fetch --depth=1 origin refs/pull/36/merge; \
+    git fetch --depth=1 origin "${DEEPGEMM_REF}"; \
     git checkout --detach FETCH_HEAD; \
-    test "$(git rev-parse HEAD)" = "${DEEPGEMM_REF}"; \
+    git rev-parse HEAD | tee /tmp/deepgemm_commit.txt; \
     git submodule update --init --recursive; \
     python3 -c 'from pathlib import Path; p = Path("sgl_deep_gemm/__init__.py"); text = p.read_text(); needle = "    mega_moe_pre_dispatch,\n)"; replacement = "    mega_moe_pre_dispatch,\n    transform_weights_for_mega_moe_sm90,\n    fp8_mega_moe,\n)"; assert needle in text; p.write_text(text.replace(needle, replacement))'; \
     echo -n "${SGL_DEEP_GEMM_VERSION}" > sgl_deep_gemm/VERSION; \
@@ -23,6 +25,7 @@ RUN set -eux; \
 FROM ${BASE_IMAGE}
 
 COPY --from=deepgemm_builder /tmp/DeepGEMM/dist/sgl_deep_gemm-*.whl /tmp/
+COPY --from=deepgemm_builder /tmp/deepgemm_commit.txt /usr/local/share/sgl-deep-gemm-commit.txt
 
 RUN set -eux; \
     python3 -m pip uninstall -y sgl-deep-gemm deep-gemm || true; \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     git checkout --detach FETCH_HEAD; \
     test "$(git rev-parse HEAD)" = "${DEEPGEMM_REF}"; \
     git submodule update --init --recursive; \
-    python3 -c 'from pathlib import Path; p = Path("deep_gemm/__init__.py"); text = p.read_text(); needle = "    mega_moe_pre_dispatch,\n)"; replacement = "    mega_moe_pre_dispatch,\n    transform_weights_for_mega_moe_sm90,\n    fp8_mega_moe,\n)"; assert needle in text; p.write_text(text.replace(needle, replacement))'; \
+    python3 -c 'from pathlib import Path; p = Path("sgl_deep_gemm/__init__.py"); text = p.read_text(); needle = "    mega_moe_pre_dispatch,\n)"; replacement = "    mega_moe_pre_dispatch,\n    transform_weights_for_mega_moe_sm90,\n    fp8_mega_moe,\n)"; assert needle in text; p.write_text(text.replace(needle, replacement))'; \
     echo -n "${SGL_DEEP_GEMM_VERSION}" > sgl_deep_gemm/VERSION; \
     bash build_sgl_deep_gemm.sh
 

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/mega_moe_pre_dispatch_sm90.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/mega_moe_pre_dispatch_sm90.cuh
@@ -1,0 +1,247 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
+
+#include <cstdint>
+#include <cuda_fp8.h>
+
+// SM90 (Hopper) variant of `mega_moe_pre_dispatch`.
+//
+// Differences vs the SM100 path (mega_moe_pre_dispatch.cuh):
+//   * Per-128 K raw FP32 scale (no UE8M0 packing). `buf_x_sf` is contiguous
+//     row-major float [P, hidden/128]; byte offset for token `t` group `g` is
+//     `(t * num_groups + g) * sizeof(float)`. This matches DeepGEMM's SM90
+//     mega-moe symm buffer layout (DeepGEMM/csrc/apis/mega.hpp, sf_dtype = f32
+//     when arch_major == 9), and the output of
+//     `sglang_per_token_group_quant_fp8(group_size=128, scale_ue8m0=False)`.
+//   * Fixed `kGroupSize = 128`.
+//   * Optionally fuses the DeepSeek `routed_scaling_factor` into the
+//     `buf_topk_weights` write so the caller can drop the post-mega
+//     `y.mul_(scale)` kernel.
+//
+// Quant main-loop (vector load + absmax + pack_fp8 store) is intentionally
+// kept inline in this file to avoid coupling with the SM100 template.
+
+namespace {
+
+using deepseek_v4::fp8::pack_fp8;
+
+struct MegaMoEPreDispatchSM90Params {
+  const bf16_t* __restrict__ x;            // [num_tokens, hidden]
+  const int32_t* __restrict__ topk_idx;    // [num_tokens, top_k]
+  const float* __restrict__ topk_weights;  // [num_tokens, top_k]
+
+  fp8_e4m3_t* __restrict__ buf_x;        // [padded_max, hidden]
+  float* __restrict__ buf_x_sf;          // contiguous fp32 [P, G]; byte off = t*G + g (per fp32)
+  int64_t* __restrict__ buf_topk_idx;    // [padded_max, top_k]
+  float* __restrict__ buf_topk_weights;  // [padded_max, top_k]
+
+  uint32_t num_tokens;
+  uint32_t padded_max;
+  uint32_t hidden;
+  uint32_t num_groups;  // hidden / group_size (= hidden / 128)
+  uint32_t top_k;
+
+  // Multiplicative factor folded into `buf_topk_weights` writes.
+  // Set to 1.0f to disable. The DeepSeek MoE final output is
+  //     y = SharedExpert(x) + alpha * sum_i (g_i * E_i(x))
+  // where alpha = routed_scaling_factor; pre-multiplying alpha into g_i
+  // allows the caller to skip the post-mega `y.mul_(alpha)` kernel.
+  float routed_scaling_factor;
+};
+
+// kGroupSize is fixed to 128 on SM90 to match DeepGEMM's per-128 channel
+// FP32 SF layout. Templated only so the JIT cache key is symmetrical with
+// the SM100 module.
+template <uint32_t kGroupSize, bool kUsePDL>
+__global__ __launch_bounds__(1024, 2) void  //
+    mega_moe_pre_dispatch_sm90_kernel(const MegaMoEPreDispatchSM90Params __grid_constant__ params) {
+  using namespace device;
+  static_assert(kGroupSize == 128, "SM90 mega-moe pre-dispatch requires per-128 SF");
+
+  constexpr uint32_t kVecElems = 8;  // 8 bf16 = 16B load per thread
+  static_assert(kGroupSize % kVecElems == 0, "group_size must be a multiple of 8");
+  constexpr uint32_t kThreadsPerGroup = kGroupSize / kVecElems;  // = 16
+  using InputVec = AlignedVector<bf16x2_t, kVecElems / 2>;
+  using OutputVec = AlignedVector<fp8x2_e4m3_t, kVecElems / 2>;
+
+  const uint32_t bid = blockIdx.x;
+  const uint32_t tid = threadIdx.x;
+
+  PDLWaitPrimary<kUsePDL>();
+  if (bid < params.num_tokens) {
+    // ---- Quantize path: one CTA per valid token ----
+
+    const uint32_t token_id = bid;
+    const auto token_in = params.x + static_cast<uint64_t>(token_id) * params.hidden;
+    const auto token_out = params.buf_x + static_cast<uint64_t>(token_id) * params.hidden;
+
+    InputVec in_vec;
+    in_vec.load(token_in, tid);
+
+    float local_max = 0.0f;
+    float vals[kVecElems];
+#pragma unroll
+    for (uint32_t i = 0; i < kVecElems / 2; ++i) {
+      const auto [v0, v1] = cast<fp32x2_t>(in_vec[i]);
+      vals[2 * i + 0] = v0;
+      vals[2 * i + 1] = v1;
+      local_max = fmaxf(local_max, fmaxf(fabsf(v0), fabsf(v1)));
+    }
+
+    // Absmax across the kThreadsPerGroup threads that cover one group.
+    local_max = warp::reduce_max<kThreadsPerGroup>(local_max);
+
+    // Match `sglang_per_token_group_quant_fp8`'s eps=1e-10 clamp.
+    const float absmax = fmaxf(local_max, 1e-10f);
+    const float raw_scale = absmax / math::FP8_E4M3_MAX;
+    // SM90 SF is raw fp32 (no UE8M0 round); inv_scale = 1 / raw_scale.
+    // `raw_scale` is strictly positive (eps clamp) so the divide is safe.
+    const float inv_scale = 1.0f / raw_scale;
+
+    OutputVec out_vec;
+#pragma unroll
+    for (uint32_t i = 0; i < kVecElems / 2; ++i) {
+      out_vec[i] = pack_fp8(vals[2 * i + 0] * inv_scale, vals[2 * i + 1] * inv_scale);
+    }
+    out_vec.store(token_out, tid);
+
+    // One thread per group writes its raw fp32 scale. Layout matches DeepGEMM's
+    // `buf.x_sf` slice for SM90: contiguous fp32 [P, num_groups], so the linear
+    // offset is `token_id * num_groups + group_id`.
+    const uint32_t group_id = tid / kThreadsPerGroup;
+    const uint32_t within_group_id = tid % kThreadsPerGroup;
+    if (within_group_id == 0 && group_id < params.num_groups) {
+      const uint32_t off = token_id * params.num_groups + group_id;
+      params.buf_x_sf[off] = raw_scale;
+    }
+
+    // Copy this token's topk row, folding routed_scaling_factor into weights.
+    if (tid < params.top_k) {
+      const uint32_t off = token_id * params.top_k + tid;
+      params.buf_topk_idx[off] = params.topk_idx[off];
+      params.buf_topk_weights[off] = params.topk_weights[off] * params.routed_scaling_factor;
+    }
+  } else {
+    // ---- Pad path: trailing blocks fill [num_tokens, padded_max) with (-1, 0) ----
+    const uint32_t copy_bid = bid - params.num_tokens;
+    const uint32_t pad_base = params.num_tokens * params.top_k;
+    const uint32_t slot = pad_base + copy_bid * blockDim.x + tid;
+    const uint32_t total_slots = params.padded_max * params.top_k;
+
+    if (slot < total_slots) {
+      params.buf_topk_idx[slot] = -1;
+      params.buf_topk_weights[slot] = 0.0f;
+    }
+  }
+  PDLTriggerSecondary<kUsePDL>();
+}
+
+// ---- Host wrapper
+// ------------------------------------------------------------------------------------------------------------------------
+
+template <int64_t kGroupSize, bool kUsePDL>
+struct MegaMoEPreDispatchSM90Kernel {
+  static_assert(kGroupSize == 128, "SM90 mega-moe pre-dispatch only supports group_size=128");
+  static constexpr auto kernel = mega_moe_pre_dispatch_sm90_kernel<static_cast<uint32_t>(kGroupSize), kUsePDL>;
+
+  static void
+  run(const tvm::ffi::TensorView x,
+      const tvm::ffi::TensorView topk_idx,
+      const tvm::ffi::TensorView topk_weights,
+      const tvm::ffi::TensorView buf_x,
+      const tvm::ffi::TensorView buf_x_sf,
+      const tvm::ffi::TensorView buf_topk_idx,
+      const tvm::ffi::TensorView buf_topk_weights,
+      double routed_scaling_factor) {
+    using namespace host;
+
+    auto device = SymbolicDevice{};
+    auto M = SymbolicSize{"num_tokens"};
+    auto P = SymbolicSize{"padded_max"};
+    auto H = SymbolicSize{"hidden"};
+    auto K = SymbolicSize{"top_k"};
+    auto G = SymbolicSize{"num_groups"};
+    device.set_options<kDLCUDA>();
+
+    TensorMatcher({M, H})  // input x
+        .with_dtype<bf16_t>()
+        .with_device(device)
+        .verify(x);
+    TensorMatcher({M, K})  // topk_idx
+        .with_dtype<int32_t>()
+        .with_device(device)
+        .verify(topk_idx);
+    TensorMatcher({M, K})  // topk_weights
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(topk_weights);
+    TensorMatcher({P, H})  // buf.x
+        .with_dtype<fp8_e4m3_t>()
+        .with_device(device)
+        .verify(buf_x);
+    // buf.x_sf is the contiguous row-major fp32 view from DeepGEMM's mega
+    // symm buffer (DeepGEMM/csrc/apis/mega.hpp, SM90 sf_dtype = f32):
+    // shape (P, G), strides (G, 1).
+    TensorMatcher({P, G})  // buf_x_sf
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(buf_x_sf);
+    TensorMatcher({P, K})  // buf.topk_idx
+        .with_dtype<int64_t>()
+        .with_device(device)
+        .verify(buf_topk_idx);
+    TensorMatcher({P, K})  // buf.topk_weights
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(buf_topk_weights);
+
+    const auto num_tokens = static_cast<uint32_t>(M.unwrap());
+    const auto padded_max = static_cast<uint32_t>(P.unwrap());
+    const auto hidden = static_cast<uint32_t>(H.unwrap());
+    const auto top_k = static_cast<uint32_t>(K.unwrap());
+    const auto num_groups = static_cast<uint32_t>(G.unwrap());
+
+    RuntimeCheck(num_tokens <= padded_max, "num_tokens must not exceed padded_max");
+    RuntimeCheck(hidden % kGroupSize == 0, "hidden must be a multiple of group_size");
+    RuntimeCheck(num_groups == hidden / static_cast<uint32_t>(kGroupSize),
+                 "num_groups must equal hidden / group_size");
+    RuntimeCheck(hidden % 8u == 0, "hidden must be a multiple of 8 (16B bf16 loads)");
+    const auto num_threads = hidden / 8u;
+    RuntimeCheck(num_threads <= 1024, "hidden too large for single-block-per-row quant");
+    RuntimeCheck(num_threads >= top_k, "top_k must fit into one quant CTA");
+
+    const auto pad_slots = (padded_max - num_tokens) * top_k;
+    const uint32_t num_pad_blocks = pad_slots == 0 ? 0u : ((pad_slots + num_threads - 1u) / num_threads);
+    const auto num_total_blocks = num_tokens + num_pad_blocks;
+
+    const auto params = MegaMoEPreDispatchSM90Params{
+        .x = static_cast<const bf16_t*>(x.data_ptr()),
+        .topk_idx = static_cast<const int32_t*>(topk_idx.data_ptr()),
+        .topk_weights = static_cast<const float*>(topk_weights.data_ptr()),
+        .buf_x = static_cast<fp8_e4m3_t*>(buf_x.data_ptr()),
+        .buf_x_sf = static_cast<float*>(buf_x_sf.data_ptr()),
+        .buf_topk_idx = static_cast<int64_t*>(buf_topk_idx.data_ptr()),
+        .buf_topk_weights = static_cast<float*>(buf_topk_weights.data_ptr()),
+        .num_tokens = num_tokens,
+        .padded_max = padded_max,
+        .hidden = hidden,
+        .num_groups = num_groups,
+        .top_k = top_k,
+        .routed_scaling_factor = static_cast<float>(routed_scaling_factor),
+    };
+
+    if (num_total_blocks == 0) return;
+    LaunchKernel(num_total_blocks, num_threads, device.unwrap())  //
+        .enable_pdl(kUsePDL)(kernel, params);
+  }
+};
+
+}  // namespace

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -327,6 +327,17 @@ def _jit_mega_moe_pre_dispatch_module(quant_group_size: int) -> Module:
 
 
 @cache_once
+def _jit_mega_moe_pre_dispatch_sm90_module(quant_group_size: int) -> Module:
+    args = make_cpp_args(quant_group_size, is_arch_support_pdl())
+    return load_jit(
+        make_name("mega_moe_pre_dispatch_sm90"),
+        *args,
+        cuda_files=["deepseek_v4/mega_moe_pre_dispatch_sm90.cuh"],
+        cuda_wrappers=[("run", f"MegaMoEPreDispatchSM90Kernel<{args}>::run")],
+    )
+
+
+@cache_once
 def _jit_hisparse_transfer_module() -> Module:
     return load_jit(
         make_name("hisparse_transfer"),
@@ -921,6 +932,8 @@ def silu_and_mul_contig_post_quant(
     swizzle: bool = False,
 ) -> None:
     apply_swiglu_limit = swiglu_limit is not None
+    if input.shape[0] == 0:
+        return
     module = _jit_silu_mul_quant_contig_module(
         quant_group_size, scale_ue8m0, swizzle, apply_swiglu_limit
     )
@@ -952,6 +965,30 @@ def mega_moe_pre_dispatch(
         buf_x_sf,
         buf_topk_idx,
         buf_topk_weights,
+    )
+
+
+def mega_moe_pre_dispatch_sm90(
+    x: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    buf_x: torch.Tensor,
+    buf_x_sf: torch.Tensor,
+    buf_topk_idx: torch.Tensor,
+    buf_topk_weights: torch.Tensor,
+    routed_scaling_factor: float = 1.0,
+    quant_group_size: int = 128,
+) -> None:
+    module = _jit_mega_moe_pre_dispatch_sm90_module(quant_group_size)
+    module.run(
+        x,
+        topk_idx,
+        topk_weights,
+        buf_x,
+        buf_x_sf,
+        buf_topk_idx,
+        buf_topk_weights,
+        float(routed_scaling_factor),
     )
 
 

--- a/python/sglang/jit_kernel/dsv4/__init__.py
+++ b/python/sglang/jit_kernel/dsv4/__init__.py
@@ -1,4 +1,6 @@
 from .compress import *
+from sglang.jit_kernel.deepseek_v4 import mega_moe_pre_dispatch_sm90
+
 from .utils import make_name
 
 __all__ = [
@@ -7,4 +9,5 @@ __all__ = [
     "compress_forward",
     "compress_norm_rope_store",
     "make_name",
+    "mega_moe_pre_dispatch_sm90",
 ]

--- a/python/sglang/jit_kernel/tests/test_mega_moe_pre_dispatch_sm90.py
+++ b/python/sglang/jit_kernel/tests/test_mega_moe_pre_dispatch_sm90.py
@@ -1,0 +1,270 @@
+"""Tests for the SM90 fused mega-MoE pre-dispatch kernel.
+
+The kernel is the SM90 (Hopper) variant of `mega_moe_pre_dispatch` and is
+expected to match the legacy fallback's topk writes exactly and its FP8
+quantization numerically within FP8 rounding tolerance:
+
+    1) sglang_per_token_group_quant_fp8(x, group_size=128, scale_ue8m0=False)
+       -> writes buf.x[:M], buf.x_sf[:M]
+    2) buf.topk_idx[:M].copy_(topk_idx); buf.topk_weights[:M].copy_(weights * alpha)
+    3) buf.topk_idx[M:].fill_(-1); buf.topk_weights[M:].zero_()
+
+with the additional capability of folding a `routed_scaling_factor` (= alpha)
+into the `buf.topk_weights` write so the caller can drop the post-mega
+`y.mul_(alpha)` kernel.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def _has_hopper() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major == 9
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_hopper(),
+    reason="SM90 mega-moe pre-dispatch requires a Hopper (sm_90) GPU",
+)
+
+
+def _reference_pre_dispatch(
+    x: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    padded_max: int,
+    routed_scaling_factor: float,
+):
+    """Mirror `_run_mega_routed`'s non-fused SM90 path."""
+    from sglang.srt.layers.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    num_tokens, hidden = x.shape
+    top_k = topk_idx.shape[1]
+    num_groups = hidden // 128
+
+    buf_x = torch.empty(
+        (padded_max, hidden), dtype=torch.float8_e4m3fn, device=x.device
+    )
+    buf_x_sf = torch.empty(
+        (padded_max, num_groups), dtype=torch.float32, device=x.device
+    )
+    buf_topk_idx = torch.empty(
+        (padded_max, top_k), dtype=torch.int64, device=x.device
+    )
+    buf_topk_weights = torch.empty(
+        (padded_max, top_k), dtype=torch.float32, device=x.device
+    )
+
+    if num_tokens > 0:
+        x_fp8, x_sf = sglang_per_token_group_quant_fp8(
+            x, group_size=128, scale_ue8m0=False
+        )
+        buf_x[:num_tokens].copy_(x_fp8)
+        buf_x_sf[:num_tokens].copy_(x_sf)
+        buf_topk_idx[:num_tokens].copy_(topk_idx)
+        buf_topk_weights[:num_tokens].copy_(topk_weights * routed_scaling_factor)
+
+    if num_tokens < padded_max:
+        buf_topk_idx[num_tokens:].fill_(-1)
+        buf_topk_weights[num_tokens:].zero_()
+
+    return buf_x, buf_x_sf, buf_topk_idx, buf_topk_weights
+
+
+def _run_kernel(
+    x: torch.Tensor,
+    topk_idx: torch.Tensor,
+    topk_weights: torch.Tensor,
+    padded_max: int,
+    routed_scaling_factor: float,
+):
+    from sglang.jit_kernel.dsv4 import mega_moe_pre_dispatch_sm90
+
+    num_tokens, hidden = x.shape
+    top_k = topk_idx.shape[1]
+    num_groups = hidden // 128
+
+    buf_x = torch.empty(
+        (padded_max, hidden), dtype=torch.float8_e4m3fn, device=x.device
+    )
+    buf_x_sf = torch.empty(
+        (padded_max, num_groups), dtype=torch.float32, device=x.device
+    )
+    buf_topk_idx = torch.empty(
+        (padded_max, top_k), dtype=torch.int64, device=x.device
+    )
+    buf_topk_weights = torch.empty(
+        (padded_max, top_k), dtype=torch.float32, device=x.device
+    )
+
+    # Poison the padded region so we can confirm the kernel actually wrote it.
+    if num_tokens < padded_max:
+        buf_topk_idx[num_tokens:].fill_(0x4242)
+        buf_topk_weights[num_tokens:].fill_(float("nan"))
+
+    if num_tokens > 0:
+        topk_idx_in = topk_idx
+        topk_weights_in = topk_weights
+    else:
+        topk_idx_in = x.new_empty((0, top_k), dtype=torch.int32)
+        topk_weights_in = x.new_empty((0, top_k), dtype=torch.float32)
+
+    mega_moe_pre_dispatch_sm90(
+        x if num_tokens > 0 else x.new_empty((0, hidden), dtype=x.dtype),
+        topk_idx_in,
+        topk_weights_in,
+        buf_x,
+        buf_x_sf,
+        buf_topk_idx,
+        buf_topk_weights,
+        routed_scaling_factor=routed_scaling_factor,
+        quant_group_size=128,
+    )
+    return buf_x, buf_x_sf, buf_topk_idx, buf_topk_weights
+
+
+@pytest.mark.parametrize(
+    "num_tokens,hidden,top_k,padded_max,scale",
+    [
+        (0, 2048, 8, 32, 1.0),
+        (1, 1024, 4, 8, 2.5),
+        (7, 2048, 8, 16, 1.0),
+        (7, 2048, 8, 16, 2.5),
+        (32, 4096, 8, 32, 2.5),
+        (128, 7168, 8, 256, 2.5),
+        (128, 7168, 8, 128, 1.0),  # exact-fill (no padding rows)
+    ],
+)
+def test_sm90_pre_dispatch_matches_reference(
+    num_tokens: int,
+    hidden: int,
+    top_k: int,
+    padded_max: int,
+    scale: float,
+):
+    assert hidden % 128 == 0 and hidden % 8 == 0
+    assert num_tokens <= padded_max
+    device = torch.device("cuda")
+    torch.manual_seed(0xC0FFEE ^ num_tokens ^ hidden ^ top_k)
+
+    # Mix of small and large magnitudes so absmax / clamp logic is exercised.
+    x = torch.randn(num_tokens, hidden, dtype=torch.bfloat16, device=device) * 4.0
+    topk_idx = torch.randint(
+        0, 256, (num_tokens, top_k), dtype=torch.int32, device=device
+    )
+    topk_weights = torch.randn(
+        num_tokens, top_k, dtype=torch.float32, device=device
+    )
+
+    ref = _reference_pre_dispatch(x, topk_idx, topk_weights, padded_max, scale)
+    out = _run_kernel(x, topk_idx, topk_weights, padded_max, scale)
+
+    ref_x, ref_sf, ref_idx, ref_w = ref
+    out_x, out_sf, out_idx, out_w = out
+
+    # Note: neither the kernel nor the reference initializes buf_x / buf_x_sf
+    # past `num_tokens`, so we only compare the valid prefix for those.
+    if num_tokens > 0:
+        # Scales use the same formula as the reference, but the fused kernel and
+        # reference quantizer can differ by a few fp32 ULPs.
+        torch.testing.assert_close(
+            out_sf[:num_tokens], ref_sf[:num_tokens], rtol=1e-6, atol=0
+        )
+        # FP8 codes: the reference uses `y / y_s` while the CUDA kernel uses
+        # `y * (1 / y_s)`, which can differ by 1 ULP at quantization boundaries.
+        # Compare the dequantized values instead.
+        num_groups = x.shape[1] // 128
+
+        def _dequant(buf_x, buf_sf):
+            return (
+                buf_x[:num_tokens]
+                .float()
+                .reshape(num_tokens, num_groups, 128)
+                * buf_sf[:num_tokens].unsqueeze(-1)
+            )
+
+        out_deq = _dequant(out_x, out_sf)
+        ref_deq = _dequant(ref_x, ref_sf)
+        # Two outputs differ by at most one fp8-e4m3 mantissa step (1/8 of the
+        # local magnitude).
+        torch.testing.assert_close(out_deq, ref_deq, rtol=1.0 / 8, atol=0)
+        # Sanity: dequantized values must approximate the original input.
+        torch.testing.assert_close(
+            out_deq,
+            x.float().reshape(num_tokens, num_groups, 128),
+            rtol=0.25,
+            atol=1e-4,
+        )
+
+    # topk_idx / topk_weights are written for the entire padded buffer.
+    torch.testing.assert_close(out_idx, ref_idx, rtol=0, atol=0)
+    torch.testing.assert_close(out_w, ref_w, rtol=1e-6, atol=0)
+
+
+def test_sm90_pre_dispatch_alpha_one_equals_unscaled():
+    """`routed_scaling_factor=1.0` must reproduce the original (unfused) output."""
+    device = torch.device("cuda")
+    torch.manual_seed(7)
+    M, P, H, K = 5, 16, 2048, 8
+    x = torch.randn(M, H, dtype=torch.bfloat16, device=device)
+    topk_idx = torch.randint(0, 256, (M, K), dtype=torch.int32, device=device)
+    topk_weights = torch.randn(M, K, dtype=torch.float32, device=device)
+
+    out = _run_kernel(x, topk_idx, topk_weights, P, routed_scaling_factor=1.0)
+    _, _, _, out_w = out
+
+    # Valid rows: bit-equal to the input weights (single fp32 store).
+    torch.testing.assert_close(out_w[:M], topk_weights, rtol=0, atol=0)
+    # Padded rows: zeros (kernel-emitted, overwriting the NaN poison).
+    assert torch.all(out_w[M:] == 0.0)
+
+
+def test_sm90_pre_dispatch_zero_tokens_only_pads():
+    """num_tokens=0 must still produce a fully padded buffer."""
+    device = torch.device("cuda")
+    P, H, K = 8, 1024, 4
+    x = torch.empty(0, H, dtype=torch.bfloat16, device=device)
+    topk_idx = torch.empty(0, K, dtype=torch.int32, device=device)
+    topk_weights = torch.empty(0, K, dtype=torch.float32, device=device)
+
+    _, _, idx, w = _run_kernel(x, topk_idx, topk_weights, P, routed_scaling_factor=2.5)
+    assert torch.all(idx == -1)
+    assert torch.all(w == 0.0)
+
+
+def test_sm90_pre_dispatch_no_padding_branch():
+    """num_tokens == padded_max: kernel must not launch any pad blocks
+    yet still produce a valid buffer for the active rows."""
+    device = torch.device("cuda")
+    M = P = 16
+    H, K = 2048, 8
+    torch.manual_seed(11)
+    x = torch.randn(M, H, dtype=torch.bfloat16, device=device)
+    topk_idx = torch.randint(0, 256, (M, K), dtype=torch.int32, device=device)
+    topk_weights = torch.randn(M, K, dtype=torch.float32, device=device)
+
+    ref = _reference_pre_dispatch(x, topk_idx, topk_weights, P, 1.0)
+    out = _run_kernel(x, topk_idx, topk_weights, P, 1.0)
+    ref_x, ref_sf, ref_idx, ref_w = ref
+    out_x, out_sf, out_idx, out_w = out
+    # Scales use the same formula as the reference, with fp32 ULP-level drift.
+    torch.testing.assert_close(out_sf, ref_sf, rtol=1e-6, atol=0)
+    # topk fully written.
+    torch.testing.assert_close(out_idx, ref_idx, rtol=0, atol=0)
+    torch.testing.assert_close(out_w, ref_w, rtol=0, atol=0)
+    # FP8 quant matches within one e4m3 mantissa step via dequant.
+    num_groups = H // 128
+    out_deq = out_x.float().reshape(M, num_groups, 128) * out_sf.unsqueeze(-1)
+    ref_deq = ref_x.float().reshape(M, num_groups, 128) * ref_sf.unsqueeze(-1)
+    torch.testing.assert_close(out_deq, ref_deq, rtol=1.0 / 8, atol=0)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -21,12 +21,16 @@ from typing import TYPE_CHECKING, Optional
 
 import torch
 
-from sglang.jit_kernel.deepseek_v4 import mega_moe_pre_dispatch
+from sglang.jit_kernel.deepseek_v4 import (
+    mega_moe_pre_dispatch,
+    mega_moe_pre_dispatch_sm90,
+)
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers.dp_attention import get_dp_global_num_tokens
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
+from sglang.srt.models.deepseek_common.utils import _device_sm
 
 if TYPE_CHECKING:
     from deep_gemm import SymmBuffer
@@ -99,10 +103,29 @@ def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bo
         return False
     if not getattr(moe.experts, "_mega_moe_weights_built", False):
         return False
+    if _device_sm is None or _device_sm < 90:
+        return False
+    try:
+        import deep_gemm
+    except ImportError:
+        return False
+    if _device_sm == 90:
+        if not hasattr(deep_gemm, "fp8_mega_moe"):
+            return False
+        if not getattr(moe.experts, "_mega_moe_sm90_fp8_weights", False):
+            return False
+    elif _device_sm >= 100:
+        if not hasattr(deep_gemm, "fp8_fp4_mega_moe"):
+            return False
+    else:
+        return False
     if get_is_capture_mode():
         return True
 
-    global_num_tokens = get_dp_global_num_tokens()
+    try:
+        global_num_tokens = get_dp_global_num_tokens()
+    except AttributeError:
+        global_num_tokens = None
     if global_num_tokens:
         max_tokens_per_rank = max(global_num_tokens)
     else:
@@ -213,8 +236,28 @@ def _run_mega_routed(
         topk_ids_in = hidden_states.new_empty((0, top_k), dtype=torch.int32)
         topk_weights_in = hidden_states.new_empty((0, top_k), dtype=torch.float32)
 
-    use_fp4_acts = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS.get()
-    if use_fp4_acts:
+    use_sm90_fp8_mega = _device_sm == 90 and getattr(
+        moe.experts, "_mega_moe_sm90_fp8_weights", False
+    )
+    fused_routed_scaling = False
+    if use_sm90_fp8_mega:
+        if moe.experts.should_fuse_routed_scaling_factor_in_topk:
+            scale = 1.0
+        else:
+            scale = float(moe.routed_scaling_factor)
+            fused_routed_scaling = True
+        mega_moe_pre_dispatch_sm90(
+            hidden_states,
+            topk_ids_in,
+            topk_weights_in,
+            buf.x,
+            buf.x_sf,
+            buf.topk_idx,
+            buf.topk_weights,
+            routed_scaling_factor=scale,
+            quant_group_size=128,
+        )
+    elif envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS.get():
         # FP4 path goes through DeepGEMM's mega_moe_pre_dispatch which
         # handles the E2M1 packing variant. The jit implementation
         # only emits FP8.
@@ -250,21 +293,46 @@ def _run_mega_routed(
         device=hidden_states.device,
     )
     swiglu_limit = getattr(moe.config, "swiglu_limit", None)
-    deep_gemm.fp8_fp4_mega_moe(
-        y,
-        moe.experts.mega_l1_weights,
-        moe.experts.mega_l2_weights,
-        buf,
-        recipe=(1, 1, 32),
-        activation="swiglu",
-        activation_clamp=swiglu_limit,
-        fast_math=True,
-    )
+    if use_sm90_fp8_mega:
+        deep_gemm.fp8_mega_moe(
+            y,
+            moe.experts.mega_l1_weights,
+            moe.experts.mega_l2_weights,
+            buf,
+            recipe=(128, 128, 128),
+            activation="swiglu",
+            activation_clamp=swiglu_limit,
+            fast_math=True,
+        )
+    else:
+        deep_gemm.fp8_fp4_mega_moe(
+            y,
+            moe.experts.mega_l1_weights,
+            moe.experts.mega_l2_weights,
+            buf,
+            recipe=(1, 1, 32),
+            activation="swiglu",
+            activation_clamp=swiglu_limit,
+            fast_math=True,
+        )
     y = y[:num_tokens]
 
-    if not moe.experts.should_fuse_routed_scaling_factor_in_topk:
+    if (
+        not moe.experts.should_fuse_routed_scaling_factor_in_topk
+        and not fused_routed_scaling
+    ):
         y.mul_(moe.routed_scaling_factor)
     return y
+
+
+def _interleave_l1_weight_only(weight: torch.Tensor, gran: int = 8) -> torch.Tensor:
+    num_groups, n, *rest = weight.shape
+    half = n // 2
+    gate = weight[:, :half].reshape(num_groups, half // gran, gran, *rest)
+    up = weight[:, half:].reshape(num_groups, half // gran, gran, *rest)
+    return torch.empty_like(weight).copy_(
+        torch.stack([gate, up], dim=2).reshape(num_groups, n, *rest)
+    )
 
 
 def build_mega_moe_experts_weights(experts) -> None:
@@ -283,28 +351,88 @@ def build_mega_moe_experts_weights(experts) -> None:
     w2_sf_fp32 = experts.w2_weight_scale_inv.data
 
     num_groups, n1, half_k1 = w13.shape
-    k1 = half_k1 * 2
     _, n2, half_k2 = w2.shape
-    k2 = half_k2 * 2
 
-    w13_sf = transform_sf_into_required_layout(
-        w13_sf_fp32,
-        mn=n1,
-        k=k1,
-        recipe=(1, 32),
-        num_groups=num_groups,
-        disable_ue8m0_cast=False,
+    use_sm90_fp8_mega = (
+        _device_sm == 90
+        and w13.dtype == torch.float8_e4m3fn
+        and w2.dtype == torch.float8_e4m3fn
     )
-    w2_sf = transform_sf_into_required_layout(
-        w2_sf_fp32,
-        mn=n2,
-        k=k2,
-        recipe=(1, 32),
-        num_groups=num_groups,
-        disable_ue8m0_cast=False,
+    # FP4 weights are packed as int8 and have last dim K//2; FP8 weights use K.
+    if use_sm90_fp8_mega:
+        k1 = half_k1
+        k2 = half_k2
+    else:
+        k1 = half_k1 * 2
+        k2 = half_k2 * 2
+
+    # SM90 fp8_mega_moe consumes the checkpoint's block-(128, 128) FP32 scales
+    # directly; SM100 fp8_fp4_mega_moe keeps the UE8M0 recipe.
+    recipe = (128, 128) if use_sm90_fp8_mega else (1, 32)
+    disable_ue8m0_cast = use_sm90_fp8_mega
+
+    scale_group_mn, scale_group_k = recipe
+    assert k1 % scale_group_k == 0 and k2 % scale_group_k == 0, (
+        f"invalid mega-moe K/group_size: k1={k1}, k2={k2}, "
+        f"group_k={scale_group_k}"
+    )
+    expected_n_groups_1 = (n1 + scale_group_mn - 1) // scale_group_mn
+    expected_n_groups_2 = (n2 + scale_group_mn - 1) // scale_group_mn
+    expected_k_groups_1 = k1 // scale_group_k
+    expected_k_groups_2 = k2 // scale_group_k
+    assert w13_sf_fp32.shape[1] == expected_n_groups_1, (
+        f"w13 scale N groups mismatch: got {w13_sf_fp32.shape[1]}, "
+        f"expected {expected_n_groups_1} (n1={n1}, group_mn={scale_group_mn})"
+    )
+    assert w2_sf_fp32.shape[1] == expected_n_groups_2, (
+        f"w2 scale N groups mismatch: got {w2_sf_fp32.shape[1]}, "
+        f"expected {expected_n_groups_2} (n2={n2}, group_mn={scale_group_mn})"
+    )
+    assert w13_sf_fp32.shape[2] == expected_k_groups_1, (
+        f"w13 scale K groups mismatch: got {w13_sf_fp32.shape[2]}, "
+        f"expected {expected_k_groups_1} (k1={k1}, group_k={scale_group_k})"
+    )
+    assert w2_sf_fp32.shape[2] == expected_k_groups_2, (
+        f"w2 scale K groups mismatch: got {w2_sf_fp32.shape[2]}, "
+        f"expected {expected_k_groups_2} (k2={k2}, group_k={scale_group_k})"
     )
 
-    if envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get():
+    fix_mega_moe_memory = envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get()
+    if fix_mega_moe_memory and use_sm90_fp8_mega:
+        # SM90 shares both fp8 weights and block-(128, 128) FP32 scales with the
+        # DeepEP grouped-GEMM path. SM90 has no UTCCP scale transpose, and its
+        # scale tensors stay in checkpoint layout.
+        w13_interleaved = _interleave_l1_weight_only(w13)
+
+        experts.w13_weight.data = w13_interleaved
+
+        experts.mega_l1_weights = (
+            experts.w13_weight.data,
+            experts.w13_weight_scale_inv.data,
+        )
+        experts.mega_l2_weights = (
+            experts.w2_weight.data,
+            experts.w2_weight_scale_inv.data,
+        )
+    else:
+        w13_sf = transform_sf_into_required_layout(
+            w13_sf_fp32,
+            mn=n1,
+            k=k1,
+            recipe=recipe,
+            num_groups=num_groups,
+            disable_ue8m0_cast=disable_ue8m0_cast,
+        )
+        w2_sf = transform_sf_into_required_layout(
+            w2_sf_fp32,
+            mn=n2,
+            k=k2,
+            recipe=recipe,
+            num_groups=num_groups,
+            disable_ue8m0_cast=disable_ue8m0_cast,
+        )
+
+    if fix_mega_moe_memory and not use_sm90_fp8_mega:
         # Build the interleaved L1 weight + scale once; share the weight buffer
         # between `w13_weight.data` (normal deep-ep path) and `mega_l1_weights[0]`
         # (mega moe path). Mega moe additionally needs a UTCCP-transposed scale;
@@ -323,10 +451,17 @@ def build_mega_moe_experts_weights(experts) -> None:
 
         experts.mega_l1_weights = (experts.w13_weight.data, w13_sf_utccp)
         experts.mega_l2_weights = (experts.w2_weight.data, w2_sf_utccp)
-    else:
-        l1_pair, l2_pair = transform_weights_for_mega_moe((w13, w13_sf), (w2, w2_sf))
+    elif not fix_mega_moe_memory:
+        transform_fn = transform_weights_for_mega_moe
+        if use_sm90_fp8_mega:
+            from deep_gemm import transform_weights_for_mega_moe_sm90
+
+            transform_fn = transform_weights_for_mega_moe_sm90
+
+        l1_pair, l2_pair = transform_fn((w13, w13_sf), (w2, w2_sf))
 
         experts.mega_l1_weights = l1_pair
         experts.mega_l2_weights = l2_pair
 
+    experts._mega_moe_sm90_fp8_weights = use_sm90_fp8_mega
     experts._mega_moe_weights_built = True

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1305,7 +1305,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer.w13_weight.data = layer.w13_weight.data.view(fp4_weight_dtype)
                 layer.w2_weight.data = layer.w2_weight.data.view(fp4_weight_dtype)
 
-                if get_moe_a2a_backend().is_megamoe():
+                # FP4 expert mega MoE requires SM100. All-FP8 mega MoE on
+                # SM90 is handled below in the non-fp4-expert branch.
+                if (
+                    get_moe_a2a_backend().is_megamoe()
+                    and is_sm100_supported()
+                ):
                     from sglang.srt.layers.moe.mega_moe import (
                         build_mega_moe_experts_weights,
                     )
@@ -1332,6 +1337,19 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                         )
                     layer.w13_weight_scale_inv.format_ue8m0 = True
                     layer.w2_weight_scale_inv.format_ue8m0 = True
+
+            if (
+                not self.is_fp4_expert
+                and get_moe_a2a_backend().is_megamoe()
+                and is_sm90_supported()
+                and not is_sm100_supported()
+            ):
+                from sglang.srt.layers.moe.mega_moe import (
+                    build_mega_moe_experts_weights,
+                )
+
+                build_mega_moe_experts_weights(layer)
+                return
 
             if (
                 not self.is_fp4_expert

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -887,12 +887,16 @@ class DeepseekV4DecoderLayer(nn.Module):
             and not get_moe_a2a_backend().is_none()
         )
         if _use_cp:
-            if get_moe_a2a_backend().is_none():
+            moe_a2a_backend = get_moe_a2a_backend()
+            if moe_a2a_backend.is_none():
                 hidden_states = nsa_cp_gather_hidden_states(hidden_states)
             else:
-                assert get_moe_a2a_backend().is_deepep(), (
-                    "CP requires DeepEP (moe_a2a_backend == deepep). "
-                    "Only DeepEP is tested with CP's per-rank token split."
+                cp_moe_backend_supported = (
+                    moe_a2a_backend.is_deepep() or moe_a2a_backend.is_megamoe()
+                )
+                assert cp_moe_backend_supported, (
+                    "CP requires DeepEP (moe_a2a_backend == deepep) or MegaMoE "
+                    "(moe_a2a_backend == megamoe)."
                 )
                 cp_rank = get_attention_cp_rank()
                 cp_size = get_attention_cp_size()


### PR DESCRIPTION
Cherry-picks qiushixiaoyu/sglang@5776a42f3490670e56dbe1d32ef347ea429e9515 onto bytedance/deepseek_v4.

Conflict resolution notes:
- Kept the bytedance/deepseek_v4 JIT layout based on sglang.jit_kernel.deepseek_v4.
- Added the SM90 mega_moe_pre_dispatch entrypoint there and re-exported it from dsv4 for the new test.
- Preserved the existing CP path for moe_a2a_backend=none while allowing MegaMoE alongside DeepEP.

Devcontainer change:
- Updates .devcontainer/Dockerfile to build sgl-deep-gemm from sgl-project/DeepGEMM refs/pull/36/merge at 1554ec1d52010e49cdd18b75f57c4d04fee838c7.
- Reinstalls the resulting wheel as sgl-deep-gemm version 0.1.0+dev.pr36 in the final lmsysorg/sglang:dev-based image.
- Patches the packaged sgl_deep_gemm/__init__.py export list before wheel build so the top-level deep_gemm module exposes SM90 MegaMoE symbols required by this SGLang change.

Validation:
- python3 -m compileall on changed Python files.
- Docker image built on H20_COMM28: iaas-gpu-cn-beijing.cr.volces.com/serving/sglang:deepseek-v4-pr516-8e366b4d6.
- Container import verification passed: sgl-deep-gemm=0.1.0+dev.pr36, top_level=deep_gemm, and deep_gemm exposes fp8_mega_moe, fp8_fp4_mega_moe, mega_moe_pre_dispatch, transform_weights_for_mega_moe_sm90.
