### PR TITLE
Cherry-pick #26607 into bytedance/deepseek_v4

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -123,8 +123,10 @@ class PrefillBootstrapQueue:
         self.bootstrap_port = bootstrap_port
         self.queue: List[Req] = []
         self.gloo_group = gloo_group
-        self.max_total_num_tokens = max_total_num_tokens
         self.scheduler = scheduler
+        self.max_total_num_tokens = (
+            self.scheduler.tp_worker.model_runner.max_token_pool_size
+        )
         self.transfer_backend = transfer_backend
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get() and self.is_mla_backend:
             raise RuntimeError(
@@ -132,13 +134,6 @@ class PrefillBootstrapQueue:
                 "(e.g. GQA, MHA). MLA models should not set this flag."
             )
         self.kv_manager = self._init_kv_manager()
-
-        if self.scheduler.tp_worker.is_hybrid_swa:
-            # FIXME: current SWA allocation allocate full kv cache size in prefill
-            self.max_total_num_tokens = min(
-                self.max_total_num_tokens,
-                self.scheduler.tp_worker.model_runner.swa_max_total_num_tokens,
-            )
 
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)


### PR DESCRIPTION
Cherry-picks upstream sgl-project/sglang#26607 (commit 931765e23e9b7ca64f232c9941a122ef4895206a) onto bytedance/deepseek_v4.\n\nThis removes the DeepSeek V4 PD prefill cap by SWA pool size and uses model_runner.max_token_pool_size for prefill admission.\n\nLocal verification:\n- cherry-pick applied cleanly\n- inspected resulting diff: python/sglang/srt/disaggregation/prefill.py only

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->