### PR TITLE
[codex] Fix kernel workflow concurrency grouping

### DIFF
--- a/.github/workflows/release-whl-kernel.yml
+++ b/.github/workflows/release-whl-kernel.yml
@@ -74,7 +74,7 @@ on:
         required: false
 
 concurrency:
-  group: release-sglang-kernels-${{ github.ref }}
+  group: release-sglang-kernels-${{ github.ref }}-${{ inputs.artifact_name || github.event.inputs.target || 'standalone' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- include the reusable kernel workflow input in the concurrency group
- keep independent scheduled kernel wheel builds from cancelling each other

## Root Cause

`release-docker-dev.yml` calls `release-whl-kernel.yml` twice in a matrix for `sgl-kernel-x86` and `sgl-kernel-x86-cu13`. The reusable workflow used only `${{ github.ref }}` in its concurrency group, so both calls landed in the same group on `ep_main`. With `cancel-in-progress: true`, one kernel wheel build could cancel the other before it reached a runner.

## Validation

- Parsed `.github/workflows/release-whl-kernel.yml` with Python `yaml.safe_load` and asserted the expected concurrency group
- Ran `git diff --check -- .github/workflows/release-whl-kernel.yml`

`actionlint` is not installed in this environment, so Actions-specific lint was not run locally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->