### PR TITLE
[codex] Fix kernels dependency version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
   "watchfiles",
   "xgrammar==0.2.0",
   "smg-grpc-servicer>=0.5.0",
-  "kernels",
+  "kernels==0.14.1",
 ]
 
 [[tool.uv.index]]


### PR DESCRIPTION
## Summary

- Pin `kernels` to `0.14.1` in the Python dependency spec used by the Docker dependency-install layer.
- Avoid resolving `kernels 0.15.2`, which currently breaks SGLang startup with `transformers==5.6.0` during `transformers.integrations.hub_kernels` import.

## Root Cause

The release image build installs dependencies from `python/pyproject.toml` in `docker/Dockerfile`. With the dependency declared as unconstrained `kernels`, pip resolves `kernels 0.15.2`. In live release011 validation, that stack failed before serving startup:

```text
ValueError: Either a revision or a version must be specified.
```

The traceback comes from `transformers.integrations.hub_kernels` through `kernels.layer.LayerRepository`. The same release011 deployments passed after installing `kernels<0.15`; the verified runtime version was `kernels 0.14.1`.

A similar fix already exists on another bytedance-iaas branch as `23032427d7 Fix kernels version (#529)`, but it is not present on `ep_main`.

## Validation

- `git diff --check HEAD~1..HEAD`
- Parsed `python/pyproject.toml` with `tomllib` and asserted:
  - `kernels==0.14.1` is present
  - unconstrained `kernels` is absent
  - `transformers==5.6.0` remains present
- Verified `docker/Dockerfile` copies `python/pyproject.toml` into the dependency-install layer before `pip install`.


<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->