### PR TITLE
[codex] Split DeepGEMM Docker install layer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,11 +12,6 @@ ARG DEEPEP_COMMIT=9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee
 ARG BUILD_AND_DOWNLOAD_PARALLEL=8
 ARG SGL_KERNEL_VERSION=0.4.2.post2
 ARG SGL_VERSION
-ARG SGL_DEEP_GEMM_VERSION=0.1.0+merge.pr332.pr36.sgl.dev
-ARG DEEPGEMM_REPO=qiushixiaoyu/DeepGEMM
-ARG DEEPGEMM_REF=merge-pr332-pr36-sgl-dev
-ARG DEEPGEMM_CACHE_BUST=manual
-ARG DEEPGEMM_GITHUB_ARTIFACTORY
 ARG USE_LATEST_SGLANG=0
 ARG GDRCOPY_VERSION=2.5.1
 ARG GDRCOPY_GITHUB_ARTIFACTORY
@@ -183,11 +178,6 @@ FROM base AS torch_deps
 ARG CUDA_VERSION
 ARG BUILD_TYPE
 ARG SGL_KERNEL_VERSION
-ARG SGL_DEEP_GEMM_VERSION=0.1.0+merge.pr332.pr36.sgl.dev
-ARG DEEPGEMM_REPO=qiushixiaoyu/DeepGEMM
-ARG DEEPGEMM_REF=merge-pr332-pr36-sgl-dev
-ARG DEEPGEMM_CACHE_BUST=manual
-ARG DEEPGEMM_GITHUB_ARTIFACTORY
 ARG GITHUB_ARTIFACTORY
 
 WORKDIR /sgl-workspace
@@ -255,8 +245,16 @@ RUN --mount=type=cache,target=/root/.cache/pip \
                | xargs -r python3 -m pip uninstall -y && \
            python3 -m pip install --index-url https://download.pytorch.org/whl/cu${CUINDEX} \
                torch torchvision torchaudio --force-reinstall; \
-       fi \
-    && echo "${DEEPGEMM_CACHE_BUST}" \
+       fi
+
+ARG SGL_DEEP_GEMM_VERSION=0.1.0+merge.pr332.pr36.sgl.dev
+ARG DEEPGEMM_REPO=qiushixiaoyu/DeepGEMM
+ARG DEEPGEMM_REF=merge-pr332-pr36-sgl-dev
+ARG DEEPGEMM_CACHE_BUST=manual
+ARG DEEPGEMM_GITHUB_ARTIFACTORY
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    echo "${DEEPGEMM_CACHE_BUST}" \
     && DEEPGEMM_GITHUB_ARTIFACTORY="${DEEPGEMM_GITHUB_ARTIFACTORY:-${GITHUB_ARTIFACTORY}}" \
     && git config --global url."https://${DEEPGEMM_GITHUB_ARTIFACTORY}/".insteadOf "https://github.com/" \
     && rm -rf /tmp/DeepGEMM \


### PR DESCRIPTION
## Summary
- follow up #547 by moving the DeepGEMM build args next to the DeepGEMM install layer
- split the DeepGEMM install into its own Docker RUN so changing `DEEPGEMM_REF` / cache bust args does not invalidate the earlier torch dependency layer
- keep `DEEPGEMM_REF=merge-pr332-pr36-sgl-dev` without an `origin/` prefix and keep the explicit `git submodule update --init --recursive`

## Checks
- `git diff --check`
- compared the resulting `docker/Dockerfile` with the 28-validated commit `2a441425c36f40becceb797dc0bbbcc69285499d`; no Dockerfile diff

## 28 Build Validation
- Host/path: 28 env under `/data00/yinding/sglang-pr547-build-28-20260608-223548`, with proxy enabled.
- DeepGEMM install layer passed: fetched `merge-pr332-pr36-sgl-dev` via `git fetch --depth=1 origin "${DEEPGEMM_REF}"`, kept `git submodule update --init --recursive`, and built/installed `sgl-deep-gemm==0.1.0+merge.pr332.pr36.sgl.dev`.
- Container verification passed on `local/sglang:pr547-framework-deepgemm-2a441425-28` (`sha256:406876c19f0e661ceacc3016dcaede61932185d52d8815ec5b690eacdb11f10e`): version, commit marker `5a27d7c09dfe84c0ff5702cd3fbddef111390c44`, required package files, `import deep_gemm`, and `_C.so` dynamic library resolution all OK.
- Note: full final image export was not completed on 28 because the default remote-mode build first lacked `SGL_VERSION`; follow-up local/remote-version attempts were blocked by 28 rustup network errors (`504` / partial `sh.rustup.rs` transfer) in non-DeepGEMM `torch_deps` / `gateway_builder` stages.
- Logs: `/data00/yinding/sglang-pr547-build-28-20260608-223548/logs`; local bundle: `/Users/bytedance/Documents/mega_moe_dsv4pro_decode/logs/pr547-build-28-20260608-223548-logs.tar.gz`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->