### PR TITLE
eic: cherry-pick #440 + #462 onto latest ep_main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,10 @@ sgl-kernel/csrc/**/*_musa/
 *.npz
 artifacts/
 .claude/scheduled_tasks.lock
+# Generated protobuf files (regenerate during wheel build or with compile_proto.py)
+python/sglang/srt/grpc/*_pb2.py
+python/sglang/srt/grpc/*_pb2_grpc.py
+python/sglang/srt/grpc/*_pb2.pyi
+# docker
+docker/eic*
+docker/config

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -861,6 +861,28 @@ async def clear_hicache_storage_backend():
     )
 
 
+@app.api_route("/enable_eic", methods=["GET", "POST"])
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def enable_eic_cache():
+    ret = await _global_state.tokenizer_manager.enable_eic_cache()
+    return Response(
+        content="Enable eic cache.\nPlease check backend logs for more details. "
+        "(When there are running or waiting requests, the operation will not be performed.)\n",
+        status_code=200 if ret.success else HTTPStatus.BAD_REQUEST,
+    )
+
+
+@app.api_route("/disable_eic", methods=["GET", "POST"])
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def disable_eic_cache():
+    ret = await _global_state.tokenizer_manager.disable_eic_cache()
+    return Response(
+        content="disable eic cache.\nPlease check backend logs for more details. "
+        "(When there are running or waiting requests, the operation will not be performed.)\n",
+        status_code=200 if ret.success else HTTPStatus.BAD_REQUEST,
+    )
+
+
 # example usage:
 # curl -s -X PUT http://127.0.0.1:30000/hicache/storage-backend \
 #  -H 'Content-Type: application/json' \

--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -1,0 +1,534 @@
+import hashlib
+import logging
+import pickle
+import threading
+import time
+from queue import Empty, Queue
+from typing import Iterable, List, Optional
+
+import torch
+
+from sglang.srt.layers.moe.token_dispatcher.deepep import use_deepep
+from sglang.srt.managers.cache_controller import (
+    CacheOperation,
+    HiCacheController,
+    LayerDoneCounter,
+)
+from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.eic_memory_pool import EICBaseTokenToKVPoolHost
+from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def get_content_hash(
+    content: Iterable, page_size: int, prev_hash: Optional[int] = None
+) -> List[int]:
+    """
+    Get the hash of the content.
+    """
+
+    def hash_func(input):
+        input_bytes = pickle.dumps(input, protocol=pickle.HIGHEST_PROTOCOL)
+        return int.from_bytes(hashlib.sha256(input_bytes).digest(), byteorder="big")
+
+    if prev_hash is None:
+        prev_hash = 0
+    result = []
+    for i in range(len(content) // page_size):
+        page = content[i * page_size : (i + 1) * page_size]
+        page_hash = hash_func((prev_hash, page))
+        prev_hash = page_hash
+        result.append(page_hash)
+    return result
+
+
+class EICCacheOperation(CacheOperation):
+    def __init__(
+        self,
+        host_indices: torch.Tensor,
+        device_indices: torch.Tensor,
+        node_id: int,
+        content_hash: Optional[List[int]] = None,
+        priority: Optional[int] = None,
+    ):
+        self.content_hash = content_hash
+        self.node_id = node_id
+        super().__init__(
+            host_indices=host_indices,
+            device_indices=device_indices,
+            node_id=node_id,
+            priority=priority,
+        )
+
+
+class EICCacheController(HiCacheController):
+    def __init__(
+        self,
+        token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+        mem_pool_host: EICBaseTokenToKVPoolHost,
+        page_size: int,
+        tp_group: torch.distributed.ProcessGroup,
+        load_cache_event: threading.Event = None,
+        write_policy: str = "write_through",
+        server_args: Optional[ServerArgs] = None,
+    ):
+        self.mem_pool_device_allocator = token_to_kv_pool_allocator
+        self.mem_pool_device = token_to_kv_pool_allocator.get_kvcache()
+        self.mem_pool_host = mem_pool_host
+        self.write_policy = write_policy
+        self.page_size = page_size
+        self.load_cache_event = load_cache_event
+        self.layer_done_counter = LayerDoneCounter(self.mem_pool_device.layer_num)
+        self.server_args = server_args
+        self.disable_shared = server_args.disable_eic_shared
+
+        if write_policy not in [
+            "write_through",
+            "write_through_selective",
+            "write_back",
+        ]:
+            raise ValueError(f"Invalid write policy: {write_policy}")
+
+        self.write_queue = Queue()
+        self.load_queue = Queue()
+
+        self.ack_write_queue = Queue()
+        self.ack_load_queue = Queue()
+
+        self.stop_event = threading.Event()
+        self.write_wait_event = threading.Event()
+        self.load_wait_event = threading.Event()
+
+        self.write_stream = torch.cuda.Stream()
+        self.load_stream = torch.cuda.Stream()
+        self.device = token_to_kv_pool_allocator.device
+
+        # for TP synchronize
+        self.tp_world_size = torch.distributed.get_world_size(group=tp_group)
+        if self.tp_world_size > 1:
+            from sglang.srt.distributed.parallel_state import (
+                create_custom_parallel_group,
+            )
+
+            group_ranks = torch.distributed.get_process_group_ranks(tp_group)
+            self.write_tp_group = create_custom_parallel_group(
+                group_ranks=group_ranks, backend="gloo"
+            )
+            self.load_tp_group = create_custom_parallel_group(
+                group_ranks=group_ranks, backend="gloo"
+            )
+
+        # synchronize for write or load operation
+        self.scheduler_stream = torch.get_device_module(self.device).current_stream()
+        if self.device == "cpu":
+            self.scheduler_stream.synchronize = lambda: None
+        self.sync_before_write = self.need_sync_before_write()
+        if server_args.moe_a2a_backend == "deepep":
+            self.hook_model_forward()
+            self.hook_deepep_dispatch()
+
+        self.write_parallel = 1
+        self.load_parallel = 1
+
+        self.write_thread_pool = [
+            threading.Thread(target=self.write_thread_func_direct, daemon=True)
+            for _ in range(self.write_parallel)
+        ]
+        self.load_thread_pool = [
+            threading.Thread(target=self.load_thread_func_direct, daemon=True)
+            for _ in range(self.load_parallel)
+        ]
+
+        for th in self.write_thread_pool:
+            th.start()
+        for th in self.load_thread_pool:
+            th.start()
+
+    def reset(self):
+        self.stop_event.set()
+
+        for th in self.write_thread_pool:
+            th.join()
+        for th in self.load_thread_pool:
+            th.join()
+
+        self.write_queue.queue.clear()
+        self.load_queue.queue.clear()
+        self.ack_write_queue.queue.clear()
+        self.ack_load_queue.queue.clear()
+
+        self.write_thread_pool = [
+            threading.Thread(target=self.write_thread_func_direct, daemon=True)
+            for _ in range(self.write_parallel)
+        ]
+        self.load_thread_pool = [
+            threading.Thread(target=self.load_thread_func_direct, daemon=True)
+            for _ in range(self.load_parallel)
+        ]
+
+        self.stop_event.clear()
+        self.write_wait_event.clear()
+        self.load_wait_event.clear()
+
+        for th in self.write_thread_pool:
+            th.start()
+        for th in self.load_thread_pool:
+            th.start()
+
+    def hook_empty_cache(self):
+        """
+        Safely empty the CUDA stream.
+        """
+        original_empty_cache = torch.cuda.empty_cache
+
+        def safe_empty_cache():
+            self.write_wait_event.set()
+            write_stream = self.write_stream
+            write_event = torch.cuda.Event()
+            write_event.record(write_stream)
+            write_event.synchronize()
+            original_empty_cache()
+            self.write_wait_event.clear()
+
+        torch.cuda.empty_cache = safe_empty_cache
+
+    def hook_model_forward(self):
+        """
+        Hook the model forward to synchronize the write stream.
+        """
+        from sglang.srt.model_executor.model_runner import ModelRunner
+
+        original_forward = ModelRunner.forward
+
+        def synced_forward(*args, **kwargs):
+            self.write_wait_event.set()
+            self.write_stream.synchronize()
+            result = original_forward(*args, **kwargs)
+            self.write_wait_event.clear()
+            return result
+
+        ModelRunner.forward = synced_forward
+        logger.info("Hooked model forward with synchronized write stream.")
+
+    def hook_deepep_dispatch(self):
+        if not use_deepep:
+            return
+        from deep_ep import Buffer
+
+        original_dispatch = Buffer.internode_dispatch
+
+        def syned_dispatch(*args, **kwargs):
+            while self.load_wait_event.is_set():
+                time.sleep(0.1)
+            result = original_dispatch(*args, **kwargs)
+            return result
+
+        Buffer.internode_dispatch = syned_dispatch
+        logger.info("Hooked deepep dispatch with synchronized load.")
+
+    def need_sync_before_write(self):
+        return (
+            self.write_policy == "write_through"
+            and not self.server_args.disable_overlap_schedule
+        )
+
+    def write_operation_exclusive(self, operation: EICCacheOperation):
+        """
+        Write the KV cache to host memory.
+        """
+        ret = self.mem_pool_host.assign_flat_data(
+            operation.host_indices, operation.data, operation.device_indices
+        )
+        if not ret:
+            logger.error(f"Failed to write to host memory {operation.node_id}")
+        result = 0 if ret else 1
+        if self.tp_world_size > 1:
+            temp_tensor = torch.tensor(result, device="cpu", dtype=torch.int32)
+            torch.distributed.all_reduce(
+                temp_tensor,
+                op=torch.distributed.ReduceOp.SUM,
+                group=self.write_tp_group,
+            )
+            result = temp_tensor.item()
+        ret = result == 0
+        self.ack_write_queue.put((operation.node_id, ret))
+
+    def batch_torch_cat(self, data_list: List[torch.Tensor], split_dim: int):
+        """
+        Batch torch.cat to avoid OOM.
+        """
+        batch_size = 1024
+        if len(data_list) <= batch_size:
+            return torch.cat(data_list, dim=split_dim)
+        else:
+            result = torch.cat(data_list[:batch_size], dim=split_dim)
+            for i in range(batch_size, len(data_list), batch_size):
+                batch = data_list[i : i + batch_size]
+                result = torch.cat(
+                    [result, torch.cat(batch, dim=split_dim)], dim=split_dim
+                )
+            return result
+
+    def load_operation_exclusive(self, operation: EICCacheOperation):
+        """
+        Load the KV cache from host memory to device memory.
+        """
+        mask = self.mem_pool_host.get_flat_data(
+            operation.host_indices, operation.device_indices
+        )
+        completed_tokens = 0
+        if not all(mask):
+            logger.warning(f"Failed to load from eic, node: {operation.node_id}")
+            for ret in mask:
+                if ret:
+                    completed_tokens += 1
+                else:
+                    break
+        else:
+            completed_tokens = len(operation.host_indices)
+
+        if self.tp_world_size > 1:
+            temp_tensor = torch.tensor(
+                completed_tokens, device="cpu", dtype=torch.int32
+            )
+            torch.distributed.all_reduce(
+                temp_tensor,
+                op=torch.distributed.ReduceOp.MIN,
+                group=self.load_tp_group,
+            )
+            completed_tokens = temp_tensor.item()
+        if completed_tokens > 0:
+            logger.debug(f"completed tokens: {completed_tokens}")
+            # completed_device_indices = operation.device_indices[:completed_tokens]
+
+            # flat_data = self.batch_torch_cat(
+            #     operation.data[:completed_tokens],
+            #     split_dim=self.mem_pool_host.split_dim,
+            # )
+            # self.mem_pool_device.transfer(completed_device_indices, flat_data)
+        self.ack_load_queue.put((operation.node_id, completed_tokens))
+
+    def write_operation_shared(self, operation: EICCacheOperation):
+        """
+        Write the KV cache to host memory.
+        """
+        assert len(operation.host_indices) == self.page_size * len(
+            operation.content_hash
+        )
+        while self.write_wait_event.is_set():
+            time.sleep(0.01)
+        logger.debug(f"write device indices: {operation.device_indices}")
+        ret = self.mem_pool_host.assign_page_data(
+            operation.content_hash, operation.data, operation.device_indices
+        )
+        if not ret:
+            logger.error(f"Failed to write to host memory {operation.node_id}")
+        result = 0 if ret else 1
+        if self.tp_world_size > 1:
+            temp_tensor = torch.tensor(result, device="cpu", dtype=torch.int32)
+            torch.distributed.all_reduce(
+                temp_tensor,
+                op=torch.distributed.ReduceOp.SUM,
+                group=self.write_tp_group,
+            )
+            result = temp_tensor.item()
+        ret = result == 0
+        self.ack_write_queue.put((operation.node_id, ret))
+
+    def load_operation_shared(self, operation: EICCacheOperation):
+        """
+        Load the KV cache from host memory to device memory.
+        """
+        assert len(operation.host_indices) == self.page_size * len(
+            operation.content_hash
+        )
+        mask = self.mem_pool_host.get_page_data(
+            operation.content_hash, operation.device_indices
+        )
+        completed_tokens = 0
+        if not all(mask):
+            logger.debug(f"Failed to load from eic, node: {operation.node_id}")
+            for ret in mask:
+                if ret:
+                    completed_tokens += self.page_size
+                else:
+                    break
+        else:
+            completed_tokens = len(operation.host_indices)
+
+        if self.tp_world_size > 1:
+            temp_tensor = torch.tensor(
+                completed_tokens, device="cpu", dtype=torch.int32
+            )
+            torch.distributed.all_reduce(
+                temp_tensor,
+                op=torch.distributed.ReduceOp.MIN,
+                group=self.load_tp_group,
+            )
+            completed_tokens = temp_tensor.item()
+        if completed_tokens > 0:
+            logger.debug(f"completed tokens: {completed_tokens}")
+            # completed_device_indices = operation.device_indices[:completed_tokens]
+
+            # flat_data = self.batch_torch_cat(
+            #     operation.data[: completed_tokens // self.page_size],
+            #     split_dim=self.mem_pool_host.split_dim,
+            # )
+            # self.mem_pool_device.transfer(completed_device_indices, flat_data)
+        self.ack_load_queue.put((operation.node_id, completed_tokens))
+
+    def write_to_eic(self, operation: EICCacheOperation):
+        """
+        Write the KV cache to host memory.
+        """
+        if self.disable_shared:
+            self.write_operation_exclusive(operation)
+        else:
+            self.write_operation_shared(operation)
+
+    def load_from_eic(self, operation: EICCacheOperation):
+        """
+        Load the KV cache from host memory to device memory.
+        """
+        if self.disable_shared:
+            self.load_operation_exclusive(operation)
+        else:
+            self.load_operation_shared(operation)
+
+    def write_thread_func_direct(self):
+        """
+        Directly write through KV caches to host memory without buffering.
+        """
+        with torch.cuda.stream(self.write_stream):
+            while not self.stop_event.is_set():
+                logger.debug("write thread eventloop running")
+                try:
+                    operation = self.write_queue.get(block=True, timeout=1)
+                    if self.sync_before_write:
+                        self.scheduler_stream.synchronize()
+                    self.write_to_eic(operation)
+                except Empty:
+                    continue
+                except Exception as e:
+                    logger.exception("Exception in write thread: %s", e)
+                    from sglang.srt.utils import pyspy_dump_schedulers
+
+                    pyspy_dump_schedulers()
+
+    def load_thread_func_direct(self):
+        """
+        Directly load KV caches from host memory to device memory without buffering.
+        """
+        torch.cuda.current_stream().synchronize()
+        with torch.cuda.stream(self.load_stream):
+            while not self.stop_event.is_set():
+                logger.debug("load thread eventloop running")
+                # self.load_cache_event.wait(timeout=1)
+                # if not self.load_cache_event.is_set():
+                #     continue
+                # self.load_cache_event.clear()
+                try:
+                    operation = self.load_queue.get(block=True, timeout=1)
+                    self.load_wait_event.set()
+                    self.load_from_eic(operation)
+                    self.load_wait_event.clear()
+                except Empty:
+                    continue
+                except Exception as e:
+                    logger.exception("Exception in load thread: %s", e)
+                    from sglang.srt.utils import pyspy_dump_schedulers
+
+                    pyspy_dump_schedulers()
+
+    def host_allocate(self, size):
+        """
+        Allocate memory on the host.
+        """
+        return self.mem_pool_host.alloc(size)
+
+    def find_longest_prefix_in_eic(self, prompt, prev_hash=None):
+        """
+        Find the longest prefix in the EIC cache.
+        """
+        if len(prompt) == 0:
+            return [], []
+        content_hash = get_content_hash(prompt, self.page_size, prev_hash)
+        exist_result = self.mem_pool_host.exist_page(content_hash)
+        return exist_result, prompt[: len(exist_result) * self.page_size]
+
+    def batch_find_longest_prefix_in_eic(self, prompts, prev_hashes):
+        assert len(prompts) == len(
+            prev_hashes
+        ), "prompts and prev_hashes must have the same length"
+        prompt_key_offset = [
+            0,
+        ]
+        eic_prefix_len = []
+        content_hashes = []
+        for i in range(len(prompts)):
+            content_hash = get_content_hash(prompts[i], self.page_size, prev_hashes[i])
+            prompt_key_offset.append(len(content_hash) + prompt_key_offset[-1])
+            content_hashes.extend(content_hash)
+        if len(content_hashes) == 0:
+            return []
+        exist_result = self.mem_pool_host.batch_exist_page(content_hashes)
+        for i in range(len(prompts)):
+            count = 0
+            for res in exist_result[prompt_key_offset[i] : prompt_key_offset[i + 1]]:
+                if not res:
+                    break
+                count += 1
+            eic_prefix_len.append(count * self.page_size)
+
+        return eic_prefix_len
+
+    def write_page(
+        self,
+        device_indices: torch.Tensor,
+        priority: Optional[int] = None,
+        node_id: int = 0,
+        content_hash: List[int] = None,
+    ) -> Optional[torch.Tensor]:
+        """
+        Back up KV caches from device memory to host memory.
+        """
+        host_indices = device_indices.clone().cpu()
+        cache_operation = EICCacheOperation(
+            host_indices, device_indices, node_id, content_hash, priority
+        )
+        self.write_queue.put(cache_operation)
+        return host_indices
+
+    def load_page(
+        self,
+        host_indices: torch.Tensor,
+        priority: Optional[int] = None,
+        node_id: int = 0,
+        content_hash: List[int] = None,
+    ) -> Optional[torch.Tensor]:
+        """
+        Load KV caches from host memory to device memory.
+        """
+        device_indices = self.mem_pool_device_allocator.alloc(len(host_indices))
+        if device_indices is None:
+            return None
+        # to ensure the device indices are ready before accessed by another CUDA stream
+        torch.cuda.current_stream().synchronize()
+        self.load_queue.put(
+            EICCacheOperation(
+                host_indices, device_indices, node_id, content_hash, priority
+            )
+        )
+        return device_indices
+
+    def evict_device(
+        self, device_indices: torch.Tensor, host_indices: torch.Tensor
+    ) -> int:
+        if self.disable_shared and not self.mem_pool_host.is_synced(host_indices):
+            raise ValueError(
+                f"Inconsistent states: {self.mem_pool_host.get_state(host_indices)}"
+            )
+        self.mem_pool_device_allocator.free(device_indices)
+        self.mem_pool_host.update_backup(host_indices)
+        return len(device_indices)

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2106,6 +2106,16 @@ class LazyDumpTensorsReqInput(BaseReq):
 
 
 @dataclass
+class EnableEICReqInput(BaseReq):
+    pass
+
+
+@dataclass
+class DisableEICReqInput(BaseReq):
+    pass
+
+
+@dataclass
 class LazyDumpTensorsReqOutput(BaseReq):
     success: bool
 
@@ -2121,6 +2131,12 @@ class DumperControlReqOutput(BaseReq):
     success: bool
     response: List[Dict[str, Any]]
     error: str = ""
+
+
+@dataclass
+class EICSwitchOutput(BaseReq):
+    success: bool
+    message: str
 
 
 def _check_all_req_types():

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -24,8 +24,10 @@ logger = logging.getLogger(__name__)
 # ==============================================================================
 """Request scheduler policy"""
 
+import logging
 import os
 import random
+import time
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from enum import Enum, auto
@@ -53,6 +55,7 @@ from sglang.srt.server_args import ServerArgs
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+logger = logging.getLogger(__name__)
 
 # Clip the estimation of max_new_tokens for the request whose max_new_tokens is very large.
 # This can prevent the server from being too conservative.
@@ -422,6 +425,7 @@ class PrefillAdder:
         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor] = None,
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
+        enable_eic_cache: bool = False,
     ):
         self.page_size = page_size
         self.tree_cache = tree_cache
@@ -446,7 +450,10 @@ class PrefillAdder:
         self.new_chunked_req = None
         self.log_hit_tokens = 0
         # TODO(lsyin): report the real input tokens excluding page alignment
+        self.log_hit_gpu_tokens = 0
+        self.log_hit_eic_tokens = 0
         self.log_input_tokens = 0
+        self.enable_eic_cache = enable_eic_cache
 
         if running_batch is not None:
             # Estimate the offset in the remaining token space
@@ -582,7 +589,11 @@ class PrefillAdder:
         return AddReqResult.CONTINUE
 
     def _update_prefill_budget(
-        self, prefix_len: int, extend_input_len: int, max_new_tokens: int
+        self,
+        prefix_len: int,
+        extend_input_len: int,
+        max_new_tokens: int,
+        eic_prefix_len: int = 0,
     ):
         # TODO(lsyin): check this workaround logic, which only ensures the prefill will not out of memory, and may be too conservative
         extend_input_len = self.ceil_paged_tokens(extend_input_len)
@@ -602,6 +613,8 @@ class PrefillAdder:
             self.rem_chunk_tokens -= extend_input_len
 
         self.log_hit_tokens += prefix_len
+        self.log_hit_gpu_tokens += prefix_len - eic_prefix_len
+        self.log_hit_eic_tokens += eic_prefix_len
         self.log_input_tokens += extend_input_len
 
     def _get_dllm_remain_tokens(self) -> int:
@@ -876,6 +889,7 @@ class PrefillAdder:
                 if swa_needed >= self.rem_swa_tokens:
                     return AddReqResult.NO_TOKEN
 
+            eic_prefix_len = 0
             if req.host_hit_length > 0:
                 new_indices, req.last_node = self.tree_cache.init_load_back(
                     InitLoadBackParams(
@@ -884,10 +898,46 @@ class PrefillAdder:
                         req=req,
                     )
                 )
+                logger.debug(
+                    f"req {req.rid} init load back, last node:{req.last_node.id}, prefix len:{len(req.prefix_indices)}"
+                )
+                if self.enable_eic_cache:
+                    loading_check_start_ts = time.perf_counter()
+                    while not self.tree_cache.loading_complete(req.last_node):
+                        time.sleep(0.01)
+                    load_sucess = req.last_node.value is not None
+                    complete_token_num = len(new_indices)
+                    if not load_sucess:
+                        last_gpu_node = req.last_node
+                        while last_gpu_node.evicted:
+                            complete_token_num -= len(last_gpu_node.key)
+                            last_gpu_node = last_gpu_node.parent
+                        assert complete_token_num >= 0
+                        req.last_node = last_gpu_node
+                        logger.error(
+                            f"req {req.rid} after load back failed, last node:{last_gpu_node.id}, complete_token_num:{complete_token_num}"
+                        )
+                        if complete_token_num > 0:
+                            new_indices = new_indices[:complete_token_num]
+                        else:
+                            new_indices = torch.empty(
+                                (0,),
+                                dtype=torch.int64,
+                                device=req.prefix_indices.device,
+                            )
+                    loading_check_end_ts = time.perf_counter()
+                    logger.debug(
+                        f"batch_prefill loading check time {loading_check_end_ts - loading_check_start_ts}"
+                    )
+                logger.debug(
+                    f"after eic sync, req {req.rid} last node:{req.last_node.id}, prefix len:{len(req.prefix_indices)}"
+                )
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
+                req.last_matched_prefix_len = prefix_len
+                eic_prefix_len = len(new_indices)
 
             input_tokens = self.ceil_paged_tokens(req.extend_input_len)
 
@@ -916,6 +966,7 @@ class PrefillAdder:
                         req.sampling_params.max_new_tokens,
                         CLIP_MAX_NEW_TOKENS,
                     ),
+                    eic_prefix_len,
                 )
             else:
                 # Make sure at least one page is available

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -100,8 +100,11 @@ from sglang.srt.managers.io_struct import (
     DestroyWeightsUpdateGroupReqInput,
     DetachHiCacheStorageReqInput,
     DetachHiCacheStorageReqOutput,
+    DisableEICReqInput,
     DumperControlReqInput,
     DumperControlReqOutput,
+    EICSwitchOutput,
+    EnableEICReqInput,
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
@@ -187,6 +190,11 @@ from sglang.srt.managers.scheduler_update_weights_mixin import (
 from sglang.srt.managers.utils import GenerationBatchResult, validate_input_length
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.common import maybe_cache_unfinished_req, release_kv_cache
+from sglang.srt.mem_cache.eic_hiradix_cache import (
+    EICHiRadixCache,
+    EICHiRadixCacheBuilder,
+    EICPagedHiRadixCache,
+)
 from sglang.srt.mem_cache.radix_cache import RadixCache
 from sglang.srt.model_executor.forward_batch_info import ForwardMode, PPProxyTensors
 from sglang.srt.model_loader.utils import get_resolved_model_impl
@@ -396,6 +404,9 @@ class Scheduler(
         self.max_recv_per_poll = envs.SGLANG_SCHEDULER_MAX_RECV_PER_POLL.get()
         self.enable_hisparse = server_args.enable_hisparse
         self.hisparse_coordinator: Optional[HiSparseCoordinator] = None
+        self.enable_eic_cache = (
+            server_args.enable_eic_cache if self.enable_hierarchical_cache else False
+        )
 
         # Distributed rank info
         self.attn_tp_rank, self.attn_tp_size, self.attn_dp_rank = (
@@ -880,7 +891,22 @@ class Scheduler(
         )
 
         if effective_chunked_prefill_size is not None and self.disable_radix_cache:
-            if not self.is_hybrid_swa:
+            if self.enable_eic_cache:
+                from sglang.srt.mem_cache.eic_chunk_cache import (
+                    EICChunkCache,
+                    EICSWAChunkCache,
+                )
+
+                logger.info("use EICChunkCache for decode save")
+                if self.is_hybrid_swa:
+                    ChunkCacheClass = EICSWAChunkCache
+                else:
+                    ChunkCacheClass = EICChunkCache
+                self.tree_cache = ChunkCacheClass(
+                    params=params,
+                    server_args=server_args,
+                )
+            elif not self.is_hybrid_swa:
                 from sglang.srt.mem_cache.chunk_cache import ChunkCache
 
                 self.tree_cache = ChunkCache(params)
@@ -896,25 +922,36 @@ class Scheduler(
                 logger.info("Using experimental C++ radix tree implementation.")
                 self.tree_cache = RadixCacheCpp(params=params, server_args=server_args)
             elif envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.get():
-                from sglang.srt.mem_cache.unified_cache_components import (
-                    ComponentType,
-                )
-                from sglang.srt.mem_cache.unified_radix_cache import (
-                    UnifiedRadixCache,
-                )
-
-                tree_components = [ComponentType.FULL]
-                if self.is_hybrid_swa or self.is_hybrid_ssm:
-                    tree_components.append(
-                        ComponentType.SWA if self.is_hybrid_swa else ComponentType.MAMBA
+                if self.enable_eic_cache:
+                    self.tree_cache = EICHiRadixCacheBuilder.build(
+                        params=params,
+                        server_args=server_args,
                     )
-                params.tree_components = tuple(tree_components)
-                self.tree_cache = UnifiedRadixCache(params)
-                if self.enable_hierarchical_cache:
-                    self.tree_cache.init_hicache(server_args, params)
                     self.tp_worker.register_hicache_layer_transfer_counter(
                         self.tree_cache.cache_controller.layer_done_counter
                     )
+                else:
+                    from sglang.srt.mem_cache.unified_cache_components import (
+                        ComponentType,
+                    )
+                    from sglang.srt.mem_cache.unified_radix_cache import (
+                        UnifiedRadixCache,
+                    )
+
+                    tree_components = [ComponentType.FULL]
+                    if self.is_hybrid_swa or self.is_hybrid_ssm:
+                        tree_components.append(
+                            ComponentType.SWA
+                            if self.is_hybrid_swa
+                            else ComponentType.MAMBA
+                        )
+                    params.tree_components = tuple(tree_components)
+                    self.tree_cache = UnifiedRadixCache(params)
+                    if self.enable_hierarchical_cache:
+                        self.tree_cache.init_hicache(server_args, params)
+                        self.tp_worker.register_hicache_layer_transfer_counter(
+                            self.tree_cache.cache_controller.layer_done_counter
+                        )
             elif self.enable_hierarchical_cache:
                 if self.is_hybrid_ssm:
                     from sglang.srt.mem_cache.hi_mamba_radix_cache import (
@@ -923,6 +960,15 @@ class Scheduler(
 
                     self.tree_cache = HiMambaRadixCache(
                         params=params, server_args=server_args
+                    )
+                elif self.enable_eic_cache:
+                    # EIC has native hierarchical integration; route through its
+                    # builder so prefetch results land in the radix tree (otherwise
+                    # HiRadix + EICStorage fetches from remote but never registers
+                    # the prefix as a hit).
+                    self.tree_cache = EICHiRadixCacheBuilder.build(
+                        params=params,
+                        server_args=server_args,
                     )
                 else:
                     from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
@@ -1482,6 +1528,8 @@ class Scheduler(
                     ListExternalCorporaReqInput,
                     self.list_external_corpora,
                 ),
+                (EnableEICReqInput, self.enable_eic_cache_wrapped),
+                (DisableEICReqInput, self.disable_eic_cache_wrapped),
             ]
         )
 
@@ -2696,6 +2744,7 @@ class Scheduler(
             prefill_delayer_single_pass=prefill_delayer_single_pass,
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),
+            enable_eic_cache=self.enable_eic_cache,
         )
 
         if self.chunked_req is not None:
@@ -2715,6 +2764,10 @@ class Scheduler(
                     self.waiting_queue,
                     self.running_batch.reqs,
                 )
+
+        if isinstance(self.tree_cache, EICPagedHiRadixCache):
+            # for batch exists from EIC cache
+            self.tree_cache.match_from_remote(self.waiting_queue)
 
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
@@ -3757,6 +3810,74 @@ class Scheduler(
         """Send the seed instance weights to the destination instance."""
         success, message = self.tp_worker.send_weights_to_remote_instance(recv_req)
         return SendWeightsToRemoteInstanceReqOutput(success, message)
+
+    def enable_eic_cache_wrapped(self, recv_req: EnableEICReqInput) -> EICSwitchOutput:
+        if not isinstance(self.tree_cache, EICHiRadixCache):
+            success = self.flush_cache()
+            if not success:
+                # If there are pending requests, we cannot enable EIC cache.
+                return EICSwitchOutput(
+                    success=False,
+                    message="Cannot enable EIC cache while there are pending requests. Please flush the cache first.'",
+                )
+
+            self.enable_eic_cache = True
+            self.enable_hierarchical_cache = True
+            self.server_args.enable_hierarchical_cache = True
+            self.server_args.enable_eic_cache = True
+            self.init_cache_with_memory_pool()
+
+            self.policy = SchedulePolicy(
+                self.schedule_policy,
+                self.tree_cache,
+                self.enable_hierarchical_cache,
+                self.enable_priority_scheduling,
+                self.schedule_low_priority_values_first,
+            )
+            message = "EIC cache enabled successfully."
+        else:
+            message = "EIC cache is already enabled."
+
+        logger.info(message)
+        return EICSwitchOutput(
+            success=True,
+            message=message,
+        )
+
+    def disable_eic_cache_wrapped(
+        self, recv_req: DisableEICReqInput
+    ) -> EICSwitchOutput:
+        if isinstance(self.tree_cache, EICHiRadixCache):
+            success = self.flush_cache()
+            if not success:
+                # If there are pending requests, we cannot disable EIC cache.
+                return EICSwitchOutput(
+                    success=False,
+                    message="Cannot disable EIC cache while there are pending requests. Please flush the cache first.'",
+                )
+
+            self.enable_eic_cache = False
+            self.enable_hierarchical_cache = False
+            self.server_args.enable_hierarchical_cache = False
+            self.server_args.enable_eic_cache = False
+            self.init_cache_with_memory_pool()
+
+            self.policy = SchedulePolicy(
+                self.schedule_policy,
+                self.tree_cache,
+                self.enable_hierarchical_cache,
+                self.enable_priority_scheduling,
+                self.schedule_low_priority_values_first,
+            )
+            message = "EIC cache disabled successfully."
+        else:
+            message = "EIC cache is already enabled."
+
+        logger.info(message)
+        return EICSwitchOutput(
+            success=True,
+            message=message,
+        )
 
     def slow_down(self, recv_req: SlowDownReqInput):
         t = recv_req.forward_sleep_time

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -32,6 +32,7 @@ from sglang.srt.managers.io_struct import (
     DetachHiCacheStorageReqOutput,
     DumperControlReqInput,
     DumperControlReqOutput,
+    EICSwitchOutput,
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
     ExpertDistributionReqType,
@@ -121,6 +122,11 @@ _COMMUNICATOR_SPECS = [
     ("update_lora_adapter", LoRAUpdateOutput),
     ("get_loads", GetLoadsReqOutput, "watching"),
     ("dumper_control", DumperControlReqOutput),
+    # EIC toggle (PR #440 originally wired this in the old hand-built dispatcher
+    # but registered the *input* types instead of the response, so the await
+    # never unblocked. Declaring the response here in the spec restores the
+    # correct mapping: EICSwitchOutput -> eic_switch_communicator.handle_recv.
+    ("eic_switch", EICSwitchOutput),
 ]
 
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -58,7 +58,10 @@ from sglang.srt.managers.io_struct import (
     BatchTokenizedGenerateReqInput,
     ConfigureLoggingReq,
     ContinueGenerationReqInput,
+    DisableEICReqInput,
+    EICSwitchOutput,
     EmbeddingReqInput,
+    EnableEICReqInput,
     FreezeGCReq,
     GenerateReqInput,
     HealthCheckOutput,
@@ -1656,6 +1659,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 self._result_dispatcher(recv_obj)
             self.last_receive_tstamp = real_time()
             self.soft_watchdog.feed()
+
+    async def enable_eic_cache(self) -> EICSwitchOutput:
+        return (await self.eic_switch_communicator(EnableEICReqInput()))[0]
+
+    async def disable_eic_cache(self) -> EICSwitchOutput:
+        return (await self.eic_switch_communicator(DisableEICReqInput()))[0]
 
     async def _handle_batch_output(
         self,

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -563,7 +563,17 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
     return out_cache_loc
 
 
-def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = True):
+def release_kv_cache(
+    req: Req,
+    tree_cache: BasePrefixCache,
+    is_insert: bool = True,
+    is_decode: bool = False,
+):
+    from sglang.srt.mem_cache.eic_hiradix_cache import EICHiRadixCache
+
+    if isinstance(tree_cache, EICHiRadixCache) and is_decode:
+        is_insert = is_insert and tree_cache.save_decode_cache
+
     # MambaRadixCache may alloc mamba state before alloc KV cache
     if req.req_pool_idx is None:
         assert (

--- a/python/sglang/srt/mem_cache/eic_chunk_cache.py
+++ b/python/sglang/srt/mem_cache/eic_chunk_cache.py
@@ -1,0 +1,237 @@
+import logging
+import threading
+import time
+from functools import partial
+
+import torch
+
+from sglang.srt.managers.eic_cache_controller import (
+    EICCacheController,
+    get_content_hash,
+)
+from sglang.srt.managers.schedule_batch import FINISH_ABORT, Req
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.chunk_cache import ChunkCache
+from sglang.srt.mem_cache.eic_memory_pool import (
+    EICMHATokenToKVPoolHost,
+    EICMLATokenToKVPoolHost,
+)
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, MLATokenToKVPool
+from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
+from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def mha_pool_get_flat_data(self: MHATokenToKVPool, indices: torch.Tensor):
+    flatten = torch.stack(
+        [
+            torch.stack([self.k_buffer[i][indices] for i in range(self.layer_num)]),
+            torch.stack([self.v_buffer[i][indices] for i in range(self.layer_num)]),
+        ]
+    )
+    return flatten
+
+
+def mha_pool_transfer(
+    self: MHATokenToKVPool, indices: torch.Tensor, flat_data: torch.Tensor
+):
+    flat_data = flat_data.to(device=self.device, non_blocking=False)
+    k_data, v_data = flat_data[0], flat_data[1]
+    for i in range(self.layer_num):
+        self.k_buffer[i][indices] = k_data[i]
+        self.v_buffer[i][indices] = v_data[i]
+
+
+def mla_pool_get_flat_data(self: MLATokenToKVPool, indices: torch.Tensor):
+    return torch.stack([self.kv_buffer[i][indices] for i in range(self.layer_num)])
+
+
+def mla_pool_transfer(
+    self: MLATokenToKVPool, indices: torch.Tensor, flat_data: torch.Tensor
+):
+    flat_data = flat_data.to(device=self.device, non_blocking=False)
+    for i in range(self.layer_num):
+        self.kv_buffer[i][indices] = flat_data[i]
+
+
+class EICChunkCache(ChunkCache):
+    def __init__(
+        self,
+        params: CacheInitParams,
+        server_args: ServerArgs,
+    ):
+        super().__init__(params)
+        self.tp_group = params.tp_cache_group
+        self.tp_size = self.tp_group.size()
+        self.rank = self.tp_group.rank()
+        self.kv_cache = params.token_to_kv_pool_allocator.get_kvcache()
+        self.page_size = params.page_size
+        if isinstance(self.kv_cache, MHATokenToKVPool):
+            self.token_to_kv_pool_host = EICMHATokenToKVPoolHost(
+                self.kv_cache,
+                4.0,
+                0,
+                "cpu",
+                self.page_size,
+                self.rank,
+                extra_info=self.get_extra_info(server_args),
+            )
+            self.kv_cache.get_flat_data = partial(mha_pool_get_flat_data, self.kv_cache)
+            self.kv_cache.transfer = partial(mha_pool_transfer, self.kv_cache)
+        elif isinstance(self.kv_cache, MLATokenToKVPool):
+            self.token_to_kv_pool_host = EICMLATokenToKVPoolHost(
+                self.kv_cache,
+                4.0,
+                0,
+                "cpu",
+                self.page_size,
+                self.rank,
+                extra_info=self.get_extra_info(server_args),
+            )
+            self.kv_cache.get_flat_data = partial(mla_pool_get_flat_data, self.kv_cache)
+            self.kv_cache.transfer = partial(mla_pool_transfer, self.kv_cache)
+        else:
+            raise ValueError("EICChunkCache only supports MHA and MLA yet")
+
+        self.load_cache_event = threading.Event()
+        self.cache_controller = EICCacheController(
+            params.token_to_kv_pool_allocator,
+            self.token_to_kv_pool_host,
+            self.page_size,
+            load_cache_event=self.load_cache_event,
+            write_policy="write_through",
+            server_args=server_args,
+        )
+        self.ongoing_writing_queue = dict()
+        self.background_thread = threading.Thread(
+            target=self.background_thread, daemon=True
+        )
+        self.background_thread.start()
+        self._evictable_size = 0
+        self.save_docode_cache = True
+
+    def get_extra_info(self, server_args: ServerArgs):
+        extra_info = {
+            "model_path": server_args.model_path,
+            "world_size": self.tp_size,
+            "tp_rank": self.rank,
+            "framework": "sglang",
+        }
+        return extra_info
+
+    def write_backup(self, req: Req, save_decode_cache: bool = True):
+        kv_indices = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx,
+            : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
+        ]
+        if (
+            len(self.ongoing_writing_queue) >= 20
+            or len(kv_indices) < self.page_size
+            or not save_decode_cache
+            or isinstance(req.finished_reason, FINISH_ABORT)
+        ):
+            self.token_to_kv_pool_allocator.free(kv_indices)
+            return
+        page_aligned_len = len(kv_indices) // self.page_size * self.page_size
+        logger.debug(f"page aligned length: {page_aligned_len}")
+        paged_kv_indices = kv_indices[:page_aligned_len]
+        token_ids = (req.origin_input_ids + req.output_ids)[:page_aligned_len]
+        content_hash = get_content_hash(token_ids, self.page_size)
+        # filter decode
+        decode_hash_offset = len(req.origin_input_ids) // self.page_size
+        decode_content_hash = content_hash[decode_hash_offset:]
+        decode_paged_len = decode_hash_offset * self.page_size
+        if decode_paged_len < self.page_size:
+            self.token_to_kv_pool_allocator.free(kv_indices)
+            return
+        decode_device_indices = paged_kv_indices[decode_paged_len:]
+        logger.debug(f"write decode cache len: {len(decode_device_indices)}")
+        host_indices = self.cache_controller.write_page(
+            device_indices=decode_device_indices,
+            priority=None,
+            node_id=req.rid,
+            content_hash=decode_content_hash,
+            data_copy=True,
+        )
+        if host_indices is not None:
+            self.token_to_kv_pool_allocator.free(kv_indices)
+            self.ongoing_writing_queue[req.rid] = decode_device_indices.clone()
+            logger.debug(
+                f"cache request {req.rid} started, kvcache indices: {len(decode_device_indices)}"
+            )
+        else:
+            self.token_to_kv_pool_allocator.free(kv_indices)
+
+    def cache_finished_req(
+        self, req: Req, is_insert: bool = True, is_decode: bool = False
+    ):
+        save_cache = is_insert and is_decode and self.save_docode_cache
+        self.write_backup(req, save_decode_cache=save_cache)
+        self.req_to_token_pool.free(req.req_pool_idx)
+
+    def writing_check(self):
+        while not self.cache_controller.ack_write_queue.empty():
+            try:
+                rid, success = self.cache_controller.ack_write_queue.get_nowait()
+                kv_indices = self.ongoing_writing_queue.get(rid)
+                while not self.token_to_kv_pool_allocator.is_not_in_free_group:
+                    time.sleep(0.1)
+                logger.debug(
+                    f"cache request {rid} complete, kvcache indices: {len(kv_indices)} "
+                )
+                del self.ongoing_writing_queue[rid]
+            except Exception as e:
+                logger.error(f"Error in writing check: {e}")
+                continue
+
+    def background_thread(self):
+        while True:
+            time.sleep(0.1)
+            self.writing_check()
+
+    def evictable_size(self):
+        return self._evictable_size
+
+    def reset(self):
+        logger.info("Reset EICChunkCache")
+        while len(self.ongoing_writing_queue) > 0:
+            time.sleep(0.1)
+        self.cache_controller.reset()
+        self.token_to_kv_pool_host.clear()
+        self.ongoing_writing_queue = dict()
+        self._evictable_size = 0
+
+
+class EICSWAChunkCache(EICChunkCache):
+    """ChunkCache with support for hybrid KV cache operations."""
+
+    def __init__(
+        self,
+        params: CacheInitParams,
+        server_args: ServerArgs,
+    ):
+        assert isinstance(params.token_to_kv_pool_allocator, SWATokenToKVPoolAllocator)
+        super().__init__(
+            params,
+            server_args,
+        )
+
+    def evict_swa(
+        self,
+        req: Req,
+        prelen: int,
+        attention_chunk_size: int,
+    ):
+        if prelen >= req.evicted_seqlen_local + attention_chunk_size:
+            new_evicted_seqlen_local = attention_chunk_size * (
+                prelen // attention_chunk_size
+            )
+            free_slots = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, req.evicted_seqlen_local : new_evicted_seqlen_local
+            ]
+            self.token_to_kv_pool_allocator.free_swa(free_slots)
+            req.evicted_seqlen_local = new_evicted_seqlen_local
+
+    def evict(self, num_tokens: int):
+        pass

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1,0 +1,1252 @@
+import heapq
+import logging
+import os
+import threading
+import time
+from functools import partial
+from typing import List, Optional
+
+import torch
+import yaml
+
+from sglang.srt.managers.eic_cache_controller import (
+    EICCacheController,
+    get_content_hash,
+)
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    EvictResult,
+    InitLoadBackParams,
+    MatchPrefixParams,
+    MatchResult,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.eic_memory_pool import (
+    EICMHATokenToKVPoolHost,
+    EICMLATokenToKVPoolHost,
+    EICNSATokenToKVPoolHost,
+    MemoryStateInt,
+    get_eic_config_file_path,
+)
+from sglang.srt.mem_cache.memory_pool import (
+    MHATokenToKVPool,
+    MLATokenToKVPool,
+    NSATokenToKVPool,
+)
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
+from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+class EICHiRadixCacheBuilder:
+    @staticmethod
+    def build(
+        params: CacheInitParams,
+        server_args: ServerArgs,
+    ):
+        if server_args.disable_eic_shared:
+            return EICHiRadixCache(
+                params,
+                server_args,
+            )
+        else:
+            return EICPagedHiRadixCache(
+                params,
+                server_args,
+            )
+
+
+def mha_pool_get_flat_data(self: MHATokenToKVPool, indices: torch.Tensor):
+    flatten = torch.stack(
+        [
+            torch.stack([self.k_buffer[i][indices] for i in range(self.layer_num)]),
+            torch.stack([self.v_buffer[i][indices] for i in range(self.layer_num)]),
+        ]
+    )
+    return flatten
+
+
+def mha_pool_transfer(
+    self: MHATokenToKVPool, indices: torch.Tensor, flat_data: torch.Tensor
+):
+    flat_data = flat_data.to(device=self.device, non_blocking=False)
+    k_data, v_data = flat_data[0], flat_data[1]
+    for i in range(self.layer_num):
+        self.k_buffer[i][indices] = k_data[i]
+        self.v_buffer[i][indices] = v_data[i]
+
+
+def mla_pool_get_flat_data(self: MLATokenToKVPool, indices: torch.Tensor):
+    return torch.stack([self.kv_buffer[i][indices] for i in range(self.layer_num)])
+
+
+def mla_pool_transfer(
+    self: MLATokenToKVPool, indices: torch.Tensor, flat_data: torch.Tensor
+):
+    flat_data = flat_data.to(device=self.device, non_blocking=False)
+    for i in range(self.layer_num):
+        self.kv_buffer[i][indices] = flat_data[i]
+
+
+def nsa_pool_get_flat_data(self: NSATokenToKVPool, indices: torch.Tensor):
+    num_pages = len(indices) // self.page_size
+
+    # Gather MLA (num_tokens, 1, kv_cache_dim) -> (layer_num, num_tokens, kv_cache_dim)
+    mla_data = torch.stack([self.kv_buffer[i][indices] for i in range(self.layer_num)])
+    # (layer_num, num_pages, mla_page_bytes)
+    mla_bytes = mla_data.view(self.layer_num, num_pages, -1).view(torch.uint8)
+
+    # Gather NSA
+    page_indices = indices.reshape(-1, self.page_size)[:, 0] // self.page_size
+    # (layer_num, num_pages, 8448)
+    nsa_packed = torch.stack(
+        [self.index_k_with_scale_buffer[i][page_indices] for i in range(self.layer_num)]
+    )
+
+    combined = torch.cat(
+        [mla_bytes, nsa_packed], dim=-1
+    )  # (layer_num, num_pages, final_dim)
+    return combined
+
+
+def nsa_pool_transfer(
+    self: NSATokenToKVPool,
+    indices: torch.Tensor,
+    flat_data: torch.Tensor,
+):
+    flat_data = flat_data.to(device=self.device, non_blocking=False)
+    # flat_data: (layer_num, num_pages, final_dim)
+    num_pages = len(indices) // self.page_size
+    mla_page_bytes = self.kv_cache_dim * self.store_dtype.itemsize * self.page_size
+    page_indices = indices.reshape(-1, self.page_size)[:, 0] // self.page_size
+
+    for i in range(self.layer_num):
+        layer_data = flat_data[i]  # (num_pages, final_dim)
+
+        # Split
+        mla_bytes = layer_data[:, :mla_page_bytes]
+        nsa_bytes = layer_data[:, mla_page_bytes:]
+
+        # Write MLA
+        mla_part = (
+            mla_bytes.reshape(-1)
+            .view(self.store_dtype)
+            .reshape(num_pages * self.page_size, 1, self.kv_cache_dim)
+        )
+        self.kv_buffer[i][indices] = mla_part
+
+        # Write NSA
+        self.index_k_with_scale_buffer[i][page_indices] = nsa_bytes
+
+
+class EICHiRadixCache(RadixCache):
+
+    def __init__(
+        self,
+        params: CacheInitParams,
+        server_args: ServerArgs,
+    ):
+        self.tp_group = params.tp_cache_group
+        self.tp_size = self.tp_group.size()
+        self.rank = self.tp_group.rank()
+        self.kv_cache = params.token_to_kv_pool_allocator.get_kvcache()
+        if isinstance(self.kv_cache, MHATokenToKVPool):
+            self.token_to_kv_pool_host = EICMHATokenToKVPoolHost(
+                self.kv_cache,
+                server_args.hicache_ratio,
+                server_args.hicache_size,
+                "cpu",
+                params.page_size,
+                self.rank,
+                extra_info=self.get_extra_info(params, server_args),
+            )
+            self.kv_cache.get_flat_data = partial(mha_pool_get_flat_data, self.kv_cache)
+            self.kv_cache.transfer = partial(mha_pool_transfer, self.kv_cache)
+        elif isinstance(self.kv_cache, NSATokenToKVPool):
+            self.token_to_kv_pool_host = EICNSATokenToKVPoolHost(
+                self.kv_cache,
+                server_args.hicache_ratio,
+                server_args.hicache_size,
+                "cpu",
+                params.page_size,
+                self.rank,
+                extra_info=self.get_extra_info(params, server_args),
+            )
+            self.kv_cache.get_flat_data = partial(nsa_pool_get_flat_data, self.kv_cache)
+            self.kv_cache.transfer = partial(nsa_pool_transfer, self.kv_cache)
+        elif isinstance(self.kv_cache, MLATokenToKVPool):
+            self.token_to_kv_pool_host = EICMLATokenToKVPoolHost(
+                self.kv_cache,
+                server_args.hicache_ratio,
+                server_args.hicache_size,
+                "cpu",
+                params.page_size,
+                self.rank,
+                extra_info=self.get_extra_info(params, server_args),
+            )
+            self.kv_cache.get_flat_data = partial(mla_pool_get_flat_data, self.kv_cache)
+            self.kv_cache.transfer = partial(mla_pool_transfer, self.kv_cache)
+        else:
+            raise ValueError("HiRadixCache only supports MHA, MLA and NSA yet")
+
+        self.load_cache_event = threading.Event()
+        self.cache_controller = EICCacheController(
+            params.token_to_kv_pool_allocator,
+            self.token_to_kv_pool_host,
+            params.page_size,
+            tp_group=params.tp_cache_group,
+            load_cache_event=self.load_cache_event,
+            write_policy=server_args.hicache_write_policy,
+            server_args=server_args,
+        )
+
+        # record the nodes with ongoing write through
+        self.ongoing_write_through = {}
+        # record the node segments with ongoing load back
+        self.ongoing_load_back = {}
+        # EIC is native to this cache (no pluggable L3 HiCacheStorage backend);
+        # is_fully_idle() uses this flag to skip ongoing_prefetch/backup checks.
+        self.enable_storage = False
+        # todo: dynamically adjust the threshold
+        self.write_through_threshold = (
+            1 if server_args.hicache_write_policy == "write_through" else 3
+        )
+        self.load_back_threshold = 10
+        super().__init__(params)
+
+        self.save_decode_cache = True
+        config_file = get_eic_config_file_path()
+        if os.path.exists(config_file):
+            with open(config_file, "r") as fin:
+                config = yaml.safe_load(fin)
+            self.init_hyper_params(config)
+
+    def get_extra_info(self, params: CacheInitParams, server_args: ServerArgs):
+        # TODO update when sglang support pp
+        extra_info = {
+            "model_path": server_args.model_path,
+            "world_size": self.tp_size,
+            "tp_rank": self.rank,
+            "framework": "sglang",
+            "pp_rank": params.pp_rank,
+            "pp_size": params.pp_size,
+        }
+        return extra_info
+
+    def init_hyper_params(self, config: dict):
+        self.save_decode_cache = config.get("save_decode_cache", True)
+        logger.info(
+            f"EICHiRadixCache save_decode_cache set to {self.save_decode_cache}"
+        )
+        self.load_back_threshold = config.get("load_back_threshold", 10)
+        logger.info(
+            f"EICHiRadixCache load_back_threshold set to {self.load_back_threshold}"
+        )
+
+    def reset(self):
+        TreeNode.counter = 0
+        self.cache_controller.reset()
+        self.token_to_kv_pool_host.clear()
+        self.ongoing_load_back = {}
+        self.ongoing_write_through = {}
+        super().reset()
+
+    def get_height(self, node: TreeNode):
+        height = 0
+        while node != self.root_node:
+            node = node.parent
+            height += 1
+        return height
+
+    def write_backup(self, node: TreeNode, write_back=False):
+        logger.debug(f"write backup for node {node.id}")
+        if node.evicted:
+            return 0
+        host_indices = self.cache_controller.write(
+            device_indices=node.value,
+            priority=-self.get_height(node),
+            node_id=node.id,
+        )
+        if host_indices is None:
+            self.evict_host(len(node.value))
+            host_indices = self.cache_controller.write(
+                device_indices=node.value,
+                priority=-self.get_height(node),
+                node_id=node.id,
+            )
+        if host_indices is not None:
+            node.host_value = host_indices
+            self.ongoing_write_through[node.id] = node
+            if not write_back:
+                self.inc_lock_ref(node)
+        else:
+            return 0
+
+        return len(host_indices)
+
+    def inc_hit_count(self, node: TreeNode, chunked: bool = False):
+        if self.cache_controller.write_policy == "write_back" or chunked:
+            return
+        node.hit_count += 1
+        if not node.backuped:
+            if node.hit_count >= self.write_through_threshold:
+                self.write_backup(node)
+                node.hit_count = 0
+
+    def get_tp_result(self, flag):
+        if isinstance(flag, bool):
+            flag = [flag]
+        if self.tp_size <= 1:
+            return flag
+        # synchronize the result across TP workers
+        temp = [0 if x else 1 for x in flag]
+        temp_tensor = torch.tensor(temp, dtype=torch.int64, device="cpu")
+        torch.distributed.all_reduce(
+            temp_tensor, op=torch.distributed.ReduceOp.SUM, group=self.tp_group
+        )
+        result_list = temp_tensor.tolist()
+        result = []
+        for i in range(len(result_list)):
+            result.append(result_list[i] == 0)
+        return result
+
+    def writing_check(self, write_back=False):
+        if len(self.ongoing_write_through) == 0:
+            return
+        write_check_start_time = time.perf_counter()
+        if write_back:
+            while (
+                len(self.ongoing_write_through)
+                != self.cache_controller.ack_write_queue.qsize()
+            ):
+                time.sleep(0.01)
+        queue_size = torch.tensor(
+            self.cache_controller.ack_write_queue.qsize(), dtype=torch.int
+        )
+        # may skip synchronize queue_size for write
+        if torch.distributed.get_world_size(group=self.tp_group) > 1:
+            # synchrnoize TP workers to make the same update to radix cache
+            torch.distributed.all_reduce(
+                queue_size,
+                op=torch.distributed.ReduceOp.MIN,
+                group=self.tp_group,
+            )
+        ack_list = []
+        flags = []
+        for _ in range(queue_size.item()):
+            ack_id, success = self.cache_controller.ack_write_queue.get_nowait()
+            ack_list.append(ack_id)
+            flags.append(success)
+        for ack_id, success in zip(ack_list, flags):
+            if (
+                not success
+                and not isinstance(self, EICPagedHiRadixCache)
+                and self.ongoing_write_through[ack_id].host_value is not None
+            ):
+                if (
+                    self.cache_controller.mem_pool_host.get_state(
+                        self.ongoing_write_through[ack_id].host_value
+                    )
+                    != MemoryStateInt.IDLE
+                ):
+                    self.cache_controller.mem_pool_host.free(
+                        self.ongoing_write_through[ack_id].host_value
+                    )
+                self.ongoing_write_through[ack_id].host_value = None
+            if not write_back:
+                self.dec_lock_ref(self.ongoing_write_through[ack_id])
+            # clear the reference
+            del self.ongoing_write_through[ack_id]
+        cost_time = time.perf_counter() - write_check_start_time
+        if cost_time > 1:
+            logger.warning(
+                f"writing check cost {cost_time:.3f} seconds, "
+                f"queue size {queue_size.item()}"
+            )
+
+    def loading_check(self):
+        if len(self.ongoing_load_back) == 0:
+            return
+        loading_check_start_time = time.perf_counter()
+        queue_size = torch.tensor(
+            self.cache_controller.ack_load_queue.qsize(), dtype=torch.int
+        )
+        if torch.distributed.get_world_size(group=self.tp_group) > 1:
+            # synchrnoize TP workers to make the same update to radix cache
+            torch.distributed.all_reduce(
+                queue_size,
+                op=torch.distributed.ReduceOp.MIN,
+                group=self.tp_group,
+            )
+        ack_list = []
+        complete_tokens = []
+        for _ in range(queue_size.item()):
+            ack_id, complete_token = self.cache_controller.ack_load_queue.get_nowait()
+            ack_list.append(ack_id)
+            complete_tokens.append(complete_token)
+        for ack_id, complete_token in zip(ack_list, complete_tokens):
+            start_node, end_node, total_token_num = self.ongoing_load_back[ack_id]
+            self.dec_lock_ref(end_node)
+            failed_token_num = total_token_num - complete_token
+            while end_node != start_node:
+                if failed_token_num >= len(end_node.value):
+                    # node load back full fail
+                    # no need to delete failed node because the kvcache will be set after compute
+                    self.cache_controller.mem_pool_device_allocator.free(end_node.value)
+                    self.evictable_size_ -= len(end_node.value)
+                    failed_token_num -= len(end_node.value)
+                    end_node.value = None
+                    end_node.host_value = None
+                    self._update_leaf_status(end_node)
+                    self._update_leaf_status(end_node.parent)
+                elif failed_token_num > 0:
+                    # node load back partial fail, split node
+                    split_len = len(end_node.value) - failed_token_num
+                    self._split_node(end_node.key, end_node, split_len)
+                    self.evictable_size_ -= failed_token_num
+                    self.cache_controller.mem_pool_device_allocator.free(end_node.value)
+                    failed_token_num -= len(end_node.value)
+                    end_node.value = None
+                    end_node.host_value = None
+                    self._update_leaf_status(end_node)
+                    self._update_leaf_status(end_node.parent)
+                    assert failed_token_num == 0, "failed_token_num should be zero"
+                end_node = end_node.parent
+            # clear the reference
+            del self.ongoing_load_back[ack_id]
+        cost_time = time.perf_counter() - loading_check_start_time
+        if cost_time > 1:
+            logger.warning(
+                f"loading check cost {cost_time:.3f} seconds, "
+                f"queue size {queue_size.item()}"
+            )
+
+    # TODO: is not correct for eic, but neednt to be fixed rightnow
+    def evictable_size(self):
+        return self.evictable_size_
+
+    def evict(self, params: EvictParams, retry_times: int = 3) -> EvictResult:
+        num_tokens = params.num_tokens
+        while len(self.ongoing_write_through) > 50 or len(self.ongoing_load_back) > 50:
+            self.writing_check()
+            self.loading_check()
+            time.sleep(0.1)
+
+        num_evicted = 0
+        while retry_times > 0:
+            retry_times -= 1
+            leaves = list(self.evictable_leaves)
+            eviction_heap = [
+                (self.eviction_strategy.get_priority(node), node) for node in leaves
+            ]
+            heapq.heapify(eviction_heap)
+
+            write_back_nodes = []
+            idx = 0
+
+            logger.debug(
+                f"evict {num_tokens} tokens, current evictable size {self.evictable_size_}, protect_size {self.protected_size_}, leaves {len(leaves)}"
+            )
+            while num_evicted < num_tokens and len(eviction_heap):
+                _priority, x = heapq.heappop(eviction_heap)
+                logger.debug(
+                    f"evicting {idx} node {x.id}, access {x.last_access_time}, value {x.value} {x.host_value}"
+                )
+                idx += 1
+
+                if x.lock_ref > 0:
+                    logger.debug(f"node {x.id} is locked, skip eviction")
+                    continue
+
+                if not x.backuped:
+                    if self.cache_controller.write_policy == "write_back":
+                        # write to host if the node is not backuped
+                        num_evicted += self.write_backup(x, write_back=True)
+                        write_back_nodes.append(x)
+                    else:
+                        num_evicted += self._evict_regular(x)
+                else:
+                    num_evicted += self._evict_backuped(x)
+
+                for child in x.parent.children.values():
+                    if child in write_back_nodes:
+                        continue
+                    if not child.evicted:
+                        break
+                else:
+                    # all children are evicted or no children
+                    new_priority = self.eviction_strategy.get_priority(x.parent)
+                    heapq.heappush(eviction_heap, (new_priority, x.parent))
+
+            if self.cache_controller.write_policy == "write_back":
+                # blocking till all write back complete
+                self.writing_check(write_back=True)
+                for node in write_back_nodes:
+                    if node.backuped:
+                        self._evict_backuped(node)
+                    else:
+                        self._evict_regular(node)
+
+            if num_evicted < num_tokens:
+                logger.info(
+                    f"only evicted {num_evicted} tokens, less than requested {num_tokens}"
+                )
+            return EvictResult(num_tokens_evicted=num_evicted)
+
+    def _evict_backuped(self, node: TreeNode):
+        if node.host_value is None:
+            logger.error(f"host value is None for node {node.id}")
+            return self._evict_regular(node)
+        num_evicted = self.cache_controller.evict_device(node.value, node.host_value)
+        assert num_evicted > 0
+        self.evictable_size_ -= num_evicted
+        node.value = None
+        self._update_leaf_status(node)
+        self._update_leaf_status(node.parent)
+        return num_evicted
+
+    def _evict_regular(self, node: TreeNode):
+        # evict a node not initiated write to host
+        self.cache_controller.mem_pool_device_allocator.free(node.value)
+        num_evicted = len(node.value)
+        self._delete_leaf(node)
+        return num_evicted
+
+    def evict_host(self, num_tokens: int):
+        leaves = self._collect_leaves()
+        heapq.heapify(leaves)
+
+        num_evicted = 0
+        while num_evicted < num_tokens and len(leaves):
+            x = heapq.heappop(leaves)
+            if x == self.root_node:
+                break
+            # only evict the host value of evicted nodes
+            if not x.evicted:
+                continue
+            assert x.lock_ref == 0 and x.host_value is not None
+
+            assert self.cache_controller.evict_host(x.host_value) > 0
+            for k, v in x.parent.children.items():
+                if v == x:
+                    break
+            del x.parent.children[k]
+
+            if len(x.parent.children) == 0 and x.parent.evicted:
+                heapq.heappush(leaves, x.parent)
+
+    def load_back(
+        self, node: TreeNode, mem_quota: Optional[int] = None
+    ) -> Optional[torch.Tensor]:
+        # todo: more loading policies
+        last_hit_node = node
+        nodes_to_load = []
+        while node.evicted:
+            assert (
+                node.backuped
+            ), "No backup available on evicted nodes, should not happen"
+            nodes_to_load.insert(0, node)
+            node = node.parent
+        else:
+            ancester_node = node
+
+        # protect the ancestor nodes from eviction
+        result = self.inc_lock_ref(ancester_node)
+        delta = result.delta if result.delta is not None else 0
+
+        # load it all or not at all
+        host_indices = torch.cat([n.host_value for n in nodes_to_load])
+        if len(host_indices) < self.load_back_threshold or (
+            len(host_indices) > mem_quota + delta if mem_quota is not None else False
+        ):
+            # skip loading back if the total size is too small or exceeding the memory quota
+            self.dec_lock_ref(ancester_node)
+            return None
+
+        device_indices = self.cache_controller.load(
+            host_indices=host_indices, node_id=last_hit_node.id
+        )
+        if device_indices is None:
+            self.evict(EvictParams(num_tokens=len(host_indices)))
+            device_indices = self.cache_controller.load(
+                host_indices=host_indices, node_id=last_hit_node.id
+            )
+        self.dec_lock_ref(ancester_node)
+        if device_indices is None:
+            # no sufficient GPU memory to load back KV caches
+            return None
+
+        self.ongoing_load_back[last_hit_node.id] = (
+            ancester_node,
+            last_hit_node,
+            len(device_indices),
+        )
+        offset = 0
+        for node in nodes_to_load:
+            node.value = device_indices[offset : offset + len(node.host_value)]
+            offset += len(node.host_value)
+        self.evictable_size_ += len(device_indices)
+        self.inc_lock_ref(last_hit_node)
+
+        return device_indices
+
+    def loading_complete(self, node: TreeNode):
+        self.loading_check()
+        return node.id not in self.ongoing_load_back.keys()
+
+    def init_load_back(
+        self,
+        params: InitLoadBackParams,
+    ):
+        last_node = params.best_match_node
+        mem_quota = params.mem_quota
+        if last_node.evicted:
+            loading_values = self.load_back(last_node, mem_quota)
+            if loading_values is not None:
+                logger.debug(
+                    f"loading back {len(loading_values)} tokens for node {last_node.id}"
+                )
+                return loading_values, last_node
+
+            while last_node.evicted:
+                last_node = last_node.parent
+
+        return (
+            torch.empty((0,), dtype=torch.int64, device=self.device),
+            last_node,
+        )
+
+    def ready_to_load_host_cache(self):
+        producer_index = self.cache_controller.layer_done_counter.update_producer()
+        self.load_cache_event.set()
+        return producer_index
+
+    def check_hicache_events(self):
+        self.writing_check()
+        self.loading_check()
+
+    def match_prefix(self, params: MatchPrefixParams):
+        key = params.key
+        empty_value = torch.empty((0,), dtype=torch.int64, device=self.device)
+        key, _ = key.maybe_to_bigram_view(self.is_eagle)
+        if self.disable or len(key) == 0:
+            return MatchResult(
+                device_indices=empty_value,
+                last_device_node=self.root_node,
+                last_host_node=self.root_node,
+                best_match_node=self.root_node,
+                host_hit_length=0,
+            )
+
+        if self.page_size != 1:
+            page_aligned_len = len(key) // self.page_size * self.page_size
+            key = key[:page_aligned_len]
+
+        value, last_node = self._match_prefix_helper(self.root_node, key)
+        if value:
+            value = torch.cat(value)
+        else:
+            value = empty_value
+
+        host_hit_length = 0
+        last_host_node = last_node
+        while last_node.evicted:
+            while not last_node.backuped and last_node.parent is not None:
+                last_node = last_node.parent
+                last_host_node = last_node
+                host_hit_length = 0
+            if not last_node.evicted:
+                break
+            host_hit_length += len(last_node.host_value)
+            last_node = last_node.parent
+
+        return MatchResult(
+            device_indices=value,
+            last_device_node=last_node,
+            last_host_node=last_host_node,
+            best_match_node=last_host_node,
+            host_hit_length=host_hit_length,
+        )
+
+    def _match_prefix_helper(self, node: TreeNode, key: RadixKey):
+        node.last_access_time = time.monotonic()
+        child_key = key.child_key(self.page_size)
+        value = []
+
+        while len(key) > 0 and child_key in node.children.keys():
+            child = node.children[child_key]
+            child.last_access_time = time.monotonic()
+            prefix_len = child.key.match(key, page_size=self.page_size)
+            if prefix_len < len(child.key):
+                new_node = self._split_node(child.key, child, prefix_len)
+                if not new_node.evicted:
+                    value.append(new_node.value)
+                node = new_node
+                break
+            else:
+                if not child.evicted:
+                    value.append(child.value)
+                node = child
+                key = key[prefix_len:]
+
+                if len(key):
+                    child_key = key.child_key(self.page_size)
+
+        return value, node
+
+    def _split_node(self, key, child: TreeNode, split_len: int):
+        # child node split into new_node -> child
+        new_node = TreeNode(priority=child.priority)
+        new_node.children = {key[split_len:].child_key(self.page_size): child}
+        new_node.parent = child.parent
+        new_node.lock_ref = child.lock_ref
+        new_node.key = child.key[:split_len]
+        new_node.hit_count = child.hit_count
+
+        # split value and host value if exists
+        if child.evicted:
+            new_node.value = None
+        else:
+            new_node.value = child.value[:split_len]
+            child.value = child.value[split_len:]
+        if child.backuped:
+            new_node.host_value = child.host_value[:split_len]
+            child.host_value = child.host_value[split_len:]
+        child.parent = new_node
+        child.key = child.key[split_len:]
+        new_node.parent.children[key.child_key(self.page_size)] = new_node
+        return new_node
+
+    def _insert_helper(
+        self,
+        node: TreeNode,
+        key: RadixKey,
+        value,
+        priority: int = 0,
+        chunked: bool = False,
+    ):
+        if priority is None:
+            priority = 0
+        node.last_access_time = time.monotonic()
+        if len(key) == 0:
+            return 0
+
+        child_key = key.child_key(self.page_size)
+        total_prefix_length = 0
+
+        while len(key) > 0 and child_key in node.children.keys():
+            node = node.children[child_key]
+            node.last_access_time = time.monotonic()
+            prefix_len = node.key.match(key, page_size=self.page_size)
+
+            if prefix_len == len(node.key):
+                if node.evicted:
+                    # change the reference if the node is evicted
+                    # this often happens in the case of KV cache recomputation
+                    node.value = value[:prefix_len].clone()
+                    if not isinstance(self, EICPagedHiRadixCache):
+                        self.token_to_kv_pool_host.free(node.host_value)
+                    self.evictable_size_ += len(node.value)
+                    self._update_leaf_status(node)
+                    self._update_leaf_status(node.parent)
+                    self.inc_hit_count(node, chunked)
+                else:
+                    self.inc_hit_count(node, chunked)
+                    total_prefix_length += prefix_len
+            else:
+                # partial match, split the node
+                new_node = self._split_node(node.key, node, prefix_len)
+                new_node.priority = max(new_node.priority, priority)
+                if new_node.evicted:
+                    new_node.value = value[:prefix_len].clone()
+                    if not isinstance(self, EICPagedHiRadixCache):
+                        self.token_to_kv_pool_host.free(new_node.host_value)
+                    self.evictable_size_ += len(new_node.value)
+                    self._update_leaf_status(new_node)
+                    self._update_leaf_status(new_node.parent)
+                    self.inc_hit_count(new_node, chunked)
+                else:
+                    self.inc_hit_count(new_node, chunked)
+                    total_prefix_length += prefix_len
+                node = new_node
+
+            key = key[prefix_len:]
+            value = value[prefix_len:]
+
+            if len(key):
+                child_key = key.child_key(self.page_size)
+
+        if len(key):
+            new_node = TreeNode(priority=priority)
+            new_node.parent = node
+            new_node.key = key
+            new_node.value = value.clone()
+            node.children[child_key] = new_node
+            self.evictable_size_ += len(value)
+            self._update_leaf_status(node)
+            self._update_leaf_status(new_node)
+
+            if self.cache_controller.write_policy != "write_back":
+                self.inc_hit_count(new_node, chunked)
+        return total_prefix_length
+
+    def _collect_leaves_device(self):
+        def is_leaf(node):
+            if node.evicted:
+                return False
+            if node == self.root_node:
+                return False
+            if len(node.children) == 0:
+                return True
+            for child in node.children.values():
+                if not child.evicted:
+                    return False
+            return True
+
+        ret_list = []
+        stack = [self.root_node]
+        while stack:
+            cur_node = stack.pop()
+            if is_leaf(cur_node):
+                ret_list.append(cur_node)
+            else:
+                for cur_child in cur_node.children.values():
+                    if not cur_child.evicted:
+                        stack.append(cur_child)
+        return ret_list
+
+
+def _need_calculate_hash(node: TreeNode, page_size: int):
+    if node is None or node.key is None or len(node.key) == 0:
+        return False
+    return node.content_hash is None or len(node.key) // page_size != len(
+        node.content_hash
+    )
+
+
+class EICPagedHiRadixCache(EICHiRadixCache):
+    def __init__(
+        self,
+        params: CacheInitParams,
+        server_args: ServerArgs,
+    ):
+        self.calculate_hash_fn = get_content_hash
+        self.load_remote_threshold = 100
+        self.match_req_set = []
+        self.eic_check_max_num = -1
+        super().__init__(params, server_args)
+
+    def init_hyper_params(self, config):
+        super().init_hyper_params(config)
+        self.load_remote_threshold = max(
+            config.get("load_remote_threshold", 100), self.page_size
+        )
+        logger.info(
+            f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold}"
+        )
+        self.eic_check_max_num = config.get("eic_check_max_num", -1)
+        logger.info(
+            f"EICPagedHiRadixCache eic_check_max_num set to {self.eic_check_max_num}"
+        )
+        self.load_back_check = config.get("load_back_check", False)
+
+    def _calculate_content_hash(self, node: TreeNode):
+        if _need_calculate_hash(node.parent, self.page_size):
+            self._calculate_content_hash(node.parent)
+        if node.parent is not None and node.parent.content_hash is not None:
+            prev_node_hash = node.parent.content_hash[-1]
+        else:
+            prev_node_hash = None
+        node.content_hash = self.calculate_hash_fn(
+            node.key, self.page_size, prev_node_hash
+        )
+
+    def _split_node(self, key, child: TreeNode, split_len: int):
+        assert (
+            split_len % self.page_size == 0
+        ), f"split_len {split_len} is not page aligned"
+        # child node split into new_node -> child
+        if _need_calculate_hash(child, self.page_size):
+            self._calculate_content_hash(child)
+        new_node = TreeNode(priority=child.priority)
+        new_node.children = {key[split_len:].child_key(self.page_size): child}
+        new_node.parent = child.parent
+        new_node.lock_ref = child.lock_ref
+        new_node.key = child.key[:split_len]
+        new_node.hit_count = child.hit_count
+        split_hash_nums = split_len // self.page_size
+        new_node.content_hash = child.content_hash[:split_hash_nums]
+        child.content_hash = child.content_hash[split_hash_nums:]
+
+        # split value and host value if exists
+        if child.evicted:
+            new_node.value = None
+        else:
+            new_node.value = child.value[:split_len]
+            child.value = child.value[split_len:]
+        if child.backuped:
+            new_node.host_value = child.host_value[:split_len]
+            child.host_value = child.host_value[split_len:]
+        child.parent = new_node
+        child.key = child.key[split_len:]
+        new_node.parent.children[key.child_key(self.page_size)] = new_node
+        return new_node
+
+    def match_prefix_extend(self, key: RadixKey, last_node):
+        cache_prefix_len = 0
+        temp_node = last_node
+        while temp_node:
+            cache_prefix_len += len(temp_node.key)
+            temp_node = temp_node.parent
+
+        # if the cache prefix is too long, or the remaining key is too short, we can skip loading from eic
+        if (len(key) - cache_prefix_len) < self.load_remote_threshold:
+            return last_node
+
+        logger.debug(
+            f"few cache in radix, try load from eic, cache len {cache_prefix_len}, total len {len(key)}"
+        )
+        if _need_calculate_hash(last_node, self.page_size):
+            self._calculate_content_hash(last_node)
+        last_prev_hash = None
+        if last_node.content_hash is not None and len(last_node.content_hash) > 0:
+            last_prev_hash = last_node.content_hash[-1]
+        need_compute_key = key[cache_prefix_len:]
+        eic_hash, eic_key = self.cache_controller.find_longest_prefix_in_eic(
+            need_compute_key, last_prev_hash
+        )
+        if self.tp_size > 1:
+            eic_hash_len_tensor = torch.tensor(
+                [len(eic_hash)], dtype=torch.int64, device="cpu"
+            )
+            torch.distributed.all_reduce(
+                eic_hash_len_tensor,
+                op=torch.distributed.ReduceOp.MIN,
+                group=self.tp_group,
+            )
+            eic_hash_len = eic_hash_len_tensor.item()
+            eic_hash = eic_hash[:eic_hash_len]
+            eic_key = eic_key[: eic_hash_len * self.page_size]
+        if len(eic_key) < self.load_remote_threshold:
+            logger.debug(
+                f"eic key is too short, skip loading from eic, eic cache len {len(eic_key)}, need compute key len {len(need_compute_key)}"
+            )
+            return last_node
+        load_node = TreeNode()
+        load_node.key = eic_key
+        load_node.content_hash = eic_hash
+        load_node.host_value = torch.arange(
+            len(eic_key), dtype=torch.int32, device="cpu"
+        )
+        assert (
+            last_node.children.get(eic_key.child_key(self.page_size)) is None
+        ), f"eic key {eic_key} already exists in radix cache"
+        logger.debug(
+            f"load token from eic: {len(eic_key)}, node {load_node.id}, parent {last_node.id}"
+        )
+        last_node.children[eic_key.child_key(self.page_size)] = load_node
+        load_node.parent = last_node
+        return load_node
+
+    def _match_for_remote_fetch(self, node: TreeNode, key: RadixKey):
+        key, _ = key.maybe_to_bigram_view(self.is_eagle)
+        node.last_access_time = time.monotonic()
+        child_key = key.child_key(self.page_size)
+        local_prefix_len = 0
+
+        while len(key) > 0 and child_key in node.children.keys():
+            child = node.children[child_key]
+            child.last_access_time = time.monotonic()
+            prefix_len = child.key.match(key, page_size=self.page_size)
+            local_prefix_len += prefix_len
+            if prefix_len < len(child.key):
+                new_node = self._split_node(child.key, child, prefix_len)
+                node = new_node
+                break
+            else:
+                node = child
+                key = key[prefix_len:]
+
+                if len(key):
+                    child_key = key.child_key(self.page_size)
+        temp_node = node
+        local_evict_len = 0
+        while temp_node.evicted:
+            while not temp_node.backuped and temp_node.parent is not None:
+                temp_node = temp_node.parent
+                local_evict_len = 0
+            if not temp_node.evicted:
+                break
+            local_evict_len += len(temp_node.host_value)
+            temp_node = temp_node.parent
+        return local_prefix_len, local_evict_len, node
+
+    def _insert_remote_node(self, node: TreeNode, key: RadixKey):
+        node.last_access_time = time.monotonic()
+        key, _ = key.maybe_to_bigram_view(self.is_eagle)
+        if len(key) == 0:
+            return 0
+
+        child_key = key.child_key(self.page_size)
+        total_prefix_length = 0
+
+        while len(key) > 0 and child_key in node.children.keys():
+            node = node.children[child_key]
+            node.last_access_time = time.monotonic()
+            prefix_len = node.key.match(key, page_size=self.page_size)
+
+            if prefix_len == len(node.key):
+                if node.evicted and node.host_value is None:
+                    node.host_value = torch.arange(
+                        len(node.key), dtype=torch.int32, device="cpu"
+                    )
+                if not node.evicted:
+                    total_prefix_length += prefix_len
+            else:
+                # partial match, split the node
+                new_node = self._split_node(node.key, node, prefix_len)
+                if new_node.evicted and new_node.host_value is None:
+                    new_node.host_value = torch.arange(
+                        len(new_node.key), dtype=torch.int32, device="cpu"
+                    )
+                if not new_node.evicted:
+                    total_prefix_length += prefix_len
+                node = new_node
+
+            key = key[prefix_len:]
+
+            if len(key):
+                child_key = key.child_key(self.page_size)
+
+        if len(key):
+            new_node = TreeNode()
+            new_node.parent = node
+            new_node.key = key
+            new_node.host_value = torch.arange(
+                len(key), dtype=torch.int32, device="cpu"
+            )
+            node.children[child_key] = new_node
+            self._calculate_content_hash(new_node)
+        return total_prefix_length
+
+    def match_from_remote(self, waiting_queue: List[Req]):
+        compute_keys = []
+        prev_hashes = []
+        fetch_list = []
+        if len(self.match_req_set) > 1000:
+            self.match_req_set = self.match_req_set[500:]
+        eic_keys = 0
+        for req in waiting_queue:
+            logger.debug(f"req {req.rid} match from eic")
+            if req.rid in self.match_req_set:
+                continue
+            fill_ids = req.origin_input_ids + req.output_ids
+            req_tokens = fill_ids[: len(fill_ids) - 1]
+            req_key = RadixKey(req_tokens, req.extra_key)
+            local_prefix_len, local_evict_len, last_node = self._match_for_remote_fetch(
+                self.root_node, req_key
+            )
+            if (
+                len(req_key) - local_prefix_len + local_evict_len
+                < self.load_remote_threshold
+            ):
+                # skip loading from eic if the remaining key is too short
+                logger.debug(f"req {req.rid} skip loading from eic")
+                continue
+            compute_keys.append(req_key[local_prefix_len:])
+            if _need_calculate_hash(last_node, self.page_size):
+                self._calculate_content_hash(last_node)
+            prev_hashes.append(
+                last_node.content_hash[-1] if last_node.content_hash else None
+            )
+            fetch_list.append((last_node, req, local_prefix_len, local_evict_len))
+            self.match_req_set.append(req.rid)
+            eic_keys += (len(req_key) - local_prefix_len) // self.page_size
+            if self.eic_check_max_num > 0 and eic_keys >= self.eic_check_max_num:
+                logger.info(
+                    f"eic check max num {self.eic_check_max_num} reached, stop matching"
+                )
+                break
+        if len(fetch_list) == 0:
+            return
+        # batch exist
+        eic_prefix_lens = self.cache_controller.batch_find_longest_prefix_in_eic(
+            compute_keys, prev_hashes
+        )
+        if len(eic_prefix_lens) == 0 or len(eic_prefix_lens) != len(fetch_list):
+            return
+        if self.tp_size > 1:
+            eic_prefix_len_tensor = torch.tensor(
+                eic_prefix_lens, dtype=torch.int64, device="cpu"
+            )
+            torch.distributed.all_reduce(
+                eic_prefix_len_tensor,
+                op=torch.distributed.ReduceOp.MIN,
+                group=self.tp_group,
+            )
+            eic_prefix_lens = eic_prefix_len_tensor.tolist()
+        for i, (last_node, req, local_prefix_len, local_evict_len) in enumerate(
+            fetch_list
+        ):
+            eic_prefix_len = eic_prefix_lens[i]
+            if eic_prefix_len + local_evict_len < self.load_remote_threshold:
+                continue
+            eic_key = compute_keys[i][:eic_prefix_len]
+            logger.debug(
+                f"req {req.rid} match from eic, "
+                f"last node {last_node.id}, "
+                f"local prefix len {local_prefix_len}, "
+                f"eic prefix len {eic_prefix_len}"
+            )
+            self._insert_remote_node(last_node, eic_key)
+
+    def match_prefix(self, params: MatchPrefixParams):
+        key = params.key
+        empty_value = torch.empty((0,), dtype=torch.int64, device=self.device)
+        key, _ = key.maybe_to_bigram_view(self.is_eagle)
+        if self.disable or len(key) == 0:
+            return MatchResult(
+                device_indices=empty_value,
+                last_device_node=self.root_node,
+                last_host_node=self.root_node,
+                best_match_node=self.root_node,
+                host_hit_length=0,
+            )
+
+        if self.page_size != 1:
+            page_aligned_len = len(key) // self.page_size * self.page_size
+            key = key[:page_aligned_len]
+
+        value, last_node = self._match_prefix_helper(self.root_node, key)
+        if value:
+            value = torch.cat(value)
+        else:
+            value = empty_value
+
+        # last_node = self.match_prefix_extend(key, last_node)
+        host_hit_length = 0
+        last_host_node = last_node
+        while last_node.evicted:
+            while not last_node.backuped and last_node.parent is not None:
+                last_node = last_node.parent
+                last_host_node = last_node
+                host_hit_length = 0
+            if not last_node.evicted:
+                break
+            host_hit_length += len(last_node.host_value)
+            last_node = last_node.parent
+
+        return MatchResult(
+            device_indices=value,
+            last_device_node=last_node,
+            last_host_node=last_host_node,
+            best_match_node=last_host_node,
+            host_hit_length=host_hit_length,
+        )
+
+    def write_backup(self, node: TreeNode, write_back=False):
+        if node.evicted:
+            return 0
+        if _need_calculate_hash(node, self.page_size):
+            self._calculate_content_hash(node)
+        host_indices = self.cache_controller.write_page(
+            device_indices=node.value,
+            priority=-self.get_height(node),
+            node_id=node.id,
+            content_hash=node.content_hash,
+        )
+        if host_indices is not None:
+            node.host_value = host_indices
+            self.ongoing_write_through[node.id] = node
+            if not write_back:
+                self.inc_lock_ref(node)
+        else:
+            return 0
+
+        return len(host_indices)
+
+    def load_back(
+        self, node: TreeNode, mem_quota: Optional[int] = None
+    ) -> Optional[torch.Tensor]:
+        # todo: more loading policies
+        last_hit_node = node
+        nodes_to_load = []
+        while node.evicted:
+            assert (
+                node.backuped
+            ), "No backup available on evicted nodes, should not happen"
+            nodes_to_load.insert(0, node)
+            node = node.parent
+        else:
+            ancester_node = node
+
+        # protect the ancestor nodes from eviction
+        result = self.inc_lock_ref(ancester_node)
+        delta = result.delta if result.delta is not None else 0
+
+        # load it all or not at all
+        host_indices = torch.cat([n.host_value for n in nodes_to_load])
+        if len(host_indices) < self.load_back_threshold or (
+            len(host_indices) > mem_quota + delta if mem_quota is not None else False
+        ):
+            # skip loading back if the total size is too small or exceeding the memory quota
+            self.dec_lock_ref(ancester_node)
+            return None
+        host_content_hash = []
+        for n in nodes_to_load:
+            host_content_hash.extend(n.content_hash)
+
+        # check key existed
+        if self.load_back_check:
+            check_keys = host_content_hash[
+                : self.load_back_threshold // self.page_size + 1
+            ]
+            mask = self.cache_controller.mem_pool_host.batch_exist_page(check_keys)
+            check_ret = all(mask)
+            if self.tp_size > 1:
+                check_tensor = torch.tensor(
+                    0 if check_ret else 1, dtype=torch.bool, device="cpu"
+                )
+                torch.distributed.all_reduce(
+                    check_tensor,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=self.tp_group,
+                )
+                check_ret = check_tensor.item() == 0
+            if not check_ret:
+                logger.warning("key has been evicted, skip load back")
+                self.dec_lock_ref(ancester_node)
+                return None
+
+        device_indices = self.cache_controller.load_page(
+            host_indices=host_indices,
+            node_id=last_hit_node.id,
+            content_hash=host_content_hash,
+        )
+        if device_indices is None:
+            self.evict(EvictParams(num_tokens=len(host_indices)))
+            device_indices = self.cache_controller.load_page(
+                host_indices=host_indices,
+                node_id=last_hit_node.id,
+                content_hash=host_content_hash,
+            )
+        self.dec_lock_ref(ancester_node)
+        if device_indices is None:
+            # no sufficient GPU memory to load back KV caches
+            return None
+
+        self.ongoing_load_back[last_hit_node.id] = (
+            ancester_node,
+            last_hit_node,
+            len(device_indices),
+        )
+        offset = 0
+        for node in nodes_to_load:
+            node.value = device_indices[offset : offset + len(node.host_value)]
+            offset += len(node.host_value)
+        self.evictable_size_ += len(device_indices)
+        self.inc_lock_ref(last_hit_node)
+
+        return device_indices

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -1,0 +1,1575 @@
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from enum import IntEnum
+from typing import List, Optional, Tuple
+
+import torch
+import yaml
+
+from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
+from sglang.srt.mem_cache.memory_pool import (
+    KVCache,
+    MHATokenToKVPool,
+    MLATokenToKVPool,
+    NSATokenToKVPool,
+)
+from sglang.srt.mem_cache.memory_pool_host import synchronized
+
+try:
+    import eic
+except ImportError:
+    eic = None
+
+logger = logging.getLogger(__name__)
+
+REMOTE_EIC_YAML_ENV_VAR = "REMOTE_EIC_YAML"
+
+# GDR Bounce Buffer
+G_GDRBounceBufferSize = 1 * 1024 * 1024 * 1024
+G_GDRBounceTensorCount = 128  # calculated by G_GDRBounceBufferSize / kvcache_size
+
+# gpu direct rdma for kv set
+G_EnableKVSetGPUDirect = False
+
+# gpu direct rdma for kv get
+G_EnableKVGetGPUDirect = True
+
+# gpu nic affinity
+G_EnableGPUNicAffinity = False
+
+# async kv set
+G_EnableAsyncKVSet = False
+G_KVSetTTLOption = -1
+
+
+# default H20 gpu nic affinity
+GPUNicAffinity = {
+    "cuda:0": "eth1",
+    "cuda:1": "eth1",
+    "cuda:2": "eth2",
+    "cuda:3": "eth2",
+    "cuda:4": "eth3",
+    "cuda:5": "eth3",
+    "cuda:6": "eth4",
+    "cuda:7": "eth4",
+}
+
+# default H20 cpu nic affinity
+CPUNicAffinity = {
+    "cuda:0": "cpu",
+    "cuda:1": "cpu",
+    "cuda:2": "cpu",
+    "cuda:3": "cpu",
+    "cuda:4": "cpu",
+    "cuda:5": "cpu",
+    "cuda:6": "cpu",
+    "cuda:7": "cpu",
+}
+
+
+def get_eic_config_file_path():
+    if os.environ.get(REMOTE_EIC_YAML_ENV_VAR) is not None:
+        logger.info(f"eic init with env var {REMOTE_EIC_YAML_ENV_VAR}")
+        config_file = os.environ.get(REMOTE_EIC_YAML_ENV_VAR)
+    else:
+        config_file = "/sgl-workspace/config/remote-eic.yaml"
+        logger.info(f"eic init with default config, config_file {config_file}")
+    return config_file
+
+
+class MemoryStateInt(IntEnum):
+    IDLE = 0
+    RESERVED = 1
+    PROTECTED = 2
+    SYNCED = 3
+    BACKUP = 4
+
+
+class FlexibleKVCacheMemoryPool:
+    def __init__(self, conn, kvcache_shape, kvcache_dtype, device):
+        self.connection = conn
+        self.kvcache_shape = kvcache_shape
+        self.kvcache_dtype = kvcache_dtype
+
+        self.kv_cache_numel = 1
+        for i in kvcache_shape:
+            self.kv_cache_numel *= i
+
+        if device.startswith("cpu") and G_EnableGPUNicAffinity:
+            gpu_id = torch.cuda.current_device()
+            self.device = CPUNicAffinity["cuda:" + str(gpu_id)]
+            # current memory pool size is 5 times of CPU buffer size
+            mempool_size = G_GDRBounceTensorCount * 5
+        else:
+            self.device = device
+            mempool_size = G_GDRBounceTensorCount
+
+        self.free_data_addr = set()
+        self.data_ptr_to_index = dict()
+
+        if self.device.startswith("cpu"):
+            self.kvcache_mempool = torch.zeros(
+                (mempool_size,) + kvcache_shape,
+                dtype=kvcache_dtype,
+                device=self.device,
+                pin_memory=True,
+            )
+        else:
+            self.kvcache_mempool = torch.zeros(
+                (mempool_size,) + kvcache_shape, dtype=kvcache_dtype, device=self.device
+            )
+        for i in range(mempool_size):
+            self.free_data_addr.add(i)
+            self.data_ptr_to_index[self.kvcache_mempool[i].data_ptr()] = i
+
+        meminfo = eic.MemoryInfo()
+        meminfo.type = eic.MemoryType.MEMORY_CUDA
+        meminfo.cuda_id = 0
+        vals = eic.IOBuffers()
+        vals.append(
+            self.kvcache_mempool.data_ptr(),
+            self.kvcache_mempool.numel() * self.kvcache_mempool.element_size(),
+            True,
+        )
+        self.connection.register_memory(vals, meminfo)
+        logger.info(
+            f"allocate memory pool, size {self.kvcache_mempool.numel() * self.kvcache_mempool.element_size()}, device {self.device}"
+        )
+
+    def try_allocate_kv_cache(self, shape, dtype, count=1):
+        if len(self.free_data_addr) < count:
+            return None, None
+
+        numel = 1
+        for i in shape:
+            numel *= i
+        if numel != self.kv_cache_numel or dtype != self.kvcache_dtype:
+            logger.error(
+                f"allocate from mempool failed, self.kvcache_shape {self.kvcache_shape}, dtype {self.kvcache_dtype}, require shape {shape}, dtype {dtype}"
+            )
+            return None, None
+
+        ret = []
+        indices = []
+        for _ in range(count):
+            free_index = self.free_data_addr.pop()
+            ret.append(self.kvcache_mempool[free_index])
+            indices.append(free_index)
+        return ret, indices
+
+    def free_to_mempool(self, data_ptr):
+        if data_ptr not in self.data_ptr_to_index:
+            logger.error(
+                f"free_to_mempool failed, data_ptr {data_ptr} not in allocated_data_addr"
+            )
+            return
+        self.free_data_addr.add(self.data_ptr_to_index[data_ptr])
+
+    def check_data_ptr_allocated(self, data_ptr):
+        return data_ptr in self.data_ptr_to_index
+
+    def left_count(self):
+        return len(self.free_data_addr)
+
+
+class EICKVClient:
+    """
+    The remote url should start with "eic://" and only have one host-port pair
+    """
+
+    def __init__(self, kv_cache_dtype, kv_cache_shape, device_pool, device="cpu"):
+        if eic is None:
+            raise ImportError("eic module is not found, please install eic package")
+        global G_EnableKVSetGPUDirect, G_EnableKVGetGPUDirect, G_EnableAsyncKVSet
+        global GPUNicAffinity, CPUNicAffinity, G_EnableGPUNicAffinity, G_KVSetTTLOption
+        global G_GDRBounceBufferSize, G_GDRBounceTensorCount
+
+        config_file = get_eic_config_file_path()
+        if os.path.exists(config_file) is False:
+            logger.error(f"config file {config_file} not exists")
+            exit(1)
+
+        with open(config_file, "r") as fin:
+            config = yaml.safe_load(fin)
+
+        remote_url = config.get("remote_url", None)
+        if remote_url is None:
+            raise RuntimeError("remote_url is None")
+
+        endpoint = remote_url[len("eic://") :]
+
+        logger.info(f"eic remote_url: {remote_url} endpoint: {endpoint}")
+
+        eic_instance_id = config.get("eic_instance_id", None)
+        logger.info(f"eic instance_id: {eic_instance_id}")
+
+        eic_thread_num = config.get("eic_thread_num", 1)
+        logger.info(f"eic thread_num: {eic_thread_num}")
+
+        eic_log_dir = config.get("eic_log_dir", None)
+        logger.info(f"eic log_dir: {eic_log_dir}")
+
+        eic_log_level = config.get("eic_log_level", 2)
+        logger.info(f"eic log_level: {eic_log_level}")
+
+        eic_trans_type = config.get("eic_trans_type", 3)
+        logger.info(f"eic trans_type: {eic_trans_type}")
+
+        eic_flag_file = config.get("eic_flag_file", None)
+        logger.info(f"eic flag_file: {eic_flag_file}")
+
+        G_EnableKVSetGPUDirect = (
+            config.get("enable_kvset_gpu_direct", False) and torch.cuda.is_available()
+        )
+        logger.info(f"eic enable_kvset_gpu_direct: {G_EnableKVSetGPUDirect}")
+
+        G_EnableKVGetGPUDirect = (
+            config.get("enable_kvget_gpu_direct", True) and torch.cuda.is_available()
+        )
+        logger.info(f"eic enable_kvget_gpu_direct: {G_EnableKVGetGPUDirect}")
+
+        # rdma write
+        enable_kv_set_direct = config.get("enable_kvset_direct", True)
+        logger.info(f"eic enable_kv_set_direct: {enable_kv_set_direct}")
+        self.enable_kv_set_direct = enable_kv_set_direct
+
+        # gpu nic affinity
+        G_EnableGPUNicAffinity = config.get("enable_gpu_nic_affinity", False)
+        logger.info(f"eic enable_gpu_nic_affinity: {G_EnableGPUNicAffinity}")
+        self.enable_gpu_nic_affinity = G_EnableGPUNicAffinity
+
+        G_KVSetTTLOption = config.get("kv_set_ttl_option", -1)
+        logger.info(f"eic kv set ttl: {G_KVSetTTLOption}")
+        self.kv_set_ttl_option = G_KVSetTTLOption
+
+        if G_EnableGPUNicAffinity:
+            if "gpu_nic_affinity_config" in config:
+                GPUNicAffinity = json.loads(config["gpu_nic_affinity_config"])
+            if "cpu_nic_affinity_config" in config:
+                CPUNicAffinity = json.loads(config["cpu_nic_affinity_config"])
+            logger.info(f"eic gpu nic affinity {GPUNicAffinity}")
+            logger.info(f"eic cpu nic affinity {CPUNicAffinity}")
+
+        G_EnableAsyncKVSet = config.get("enable_async_kvset", False)
+        logger.info(f"eic enable_async_kvset: {G_EnableAsyncKVSet}")
+
+        eic_namespace = config.get("eic_namespace", "")
+        logger.info(f"eic namespace: {eic_namespace}")
+        self.eic_namespace = eic_namespace
+
+        self.gdr_bounce_buffer_size = config.get(
+            "gdr_bounce_buffer_size", G_GDRBounceBufferSize
+        )
+        G_GDRBounceBufferSize = self.gdr_bounce_buffer_size
+        logger.info(f"eic gdr_bounce_buffer_size: {self.gdr_bounce_buffer_size}")
+
+        kv_cache_numel = 1
+        for i in kv_cache_shape:
+            kv_cache_numel *= i
+        G_GDRBounceTensorCount = self.gdr_bounce_buffer_size // (
+            kv_cache_numel * kv_cache_dtype.itemsize
+        )
+        logger.info(
+            f"eic gdr_bounce_tensor_count: {G_GDRBounceTensorCount}, kvcache_size {kv_cache_numel * kv_cache_dtype.itemsize}"
+        )
+
+        # other configurations
+        self.eic_check_bs = config.get("eic_check_bs", 2048)
+        logger.debug(f"eic check bs: {self.eic_check_bs}")
+        self.eic_direct_backup = config.get("eic_direct_backup", False)
+        logger.debug(f"eic direct backup: {self.eic_direct_backup}")
+        self.eic_direct_writeback = (
+            config.get("eic_direct_writeback", False) and G_EnableKVGetGPUDirect
+        )
+        logger.debug(f"eic direct writeback: {self.eic_direct_writeback}")
+
+        if not os.path.exists(eic_log_dir) and not os.path.isdir(eic_log_dir):
+            os.makedirs(eic_log_dir, exist_ok=True)
+
+        self.connection = eic.Client()
+        init_option = eic.InitOption()
+        init_option.log_dir = eic_log_dir
+        init_option.log_level = eic.LogLevel(eic_log_level)
+        init_option.transport_type = eic.TransportType(eic_trans_type)
+        init_option.flag_file = eic_flag_file
+
+        if G_EnableGPUNicAffinity:
+            gpu_id = torch.cuda.current_device()
+            init_option.multi_net_local_interface_names = GPUNicAffinity[
+                "cuda:" + str(gpu_id)
+            ]
+            logger.info(
+                f"gpu {gpu_id} set gpu nic affinity to {init_option.multi_net_local_interface_names}"
+            )
+
+        ret = self.connection.init(eic_instance_id, endpoint, init_option)
+        if ret != 0:
+            logger.error(f"fail to init eic client, ret: {ret}")
+            exit(1)
+
+        self.device = device
+        self.trans_type = eic.TransportType(eic_trans_type)
+        self.kv_cache_shape = kv_cache_shape
+        self.kv_cache_dtype = kv_cache_dtype
+        self.device_pool = device_pool
+
+        # use for kv get
+        self.kv_cache_read_mem_pool = FlexibleKVCacheMemoryPool(
+            self.connection,
+            self.kv_cache_shape,
+            self.kv_cache_dtype,
+            self.device if G_EnableKVGetGPUDirect else "cpu",
+        )
+
+        if G_EnableAsyncKVSet:
+            logger.info("enable async kv set")
+            self.kv_cache_write_mem_pool = FlexibleKVCacheMemoryPool(
+                self.connection,
+                self.kv_cache_shape,
+                self.kv_cache_dtype,
+                "cpu",
+            )
+        else:
+            logger.info("enable sync kv set")
+            self.kv_cache_write_mem_pool = FlexibleKVCacheMemoryPool(
+                self.connection,
+                self.kv_cache_shape,
+                self.kv_cache_dtype,
+                self.device if G_EnableKVSetGPUDirect else "cpu",
+            )
+
+        self.write_queue = queue.Queue()
+        self._write_thread_num = 1
+        self._write_thread_pool = [
+            threading.Thread(target=self._write_thread, args=())
+            for _ in range(self._write_thread_num)
+        ]
+        for thread in self._write_thread_pool:
+            thread.start()
+
+        self._warm_up()
+
+    def _warm_up(self):
+        logger.info("begin warm up eic client")
+        start_time = time.perf_counter()
+        num_warmup = 1024
+        preheat_keys = ["warmup_key_" + str(i) for i in range(num_warmup)]
+        batch_size = 32
+        for i in range(0, num_warmup, batch_size):
+            keys_vec = eic.StringVector()
+            for key in preheat_keys[i : i + batch_size]:
+                keys_vec.append(key)
+            exist_option = eic.ExistOption()
+            status_code, exist_outcome = self.connection.mexist(keys_vec, exist_option)
+        logger.info(
+            f"finish eic client warm up, warm up cost {time.perf_counter() - start_time:.2f} seconds"
+        )
+
+    def _write_thread(self):
+        logger.info(f"start write thread thread_id {threading.get_ident()}")
+        while True:
+            keys, values = self.write_queue.get()
+            self._async_set_impl(keys, values)
+            for value in values:
+                if self.kv_cache_write_mem_pool.check_data_ptr_allocated(
+                    value.data_ptr()
+                ):
+                    self.kv_cache_write_mem_pool.free_to_mempool(value.data_ptr())
+
+    def async_batch_set(
+        self,
+        keys: List[str],
+        obj_inputs: List[torch.Tensor],
+        device_indices: torch.Tensor = None,
+        copy_func=None,
+    ) -> bool:
+        logger.debug(f"eic async_batch_set {len(keys)}")
+        start_time = time.perf_counter()
+        count = len(keys)
+
+        if self.kv_cache_write_mem_pool.left_count() >= count:
+            objs, host_indices = self.kv_cache_write_mem_pool.try_allocate_kv_cache(
+                self.kv_cache_shape, self.kv_cache_dtype, count
+            )
+            if objs is None:
+                return False
+
+            if obj_inputs is not None:
+                write_stream = torch.cuda.current_stream()
+                with torch.cuda.stream(write_stream):
+                    for i in range(len(keys)):
+                        objs[i] = objs[i].reshape(obj_inputs[i].shape)
+                        objs[i].copy_(obj_inputs[i], non_blocking=True)
+                write_stream.synchronize()
+            elif device_indices is not None and copy_func is not None:
+                copy_func(device_indices, objs)
+            else:
+                logger.error(
+                    "async set impl input obj_inputs and device_indices are both None"
+                )
+                return False
+            self.write_queue.put((keys, objs))
+
+            cost_time = time.perf_counter() - start_time
+            if cost_time >= 0.5:
+                logger.info(
+                    f"async batch set cost { cost_time * 1e3}.2f ms, {len(keys)} keys"
+                )
+        else:
+            objs = []
+            if obj_inputs is not None:
+                objs = [item.cpu() for item in obj_inputs]
+            elif device_indices is not None and copy_func is not None:
+                large_tensor = torch.empty(
+                    (count,) + self.kv_cache_shape,
+                    dtype=self.kv_cache_dtype,
+                    device="cpu",
+                )
+                objs = [large_tensor[i] for i in range(len(keys))]
+                copy_func(device_indices, objs)
+            else:
+                logger.error(
+                    "async set impl input obj_inputs and device_indices are both None"
+                )
+                return False
+            self.write_queue.put((keys, objs))
+            logger.warning(
+                f"async batch set fallback to malloc, cost {(time.perf_counter() - start_time) * 1e3}.2f ms, {len(keys)} keys"
+            )
+        return True
+
+    def exists(self, key: str) -> bool:
+        logger.debug(f"eic exists {key}")
+        keys = eic.StringVector()
+        keys.append(key)
+        exist_option = eic.ExistOption()
+        exist_option.ns = self.eic_namespace
+
+        status_code, exist_outcome = self.connection.mexist(keys, exist_option)
+        if status_code != eic.StatusCode.SUCCESS:
+            logger.debug(f"eic exists {key} failed, status_code {status_code}")
+
+        err_code = exist_outcome.status_codes[0]
+        success = err_code == eic.StatusCode.SUCCESS
+        if success:
+            logger.debug(f"eic exists {key} success")
+        else:
+            logger.debug(f"eic exists {key} failed, err_code {err_code}")
+        return success
+
+    def exists_batch(self, keys: List[str]) -> List[bool]:
+        logger.debug(f"eic exists {len(keys)}")
+        keys_vec = eic.StringVector()
+        for key in keys:
+            keys_vec.append(key)
+        exist_option = eic.ExistOption()
+        exist_option.ns = self.eic_namespace
+
+        status_code, exist_outcome = self.connection.mexist(keys_vec, exist_option)
+        if status_code != eic.StatusCode.SUCCESS:
+            logger.error(f"eic exists {len(keys)} failed, status_code {status_code}")
+            return [False] * len(keys)
+        res = []
+        for err_code in exist_outcome.status_codes:
+            res.append(err_code == eic.StatusCode.SUCCESS)
+        return res
+
+    def allocate_eic_read_buffer(self, count):
+        registered = True
+        tensors, indices = self.kv_cache_read_mem_pool.try_allocate_kv_cache(
+            self.kv_cache_shape, self.kv_cache_dtype, count
+        )
+        host_memory_pool = self.kv_cache_read_mem_pool.kvcache_mempool
+        if tensors is None:
+            logger.error("can not allocate tensor from pool")
+            registered = False
+            kvcache_tensor = torch.empty(
+                (count,) + self.kv_cache_shape, dtype=self.kv_cache_dtype, device="cpu"
+            )
+            tensors = [kvcache_tensor[i] for i in range(count)]
+            host_memory_pool = kvcache_tensor
+            indices = range(count)
+        return tensors, host_memory_pool, indices, registered
+
+    def batch_get(
+        self, keys: List[str], device_indices: torch.Tensor = None, copy_func=None
+    ) -> Tuple[Optional[List[torch.Tensor]], List[bool]]:
+        logger.debug(f"eic get {len(keys)}")
+
+        # Get Data: generate data keys and vals
+        get_data_start_time = time.perf_counter()
+        data_keys = eic.StringVector()
+        data_vals = eic.IOBuffers()
+        objs = None
+        success_mask = [True for _ in range(len(keys))]
+        count = len(keys)
+
+        objs, host_memory_pool, host_indices, registered = (
+            self.allocate_eic_read_buffer(count)
+        )
+
+        for i, key in enumerate(keys):
+            data_keys.append(key)
+            data_vals.append(
+                objs[i].data_ptr(), objs[i].element_size() * objs[i].numel(), registered
+            )
+
+        # Get data: recv data buffer tensor
+        get_option = eic.GetOption()
+        get_option.ns = self.eic_namespace
+        status_code, data_vals, get_outcome = self.connection.mget(
+            data_keys, get_option, data_vals
+        )
+
+        result = []
+        device_copy = False
+        # copy before free
+        if device_indices is None or copy_func is None:
+            if registered:
+                for obj in objs:
+                    result.append(obj.clone())
+            else:
+                result = objs
+        else:
+            device_copy = True
+
+        fail_count = 0
+        if status_code != eic.StatusCode.SUCCESS:
+            if status_code == eic.StatusCode.PARTIAL_FAILED:
+                for i, err_code in enumerate(get_outcome.status_codes):
+                    success = err_code == eic.StatusCode.SUCCESS
+                    if success:
+                        logger.debug(f"eic get data {keys[i]} success")
+                    else:
+                        logger.debug(
+                            f"eic get data {keys[i]} failed, err_code {err_code}"
+                        )
+                        success_mask[i] = False
+                        fail_count += 1
+            else:
+                logger.error(
+                    f"eic mget {len(keys)} keys failed, status_code {status_code}"
+                )
+                result = None
+                success_mask = [False for _ in range(len(keys))]
+                fail_count = len(keys)
+
+        if fail_count != 0:
+            # Note that fail count only means how many keys failed in this batch get, not really failed in prefix cache
+            logger.warning(
+                f"eic mget {len(keys)} keys failed, fail count {fail_count}, success count {count - fail_count}"
+            )
+        if device_copy:
+            suc_count = 0
+            for mask in success_mask:
+                if mask:
+                    suc_count += 1
+                else:
+                    break
+            if suc_count > 0:
+                copy_func(device_indices, host_memory_pool, host_indices[:suc_count])
+
+        if registered:
+            for item in objs:
+                self.kv_cache_read_mem_pool.free_to_mempool(item.data_ptr())
+
+        get_data_end_time = time.perf_counter()
+        get_data_execution_time = (get_data_end_time - get_data_start_time) * 1e6
+        logger.debug(f"eic get {count} keys data cost %.2f us", get_data_execution_time)
+        return result, success_mask
+
+    def allocate_eic_write_buffer(self, count):
+        registered = True
+        objs, _ = self.kv_cache_write_mem_pool.try_allocate_kv_cache(
+            self.kv_cache_shape, self.kv_cache_dtype, count
+        )
+        if objs is None:
+            logger.error("can not allocate tensor from pool")
+            registered = False
+            kvcache_tensor = torch.empty(
+                (count,) + self.kv_cache_shape, dtype=self.kv_cache_dtype, device="cpu"
+            )
+            objs = [kvcache_tensor[i] for i in range(count)]
+        return objs, registered
+
+    def set(
+        self,
+        keys: List[str],
+        obj_inputs: List[torch.Tensor],
+        device_indices: torch.Tensor = None,
+        copy_func=None,
+    ) -> bool:
+        logger.debug(f"eic set {len(keys)}")
+        return self._sync_set_impl(keys, obj_inputs, device_indices, copy_func)
+
+    def _sync_set_impl(
+        self,
+        keys: List[str],
+        obj_inputs: List[torch.Tensor],
+        device_indices: torch.Tensor = None,
+        copy_func=None,
+    ) -> bool:
+        logger.debug(f"eic set {len(keys)} keys")
+        keys_vec = eic.StringVector()
+        vals_vec = eic.IOBuffers()
+        count = len(keys)
+
+        objs, registered = self.allocate_eic_write_buffer(count)
+        values_data_ptrs = []
+
+        if obj_inputs is not None:
+            write_stream = torch.cuda.current_stream()
+            with torch.cuda.stream(write_stream):
+                for i, key in enumerate(keys):
+                    temp = objs[i].reshape(obj_inputs[i].shape).contiguous()
+                    temp.copy_(obj_inputs[i], non_blocking=True)
+
+                    if temp.data_ptr() != objs[i].data_ptr():
+                        registered = False
+                        temp = temp.cpu()
+                    values_data_ptrs.append(
+                        (
+                            temp.data_ptr(),
+                            temp.element_size() * temp.numel(),
+                            registered,
+                        )
+                    )
+            write_stream.synchronize()
+        elif device_indices is not None and copy_func is not None:
+            copy_func(device_indices, objs)
+            for i, key in enumerate(keys):
+                values_data_ptrs.append(
+                    (
+                        objs[i].data_ptr(),
+                        objs[i].element_size() * objs[i].numel(),
+                        registered,
+                    )
+                )
+        else:
+            logger.error("set impl input obj_inputs and device_indices are both None")
+            return False
+
+        for i, key in enumerate(keys):
+            keys_vec.append(key)
+            data_ptr, data_size, registered = values_data_ptrs[i]
+            vals_vec.append(
+                data_ptr, data_size, registered and self.enable_kv_set_direct
+            )
+
+        # set options
+        set_option = eic.SetOption()
+        set_option.ns = self.eic_namespace
+        set_option.ttl_second = self.kv_set_ttl_option
+        status_code, set_outcome = self.connection.mset(keys_vec, vals_vec, set_option)
+        if status_code != eic.StatusCode.SUCCESS:
+            logger.error(f"eic mset {len(keys)} failed, status_code {status_code}")
+        else:
+            logger.debug(f"eic mset {len(keys)} success")
+
+        if registered:
+            for item in objs:
+                self.kv_cache_write_mem_pool.free_to_mempool(item.data_ptr())
+
+        err_code = set_outcome.status_codes[0]
+        if err_code != eic.StatusCode.SUCCESS:
+            logger.error(f"set data key {len(keys)} failed, err_code {err_code}")
+            return False
+
+        logger.debug(f"set data key {len(keys)} success")
+        return True
+
+    def _async_set_impl(self, keys: List[str], obj_inputs: List[torch.Tensor]) -> None:
+        logger.debug(f"eic set {len(keys)} keys")
+        keys_vec = eic.StringVector()
+        vals_vec = eic.IOBuffers()
+
+        # set data key & value
+        for key, value in zip(keys, obj_inputs):
+            obj = value
+            # set data key & value
+            keys_vec.append(key)
+            registered = self.kv_cache_write_mem_pool.check_data_ptr_allocated(
+                obj.data_ptr()
+            )
+            vals_vec.append(
+                obj.data_ptr(),
+                obj.element_size() * obj.numel(),
+                registered,
+            )
+
+        # set options
+        set_option = eic.SetOption()
+        set_option.ns = self.eic_namespace
+        set_option.ttl_second = self.kv_set_ttl_option
+        status_code, set_outcome = self.connection.mset(keys_vec, vals_vec, set_option)
+
+        if status_code != eic.StatusCode.SUCCESS:
+            logger.error(f"eic mset {len(keys)} failed, status_code {status_code}")
+            return False
+        else:
+            logger.debug(f"eic mset {len(keys)} success")
+        return True
+
+
+class EICBaseTokenToKVPoolHost:
+    def __init__(
+        self,
+        device_pool: KVCache,
+        host_to_device_ratio: float = 4.0,
+        host_size: int = 10,
+        device: str = "cpu",
+        page_size: int = 1,
+        rank: int = 0,
+        extra_info: Optional[dict] = None,
+    ):
+        self.device_pool = device_pool
+        self.host_to_device_ratio = host_to_device_ratio
+        self.device = device
+        self.dtype = device_pool.store_dtype
+        self.page_size = page_size
+        self.size_per_token = self.get_size_per_token()
+        if host_size > 0:
+            self.size = int(host_size * 1e9 // self.size_per_token)
+        else:
+            self.size = int(device_pool.size * host_to_device_ratio)
+        self.size = self.size - (self.size % self.page_size)
+
+        # Initialize memory states and tracking structures.
+        self.mem_state = torch.zeros(
+            (self.size,), dtype=torch.uint8, device=self.device
+        )
+        self.free_slots = torch.arange(self.size, dtype=torch.int32)
+        self.can_use_mem_size = self.size
+
+        # A lock for synchronized() operations on memory allocation and state transitions.
+        self.lock = threading.RLock()
+        self.debug = logger.isEnabledFor(logging.DEBUG)
+
+        self.rank = rank
+        self.attn_tp_size = get_attention_tp_size()
+        self.attn_tp_rank = get_attention_tp_rank()
+        self.host_ip = self._get_host_ip()
+        self.split_dim = 2
+        self.split_size = self.page_size
+        self.extra_info = extra_info
+        self.deploy_key = self._get_deploy_info()
+        self.device_backup_func = self.device_backup
+        self.device_writeback_func = self.device_writeback
+
+    def _encode_key_exclusive(self, indices):
+        return [
+            f"{self.host_ip}_{self.rank}_{index}"
+            for index in indices.to("cpu").tolist()
+        ]
+
+    def _get_host_ip(self):
+        import socket
+
+        return socket.gethostbyname(socket.gethostname())
+
+    def _get_deploy_info(self):
+        model_path = self.extra_info.get("model_path", "fake_model_path")
+        attn_tp_size = self.attn_tp_size
+        attn_tp_rank = self.attn_tp_rank
+        page_size = self.page_size
+        dtype = self.dtype
+        framework = self.extra_info.get("framework", "sglang")
+        pp_size = self.extra_info.get("pp_size", 1)
+        if pp_size > 1:
+            pp_rank = self.extra_info.get("pp_rank", 0)
+            deploy_key = f"{model_path}_{pp_size}_{pp_rank}_{attn_tp_size}_{attn_tp_rank}_{page_size}_{dtype}@{framework}"
+        else:
+            deploy_key = f"{model_path}_{attn_tp_size}_{attn_tp_rank}_{page_size}_{dtype}@{framework}"
+        return deploy_key
+
+    def _encode_key_shared(self, content_hashs):
+        return [f"{content_hash}@{self.deploy_key}" for content_hash in content_hashs]
+
+    def batch_exist_page(self, content_hashes):
+        """
+        for multi prompt detect prefix key
+        """
+        batch_size = self.eic_client.eic_check_bs
+        keys = self._encode_key_shared(content_hashes)
+
+        exist_result = []
+        for i in range(0, len(keys), batch_size):
+            batch_ret = self.eic_client.exists_batch(keys[i : i + batch_size])
+            exist_result.extend(batch_ret)
+        return exist_result
+
+    def get_flat_data_direct(self, keys, device_indices=None):
+        bs = G_GDRBounceTensorCount // 2
+        masks = []
+
+        for i in range(0, len(keys), bs):
+            key = keys[i : i + bs]
+            indices = device_indices[i : i + bs]
+            _, success_mask = self.eic_client.batch_get(
+                key, indices, self.device_writeback_func
+            )
+            masks.extend(success_mask)
+            if not all(success_mask):
+                break
+        return masks
+
+    def get_flat_data_common(self, keys, device_indices=None):
+        bs = G_GDRBounceTensorCount // 2
+        ret = []
+        masks = []
+        suc_count = 0
+
+        for i in range(0, len(keys), bs):
+            key = keys[i : i + bs]
+            objs, success_mask = self.eic_client.batch_get(key)
+            if objs is None:
+                logger.debug(f"get_page_data keys {key} failed, eic_client return none")
+                break
+            # todo(zhongwei.ren): preallocate recv tensors
+            ret.extend(objs)
+            masks.extend(success_mask)
+
+            if not all(success_mask):
+                break
+
+        for mask in masks:
+            if mask:
+                suc_count += 1
+            else:
+                break
+        if suc_count > 0:
+            flat_data = torch.cat(ret[:suc_count], dim=self.split_dim)
+            self.device_pool.transfer(
+                device_indices[: suc_count * self.page_size], flat_data
+            )
+        return masks
+
+    def get_flat_data(self, indices) -> Tuple[Optional[torch.Tensor], List[bool]]:
+        logger.debug(f"get_flat_data indices {indices}")
+        keys = self._encode_key_exclusive(indices)
+        if self.eic_client.eic_direct_writeback:
+            return self.get_flat_data_direct(keys, indices)
+        else:
+            return self.get_flat_data_common(keys, indices)
+
+    def assign_flat_data_common(self, keys, flat_data, device_indices=None) -> bool:
+        if flat_data is None:
+            flat_data = self.device_pool.get_flat_data(device_indices)
+        start_time = time.perf_counter()
+        flat_data = flat_data.contiguous()
+        values = torch.split(flat_data, 1, dim=self.split_dim)
+
+        bs = G_GDRBounceTensorCount
+        split_time = time.perf_counter()
+        count = len(keys)
+        for i in range(0, count, bs):
+            key = keys[i : i + bs]
+            value = values[i : i + bs]
+            if G_EnableAsyncKVSet:
+                ret = self.eic_client.async_batch_set(key, value)
+            else:
+                ret = self.eic_client.set(key, value)
+            if not ret:
+                logger.error(
+                    f"assign_flat_data keys {key} failed, eic_client return none"
+                )
+                return False
+        cost_time = time.perf_counter() - split_time
+        if cost_time > 1:
+            logger.warning(
+                f"finish assign flat data, total keys {len(keys)}, split time {split_time - start_time}, transfer time {cost_time}"
+            )
+        return True
+
+    def assign_flat_data_direct(self, keys, device_indices=None) -> bool:
+        if device_indices is None:
+            logger.error("assign_flat_data_direct device_indices is None")
+            return False
+
+        bs = G_GDRBounceTensorCount
+        start_time = time.perf_counter()
+        count = len(keys)
+        for i in range(0, count, bs):
+            key = keys[i : i + bs]
+            indices = device_indices[i : i + bs]
+            if G_EnableAsyncKVSet:
+                ret = self.eic_client.async_batch_set(
+                    key, None, indices, copy_func=self.device_backup_func
+                )
+            else:
+                ret = self.eic_client.set(
+                    key, None, indices, copy_func=self.device_backup_func
+                )
+            if not ret:
+                logger.error(
+                    f"assign_flat_data keys {key} failed, eic_client return none"
+                )
+                return False
+        cost_time = time.perf_counter() - start_time
+        if cost_time > 1:
+            logger.warning(
+                f"finish assign flat data, total keys {len(keys)}, transfer time {cost_time}"
+            )
+        return True
+
+    def assign_flat_data(self, indices, flat_data, device_indices=None) -> bool:
+        logger.debug(f"assign_flat_data indices {indices}")
+        keys = self._encode_key_exclusive(indices)
+        if self.eic_client.eic_direct_backup and flat_data is None:
+            return self.assign_flat_data_direct(keys, device_indices)
+        else:
+            return self.assign_flat_data_common(keys, flat_data, device_indices)
+
+    def get_size_per_token(self):
+        self.head_num = self.device_pool.head_num
+        self.head_dim = self.device_pool.head_dim
+        self.layer_num = self.device_pool.layer_num
+
+        return self.head_dim * self.head_num * self.layer_num * self.dtype.itemsize * 2
+
+    def exist_page(self, content_hashes):
+        """
+        for single prompt detect prefix key
+        """
+        keys = self._encode_key_shared(content_hashes)
+        ret = self.eic_client.exists_batch(keys)
+        res = []
+        for i, exist in enumerate(ret):
+            if exist:
+                res.append(content_hashes[i])
+            else:
+                break
+        return res
+
+    def get_page_data_direct(self, keys, device_indices=None):
+        bs = G_GDRBounceTensorCount
+        masks = []
+        count = len(keys)
+        for i in range(0, count, bs):
+            key = keys[i : i + bs]
+            indices = device_indices[i : i + bs * self.page_size]
+            _, success_mask = self.eic_client.batch_get(
+                key, indices, self.device_writeback_func
+            )
+            masks.extend(success_mask)
+            if not all(success_mask):
+                break
+        return masks
+
+    def get_page_data_common(self, keys, device_indices=None):
+        count = len(keys)
+        bs = G_GDRBounceTensorCount // 2
+        ret = []
+        masks = []
+        suc_count = 0
+
+        for i in range(0, count, bs):
+            key = keys[i : i + bs]
+            objs, success_mask = self.eic_client.batch_get(key)
+            if objs is None:
+                logger.debug(f"get_page_data keys {key} failed, eic_client return none")
+                break
+            # todo(zhongwei.ren): preallocate recv tensors
+            ret.extend(objs)
+            masks.extend(success_mask)
+
+            if not all(success_mask):
+                break
+
+        for mask in masks:
+            if mask:
+                suc_count += 1
+            else:
+                break
+
+        if suc_count > 0:
+            flat_data = torch.cat(ret[:suc_count], dim=self.split_dim)
+            self.device_pool.transfer(
+                device_indices[: suc_count * self.page_size], flat_data
+            )
+        return masks
+
+    def get_page_data(self, content_hashs, device_indices=None):
+        logger.debug(f"get_page_data content_hashs {content_hashs}")
+        keys = self._encode_key_shared(content_hashs)
+        if self.eic_client.eic_direct_writeback:
+            return self.get_page_data_direct(keys, device_indices)
+        else:
+            return self.get_page_data_common(keys, device_indices)
+
+    def assign_page_data_common(self, keys, flat_data, device_indices=None) -> bool:
+        if flat_data is None:
+            flat_data = self.device_pool.get_flat_data(device_indices)
+        start_time = time.perf_counter()
+        flat_data = flat_data.contiguous()
+        values = torch.split(flat_data, self.split_size, dim=self.split_dim)
+
+        bs = G_GDRBounceTensorCount
+        split_time = time.perf_counter()
+        count = len(keys)
+        for i in range(0, count, bs):
+            key = keys[i : i + bs]
+            value = values[i : i + bs]
+            if G_EnableAsyncKVSet:
+                ret = self.eic_client.async_batch_set(key, value)
+            else:
+                ret = self.eic_client.set(key, value)
+            if not ret:
+                logger.error(
+                    f"assign_page_data keys {key} failed, eic_client return none"
+                )
+                return False
+
+        cost_time = time.perf_counter() - split_time
+        if cost_time > 1:
+            logger.warning(
+                f"finish assign page data, total keys {len(keys)}, split time {split_time - start_time}, transfer time {cost_time}"
+            )
+        return True
+
+    def assign_page_data_direct(self, keys, device_indices=None) -> bool:
+        if device_indices is None:
+            logger.error("assign_page_data_direct device_indices is None")
+            return False
+        start_time = time.perf_counter()
+        bs = G_GDRBounceTensorCount
+        count = len(keys)
+        for i in range(0, count, bs):
+            key = keys[i : i + bs]
+            indices = device_indices[i : i + bs * self.page_size]
+            if G_EnableAsyncKVSet:
+                ret = self.eic_client.async_batch_set(
+                    key, None, indices, copy_func=self.device_backup_func
+                )
+            else:
+                ret = self.eic_client.set(
+                    key, None, indices, copy_func=self.device_backup_func
+                )
+            if not ret:
+                logger.error(
+                    f"assign_page_data keys {key} failed, eic_client return none"
+                )
+                return False
+
+        cost_time = time.perf_counter() - start_time
+        if cost_time > 1:
+            logger.warning(
+                f"finish assign page data, total keys {len(keys)}, transfer time {cost_time}"
+            )
+        return True
+
+    def assign_page_data(self, content_hashes, flat_data, device_indices=None):
+        logger.debug(f"assign_page_data hashes {content_hashes}")
+        if len(content_hashes) == 0:
+            return True
+        keys = self._encode_key_shared(content_hashes)
+        if self.eic_client.eic_direct_backup and flat_data is None:
+            return self.assign_page_data_direct(keys, device_indices)
+        else:
+            return self.assign_page_data_common(keys, flat_data, device_indices)
+
+    def device_backup(
+        self, device_indices: torch.Tensor, dst_tensors: List[torch.Tensor]
+    ) -> None:
+        raise NotImplementedError
+
+    def device_writeback(
+        self,
+        device_indices: torch.Tensor,
+        src_tensors: List[torch.Tensor],
+        masks: List[bool],
+    ) -> None:
+        raise NotImplementedError
+
+    @synchronized
+    def clear(self):
+        self.mem_state.fill_(0)
+        self.can_use_mem_size = self.size
+        self.free_slots = torch.arange(self.size, dtype=torch.int32)
+
+    @synchronized
+    def get_state(self, indices: torch.Tensor) -> MemoryStateInt:
+        assert len(indices) > 0, "The indices should not be empty"
+        states = self.mem_state[indices]
+        assert (
+            states == states[0]
+        ).all(), "The memory slots should have the same state {}".format(states)
+        return MemoryStateInt(states[0].item())
+
+    @synchronized
+    def alloc(self, need_size: int) -> torch.Tensor:
+        if need_size > self.can_use_mem_size:
+            return None
+
+        # todo: de-fragementation
+        select_index = self.free_slots[:need_size]
+        self.free_slots = self.free_slots[need_size:]
+
+        self.mem_state[select_index] = MemoryStateInt.RESERVED
+        self.can_use_mem_size -= need_size
+
+        return select_index
+
+    @synchronized
+    def is_reserved(self, indices: torch.Tensor) -> bool:
+        return self.get_state(indices) == MemoryStateInt.RESERVED
+
+    @synchronized
+    def is_protected(self, indices: torch.Tensor) -> bool:
+        return self.get_state(indices) == MemoryStateInt.PROTECTED
+
+    @synchronized
+    def is_synced(self, indices: torch.Tensor) -> bool:
+        return self.get_state(indices) == MemoryStateInt.SYNCED
+
+    @synchronized
+    def is_backup(self, indices: torch.Tensor) -> bool:
+        return self.get_state(indices) == MemoryStateInt.BACKUP
+
+    @synchronized
+    def update_backup(self, indices: torch.Tensor):
+        self.mem_state[indices] = MemoryStateInt.BACKUP
+
+    @synchronized
+    def update_synced(self, indices: torch.Tensor):
+        self.mem_state[indices] = MemoryStateInt.SYNCED
+
+    @synchronized
+    def protect_write(self, indices: torch.Tensor):
+        assert self.is_reserved(indices), (
+            f"The host memory slots should be RESERVED before write operations. "
+            f"Current state: {self.get_state(indices)}"
+        )
+        self.mem_state[indices] = MemoryStateInt.PROTECTED
+
+    @synchronized
+    def protect_load(self, indices: torch.Tensor):
+        self.mem_state[indices] = MemoryStateInt.PROTECTED
+
+    @synchronized
+    def complete_io(self, indices: torch.Tensor):
+        assert self.is_protected(indices), (
+            f"The host memory slots should be PROTECTED during I/O operations. "
+            f"Current state: {self.get_state(indices)}"
+        )
+        self.mem_state[indices] = MemoryStateInt.SYNCED
+
+    def available_size(self):
+        return len(self.free_slots)
+
+    @synchronized
+    def free(self, indices: torch.Tensor) -> int:
+        self.mem_state[indices] = MemoryStateInt.IDLE
+        self.free_slots = torch.concat([self.free_slots, indices])
+        self.can_use_mem_size += len(indices)
+        return len(indices)
+
+
+class EICMHATokenToKVPoolHost(EICBaseTokenToKVPoolHost):
+    def __init__(
+        self,
+        device_pool: MHATokenToKVPool,
+        host_to_device_ratio: float,
+        host_size: int,
+        device: str = "cpu",
+        page_size: int = 1,
+        rank: int = 0,
+        extra_info: Optional[dict] = None,
+    ):
+        super().__init__(
+            device_pool,
+            host_to_device_ratio,
+            host_size,
+            device,
+            page_size,
+            rank,
+            extra_info,
+        )
+        self.head_num = device_pool.head_num
+        self.head_dim = device_pool.head_dim
+        self.layer_num = device_pool.layer_num
+        self.size_per_token = (
+            self.head_dim * self.head_num * self.layer_num * self.dtype.itemsize * 2
+        )
+        self.kvcache_shape = (
+            2,
+            self.layer_num,
+            page_size,
+            self.head_num,
+            self.head_dim,
+        )
+        self.kvcache_device = device_pool.device
+        self.eic_client = EICKVClient(
+            self.dtype, self.kvcache_shape, device_pool, self.kvcache_device
+        )
+
+    def device_backup(
+        self, device_indices: torch.Tensor, dst_tensors: List[torch.Tensor]
+    ) -> None:
+        assert (
+            len(device_indices) == len(dst_tensors) * self.page_size
+        ), "Length of device_indices and dst_tensors must be the same"
+        count = len(device_indices)
+        cpu_tensor = torch.zeros(
+            2,
+            self.layer_num,
+            count,
+            self.head_num,
+            self.head_dim,
+            dtype=self.dtype,
+            device="cpu",
+        )
+        for layer_id in range(self.layer_num):
+            cpu_tensor[0][layer_id][:].copy_(
+                self.device_pool.k_buffer[layer_id][device_indices], non_blocking=True
+            )
+            cpu_tensor[1][layer_id][:].copy_(
+                self.device_pool.v_buffer[layer_id][device_indices], non_blocking=True
+            )
+        torch.cuda.current_stream().synchronize()
+        for i, dst in enumerate(dst_tensors):
+            start = i * self.page_size
+            end = start + self.page_size
+            dst.copy_(cpu_tensor[:, :, start:end, :, :].contiguous())
+
+    def device_writeback(self, device_indices, src_tensor, src_indices):
+        assert (
+            len(device_indices) >= len(src_indices) * self.page_size
+        ), "Length of device_indices and src_tensors must be the same"
+        suc_count = len(src_indices)
+        device_indices = device_indices[: suc_count * self.page_size]
+        for layer_id in range(self.layer_num):
+            self.device_pool.k_buffer[layer_id][device_indices] = src_tensor[
+                src_indices, 0, layer_id
+            ].flatten(0, 1)
+            self.device_pool.v_buffer[layer_id][device_indices] = src_tensor[
+                src_indices, 1, layer_id
+            ].flatten(0, 1)
+
+
+class EICMLATokenToKVPoolHost(EICBaseTokenToKVPoolHost):
+    def __init__(
+        self,
+        device_pool: MLATokenToKVPool,
+        host_to_device_ratio: float,
+        host_size: int,
+        device: str = "cpu",
+        page_size: int = 1,
+        rank: int = 0,
+        extra_info: Optional[dict] = None,
+    ):
+        super().__init__(
+            device_pool,
+            host_to_device_ratio,
+            host_size,
+            device,
+            page_size,
+            rank,
+            extra_info,
+        )
+        self.kv_lora_rank = self.device_pool.kv_lora_rank
+        self.qk_rope_head_dim = self.device_pool.qk_rope_head_dim
+        self.kv_cache_dim = self.device_pool.kv_cache_dim
+        self.layer_num = self.device_pool.layer_num
+        self.size_per_token = self.kv_cache_dim * 1 * self.dtype.itemsize
+        self.kvcache_shape = (
+            self.layer_num,
+            page_size,
+            1,
+            self.kv_cache_dim,
+        )
+        self.kvcache_device = device_pool.device
+        self.eic_client = EICKVClient(
+            self.dtype, self.kvcache_shape, device_pool, self.kvcache_device
+        )
+        self.split_dim = 1
+
+    def _get_deploy_info(self):
+        model_path = self.extra_info.get("model_path", "fake_model_path")
+        page_size = self.page_size
+        dtype = self.dtype
+        framework = self.extra_info.get("framework", "sglang")
+        pp_size = self.extra_info.get("pp_size", 1)
+        if pp_size > 1:
+            pp_rank = self.extra_info.get("pp_rank", 0)
+            deploy_key = (
+                f"{model_path}_{pp_size}_{pp_rank}_{page_size}_{dtype}@{framework}"
+            )
+        else:
+            deploy_key = f"{model_path}_{page_size}_{dtype}@{framework}"
+        return deploy_key
+
+    def _filter_kv_cache(
+        self,
+        keys: List[str],
+        obj_inputs: torch.Tensor,
+        device_indices: torch.Tensor = None,
+    ):
+        attn_tp_size = self.attn_tp_size
+        attn_tp_rank = self.attn_tp_rank
+
+        keys_len = len(keys)
+        mean_len = keys_len // attn_tp_size
+        remainder = keys_len % attn_tp_size
+        tp_keys_len = mean_len + (1 if attn_tp_rank < remainder else 0)
+        start = attn_tp_rank * mean_len + min(attn_tp_rank, remainder)
+        end = start + tp_keys_len
+        logger.debug(f"start: {start}, end: {end}, tp_keys_len: {tp_keys_len}")
+        ret_keys = keys[start:end]
+        ret_inputs = None
+        ret_device_indices = None
+        if obj_inputs is not None:
+            ret_inputs = obj_inputs.narrow(
+                dim=self.split_dim,
+                start=start * self.page_size,
+                length=tp_keys_len * self.page_size,
+            )
+        if device_indices is not None:
+            ret_device_indices = device_indices.narrow(
+                dim=0,
+                start=start * self.page_size,
+                length=tp_keys_len * self.page_size,
+            )
+
+        return ret_keys, ret_inputs, ret_device_indices
+
+    def assign_page_data(self, content_hashes, flat_data, device_indices=None):
+        content_hashes, flat_data, device_indices = self._filter_kv_cache(
+            content_hashes, flat_data, device_indices
+        )
+        return super().assign_page_data(content_hashes, flat_data, device_indices)
+
+    def get_size_per_token(self):
+        self.kv_cache_dim = self.device_pool.kv_cache_dim
+        self.dtype = self.device_pool.store_dtype
+        self.layer_num = self.device_pool.layer_num
+
+        return self.kv_cache_dim * 1 * self.dtype.itemsize * self.layer_num
+
+    def device_backup(
+        self, device_indices: torch.Tensor, dst_tensors: List[torch.Tensor]
+    ) -> None:
+        assert (
+            len(device_indices) == len(dst_tensors) * self.page_size
+        ), "Length of device_indices and dst_tensors must be the same"
+        count = len(device_indices)
+        cpu_tensor = torch.empty(
+            self.layer_num,
+            count,
+            1,
+            self.kv_cache_dim,
+            dtype=self.dtype,
+            device="cpu",
+        )
+        for layer_id in range(self.layer_num):
+            cpu_tensor[layer_id].copy_(
+                self.device_pool.kv_buffer[layer_id][device_indices], non_blocking=True
+            )
+        torch.cuda.current_stream().synchronize()
+        for i, dst in enumerate(dst_tensors):
+            start = i * self.page_size
+            end = start + self.page_size
+            dst.copy_(cpu_tensor[:, start:end, :, :].contiguous())
+
+    def device_writeback(self, device_indices, src_tensor, src_indices):
+        assert (
+            len(device_indices) >= len(src_indices) * self.page_size
+        ), "Length of device_indices and src_tensors must be the same"
+        suc_count = len(src_indices)
+        device_indices = device_indices[: suc_count * self.page_size]
+        for layer_id in range(self.layer_num):
+            self.device_pool.kv_buffer[layer_id][device_indices] = src_tensor[
+                src_indices, layer_id
+            ].flatten(0, 1)
+
+
+class EICNSATokenToKVPoolHost(EICMLATokenToKVPoolHost):
+    def __init__(
+        self,
+        device_pool: NSATokenToKVPool,
+        host_to_device_ratio: float,
+        host_size: int,
+        device: str = "cpu",
+        page_size: int = 1,
+        rank: int = 0,
+        extra_info: Optional[dict] = None,
+    ):
+        EICBaseTokenToKVPoolHost.__init__(
+            self,
+            device_pool,
+            host_to_device_ratio,
+            host_size,
+            device,
+            page_size,
+            rank,
+            extra_info,
+        )
+        self.kv_lora_rank = self.device_pool.kv_lora_rank
+        self.qk_rope_head_dim = self.device_pool.qk_rope_head_dim
+
+        self.kvcache_shape = (
+            self.layer_num,
+            1,
+            self.final_dim,
+        )
+        self.kvcache_device = device_pool.device
+
+        # Pass device_pool=None to treat as a standard single-tensor pool in client
+        self.eic_client = EICKVClient(
+            torch.uint8, self.kvcache_shape, None, self.kvcache_device
+        )
+        self.split_dim = 1
+        self.split_size = 1
+
+    def get_size_per_token(self):
+        self.kv_cache_dim = self.device_pool.kv_cache_dim
+        self.layer_num = self.device_pool.layer_num
+        self.nsa_index_dim = self.device_pool.index_k_with_scale_buffer[0].shape[-1]
+        self.nsa_index_dtype = self.device_pool.index_k_with_scale_buffer_dtype
+
+        self.mla_page_bytes = self.kv_cache_dim * self.dtype.itemsize * self.page_size
+        self.nsa_page_bytes = self.nsa_index_dim * self.nsa_index_dtype.itemsize
+        self.final_dim = self.mla_page_bytes + self.nsa_page_bytes
+
+        self.size_per_token = self.final_dim * self.layer_num / self.page_size
+        return self.size_per_token
+
+    def device_backup(
+        self, device_indices: torch.Tensor, dst_tensors: List[torch.Tensor]
+    ) -> None:
+        assert (
+            len(device_indices) == len(dst_tensors) * self.page_size
+        ), "Length of device_indices and dst_tensors must be the same"
+        count = len(device_indices)
+        num_pages = count // self.page_size
+
+        # page_indices for NSA (compressed)
+        page_indices = (
+            device_indices.reshape(-1, self.page_size)[:, 0] // self.page_size
+        )
+
+        # CPU buffer: (layer_num, num_pages, final_dim)
+        cpu_tensor = torch.empty(
+            self.layer_num,
+            num_pages,
+            self.final_dim,
+            dtype=torch.uint8,
+            device="cpu",
+        )
+
+        for layer_id in range(self.layer_num):
+            mla_data = self.device_pool.kv_buffer[layer_id][device_indices]
+            mla_bytes = mla_data.view(num_pages, -1).view(torch.uint8)
+            cpu_tensor[layer_id, :, : self.mla_page_bytes].copy_(
+                mla_bytes, non_blocking=True
+            )
+
+            nsa_packed = self.device_pool.index_k_with_scale_buffer[layer_id][
+                page_indices
+            ]
+            cpu_tensor[layer_id, :, self.mla_page_bytes :].copy_(
+                nsa_packed, non_blocking=True
+            )
+
+        torch.cuda.current_stream().synchronize()
+
+        for i, dst in enumerate(dst_tensors):
+            dst.copy_(cpu_tensor[:, i, :].unsqueeze(1), non_blocking=True)
+
+    def device_writeback(self, device_indices, src_tensor, src_indices):
+        assert (
+            len(device_indices) >= len(src_indices) * self.page_size
+        ), "Length of device_indices and src_tensors must be the same"
+        suc_count = len(src_indices)
+
+        real_device_indices = device_indices[: suc_count * self.page_size]
+        page_indices = (
+            real_device_indices.reshape(-1, self.page_size)[:, 0] // self.page_size
+        )
+
+        src_data = src_tensor[src_indices]  # (num_pages, layer_num, 1, final_dim)
+
+        for layer_id in range(self.layer_num):
+            layer_data = src_data[:, layer_id, 0, :]  # (num_pages, final_dim)
+            mla_bytes = layer_data[:, : self.mla_page_bytes]
+            nsa_bytes = layer_data[:, self.mla_page_bytes :]
+            mla_part = (
+                mla_bytes.reshape(-1).view(self.dtype).reshape(-1, 1, self.kv_cache_dim)
+            )
+            self.device_pool.kv_buffer[layer_id][real_device_indices] = mla_part
+            self.device_pool.index_k_with_scale_buffer[layer_id][
+                page_indices
+            ] = nsa_bytes
+
+
+if __name__ == "__main__":
+    # Example usage
+    kv_cache_shape = (128, 2048)  # Example shape
+    numel = 1
+    for i in kv_cache_shape:
+        numel *= i
+    kv_cache_dtype = torch.float32  # Example dtype
+
+    import sys
+
+    if len(sys.argv) > 1:
+        data_device, mem_pool_device = sys.argv[1].split(",")
+    else:
+        data_device, mem_pool_device = "cpu", "cpu"
+
+    eic_client = EICKVClient(kv_cache_dtype, kv_cache_shape, mem_pool_device)
+    print(
+        f"EIC Client initialized with data_device: {data_device}, mem_pool_device: {mem_pool_device}, kv_cache_shape: {kv_cache_shape}, kv_cache_dtype: {kv_cache_dtype}"
+    )
+
+    test_keys = 1024
+    batch_size = 256
+    keys = ["test_key_" + str(i) for i in range(test_keys)]
+    values = [
+        torch.randn(kv_cache_shape, dtype=kv_cache_dtype, device=data_device)
+        for i in range(test_keys)
+    ]
+
+    last_time = time.perf_counter()
+    transmit_bytes = 0
+    write_size = test_keys * numel * kv_cache_dtype.itemsize
+
+    total_round = 100
+    for round_i in range(total_round):
+        for i in range(0, test_keys, batch_size):
+            eic_client._sync_set_impl(
+                keys[i : i + batch_size], values[i : i + batch_size]
+            )
+        transmit_bytes += write_size
+        if transmit_bytes >= 2 * 1024 * 1024 * 1024:
+            cost_time = time.perf_counter() - last_time
+            print(
+                f"data_device: {data_device}, mem_pool_device: {mem_pool_device}, write {transmit_bytes} bytes, cost time {cost_time}, bps {transmit_bytes // cost_time // 1024 // 1024} MB/s"
+            )
+            last_time = time.perf_counter()
+            transmit_bytes = 0
+
+    get_stream = torch.cuda.current_stream()
+    for round_i in range(total_round):
+        for i in range(0, test_keys, batch_size):
+            recv_objs, success = eic_client.batch_get(keys[i : i + batch_size])
+            with torch.cuda.stream(get_stream):
+                for j, obj in enumerate(recv_objs):
+                    obj.copy_(values[i + j], non_blocking=True)
+            get_stream.synchronize()
+
+        transmit_bytes += write_size
+        if transmit_bytes >= 2 * 1024 * 1024 * 1024:
+            cost_time = time.perf_counter() - last_time
+            print(
+                f"data_device: {data_device}, mem_pool_device: {mem_pool_device}, read {transmit_bytes} bytes, cost time {cost_time}, bps {transmit_bytes // cost_time // 1024 // 1024} MB/s"
+            )
+            last_time = time.perf_counter()
+            transmit_bytes = 0
+
+    del eic_client  # Clean up the client to release resources
+    print("EIC Client cleaned up.")

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -226,6 +226,9 @@ class TreeNode:
         self.hash_value: Optional[List[str]] = None
         # priority for priority-aware eviction
         self.priority = priority
+        self.backuped_storage = False
+        # for block-wise cache
+        self.content_hash = None
 
         self.id = TreeNode.counter if id is None else id
         TreeNode.counter += 1

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -68,6 +68,7 @@ class SchedulerStats:
     num_grammar_queue_reqs: int = 0
     gen_throughput: float = 0.0
     cache_hit_rate: float = 0.0
+    eic_cache_hit_rate: float = 0.0
     decode_sum_seq_lens: int = 0
 
     # Memory pool usage ratios (0.0–1.0).
@@ -330,6 +331,13 @@ class SchedulerMetricsCollector:
         self.mamba_used_tokens = Gauge(
             name="sglang:mamba_used_tokens",
             documentation="Number of actively used state slots in the mamba SSM pool.",
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        self.eic_cache_hit_rate = Gauge(
+            name="sglang:eic_cache_hit_rate",
+            documentation="The EIC cache hit rate.",
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
@@ -1110,6 +1118,7 @@ class SchedulerMetricsCollector:
         self._log_gauge(self.num_grammar_queue_reqs, stats.num_grammar_queue_reqs)
         self._log_gauge(self.gen_throughput, stats.gen_throughput)
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
+        self._log_gauge(self.eic_cache_hit_rate, stats.eic_cache_hit_rate)
         self._log_gauge(self.decode_sum_seq_lens, stats.decode_sum_seq_lens)
 
         # Memory pool usage ratios

--- a/python/sglang/srt/observability/scheduler_metrics_mixin.py
+++ b/python/sglang/srt/observability/scheduler_metrics_mixin.py
@@ -49,6 +49,8 @@ class PrefillStats:
 
     log_input_tokens: int
     log_hit_tokens: int
+    log_hit_gpu_tokens: int
+    log_hit_eic_tokens: int
     new_token_ratio: float
     num_running_reqs: QueueCount
     num_new_seqs: int  # len(can_run_list)
@@ -65,6 +67,8 @@ class PrefillStats:
         return cls(
             log_input_tokens=adder.log_input_tokens,
             log_hit_tokens=adder.log_hit_tokens,
+            log_hit_gpu_tokens=adder.log_hit_gpu_tokens,
+            log_hit_eic_tokens=adder.log_hit_eic_tokens,
             new_token_ratio=adder.new_token_ratio,
             num_running_reqs=QueueCount.from_reqs(
                 running_reqs, enable_priority_scheduling
@@ -519,6 +523,24 @@ class SchedulerMetricsMixin:
             f"#pending-token: {prefill_stats.num_pending_tokens}, "
         )
 
+        if self.enable_hierarchical_cache and self.enable_eic_cache:
+            num_write_queue_size = self.tree_cache.cache_controller.write_queue.qsize()
+            num_load_queue_size = self.tree_cache.cache_controller.load_queue.qsize()
+            if num_write_queue_size:
+                msg += f"#write-queue: {num_write_queue_size}, "
+            if num_load_queue_size:
+                msg += f"#load-queue: {num_load_queue_size}, "
+
+            denom = prefill_stats.log_input_tokens + prefill_stats.log_hit_tokens
+            if denom > 0:
+                total_hit_rate = prefill_stats.log_hit_tokens / denom
+                eic_hit_rate = prefill_stats.log_hit_eic_tokens / denom
+                gpu_hit_rate = total_hit_rate - eic_hit_rate
+                msg += (
+                    f"#hit_rate(total/gpu/eic): "
+                    f"{total_hit_rate:.2f}/{gpu_hit_rate:.2f}/{eic_hit_rate:.2f}, "
+                )
+
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             msg += f"#bootstrap-req: {len(self.disagg_prefill_bootstrap_queue.queue)}, "
             msg += f"#inflight-req: {len(self.disagg_prefill_inflight_queue)}, "
@@ -566,6 +588,11 @@ class SchedulerMetricsMixin:
             cache_hit_rate = (
                 prefill_stats.log_hit_tokens / total_tokens if total_tokens > 0 else 0.0
             )
+            eic_cache_hit_rate = (
+                prefill_stats.log_hit_eic_tokens / total_tokens
+                if total_tokens > 0
+                else 0.0
+            )
 
             # Basics
             self.stats.num_running_reqs = prefill_stats.num_running_reqs
@@ -574,6 +601,7 @@ class SchedulerMetricsMixin:
             )
             self.stats.num_grammar_queue_reqs = len(self.grammar_manager)
             self.stats.cache_hit_rate = cache_hit_rate
+            self.stats.eic_cache_hit_rate = eic_cache_hit_rate
 
             # Memory pool usage ratios / Absolute token counts
             pool_stats.update_scheduler_stats(self.stats)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -754,6 +754,13 @@ class ServerArgs:
     enable_draft_weights_cpu_backup: bool = False
     allow_auto_truncate: bool = False
     enable_custom_logit_processor: bool = False
+    enable_hierarchical_cache: bool = False
+    enable_eic_cache: bool = False
+    disable_eic_shared: bool = False
+    hicache_ratio: float = 2.0
+    hicache_size: int = 0
+    hicache_write_policy: str = "write_through"
+    hicache_io_backend: str = ""
     flashinfer_mla_disable_ragged: bool = False
     disable_shared_experts_fusion: bool = False
     enforce_shared_experts_fusion: bool = False
@@ -4282,6 +4289,11 @@ class ServerArgs:
                 "The arguments enable-hierarchical-cache and disable-radix-cache are mutually exclusive "
                 "and cannot be used at the same time. Please use only one of them."
             )
+        if self.custom_weight_loader is None:
+            self.custom_weight_loader = []
+
+        if self.enable_eic_cache and not self.enable_hierarchical_cache:
+            self.enable_hierarchical_cache = True
 
         if self.disaggregation_decode_enable_offload_kvcache:
             if self.disaggregation_mode != "decode":
@@ -6863,6 +6875,18 @@ class ServerArgs:
             type=str,
             default=ServerArgs.debug_tensor_dump_inject,
             help="Inject the outputs from jax as the input of every layer.",
+        )
+
+        parser.add_argument(
+            "--enable-eic-cache",
+            action="store_true",
+            help="Enable EIC cache",
+        )
+
+        parser.add_argument(
+            "--disable-eic-shared",
+            action="store_true",
+            help="Disable EIC shared cache, which is used to share the cache between multiple servers.",
         )
 
         # PD disaggregation


### PR DESCRIPTION
Cherry-picks the EIC changes from PR #481 onto the latest ep_main (13d4e40d1).

Adaptations made for current ep_main:
- Resolved PrefillAdder conflicts by keeping ep_main waiting_queue_len and PR #481 enable_eic_cache.
- Kept current LoRA drainer scheduling while preserving EICPagedHiRadixCache remote match.
- Kept ep_main unified radix branch ordering, but routes EIC through EICHiRadixCacheBuilder so generic unified cache does not bypass EIC native HiCache behavior.
- Updated EIC cache code for current BasePrefixCache/MatchResult interfaces: best_match_node, InitLoadBackParams.best_match_node, and IncLockRefResult.delta.
- Cleaned simple new EIC lint issues from the cherry-pick.

Validation:
- git diff --check origin/ep_main...HEAD
- PYTHONPATH=python python -m compileall -q <touched Python files>
- Static interface scan for MatchResult.best_match_node, InitLoadBackParams old fields, and inc_lock_ref delta usage
- python -m ruff check --select F541,F841 on new EIC cache files

Note: direct module import on this Mac stops before EIC at missing baseline dependency pybase64; I did not install the full SGLang dependency set locally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->