### PR TITLE
fix: Add workflow call

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -6,6 +6,50 @@ on:
       - main
     paths:
       - sgl-kernel/python/sgl_kernel/version.py
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: "Git ref to build from"
+        required: true
+        type: string
+      python_version:
+        description: "Python version passed to sgl-kernel/build.sh"
+        required: false
+        type: string
+        default: "3.10"
+      cuda_version:
+        description: "CUDA version passed to sgl-kernel/build.sh"
+        required: true
+        type: string
+      arch:
+        description: "Optional architecture override passed to sgl-kernel/build.sh"
+        required: false
+        type: string
+        default: ""
+      artifact_name:
+        description: "Uploaded artifact name"
+        required: true
+        type: string
+      runner:
+        description: "Runner label for the wheel build"
+        required: false
+        type: string
+        default: "x64-kernel-build-node"
+      build_jobs:
+        description: "BUILD_JOBS passed to sgl-kernel/build.sh"
+        required: false
+        type: string
+        default: "64"
+      nvcc_threads:
+        description: "NVCC_THREADS passed to sgl-kernel/build.sh"
+        required: false
+        type: string
+        default: "8"
+      use_ccache:
+        description: "USE_CCACHE passed to sgl-kernel/build.sh"
+        required: false
+        type: string
+        default: "1"
   workflow_dispatch:
     inputs:
       target:
@@ -34,6 +78,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-wheel:
+    if: ${{ inputs.artifact_name != '' }}
+    runs-on: ${{ inputs.runner }}
+    steps:
+      # Self-hosted build nodes retain the workspace across jobs. Prior builds
+      # leave root-owned artifacts under sgl-kernel/build/ that actions/checkout
+      # cannot remove, causing EACCES on rmdir. Wipe them via a throwaway root
+      # container before checkout recreates the workspace.
+      - name: Clean workspace (remove root-owned files from prior runs)
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" alpine:3 \
+            sh -c 'rm -rf /workspace/..?* /workspace/.[!.]* /workspace/*' || true
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+          ref: ${{ inputs.checkout_ref || github.ref }}
+
+      - name: Set up Python ${{ inputs.python_version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Build wheels
+        run: |
+          cd sgl-kernel
+          chmod +x ./build.sh
+          if [ -n "${{ inputs.arch }}" ]; then
+            ./build.sh "${{ inputs.python_version }}" "${{ inputs.cuda_version }}" "${{ inputs.arch }}"
+          else
+            ./build.sh "${{ inputs.python_version }}" "${{ inputs.cuda_version }}"
+          fi
+        env:
+          BUILD_JOBS: ${{ inputs.build_jobs }}
+          NVCC_THREADS: ${{ inputs.nvcc_threads }}
+          USE_CCACHE: ${{ inputs.use_ccache }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: sgl-kernel/dist/*
+          if-no-files-found: error
+
   # cu130 is the PyPI-released variant; cu129 wheels are published only to the
   # sgl-project/whl index (consumed via `pip install ...+cu129` for the legacy
   # cuda 12.9 path), not to PyPI.


### PR DESCRIPTION
Add workflow call. Otherwise, using release-whl-kernel.yml for compiling sgl-kernel will fail.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->