### PR TITLE
Qian/sm90 asym gemm

### DIFF
--- a/python/sglang/srt/layers/asym_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/configurer.py
@@ -2,12 +2,7 @@ import logging
 import os
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import (
-    get_device_sm,
-    is_blackwell_supported,
-    is_sm89_supported,
-    is_sm90_supported,
-)
+from sglang.srt.utils import get_device_sm
 
 logger = logging.getLogger(__name__)
 
@@ -27,23 +22,28 @@ def _compute_enable_asym_gemm():
 
 ENABLE_JIT_ASYMGEMM = _compute_enable_asym_gemm()
 
-ASYMGEMM_BLACKWELL = ENABLE_JIT_ASYMGEMM and is_blackwell_supported()
-ASYMGEMM_SCALE_UE8M0 = ASYMGEMM_BLACKWELL
-ASYMGEMM_SM89 = ENABLE_JIT_ASYMGEMM and (
-    (is_sm89_supported() and not ASYMGEMM_BLACKWELL)
-    or os.environ.get("SGLANG_ASYMGEMM_SM89", "0") == "1"
-)
-# SM90 (Hopper / H20). The TMA/UMMA `*_asym_gemm_nt_*` kernels are compiled for
-# SM100 (Blackwell) only in the asym_gemm build, so Hopper cannot use them and
-# instead shares the native FP8 grouped-GEMM kernels with Ada (SM89).
-ASYMGEMM_SM90 = ENABLE_JIT_ASYMGEMM and (
-    (is_sm90_supported() and not ASYMGEMM_BLACKWELL and not ASYMGEMM_SM89)
-    or os.environ.get("SGLANG_ASYMGEMM_SM90", "0") == "1"
-)
 
-# Native FP8 grouped-GEMM path (`m_grouped_fp8_asym_gemm_sm89[_masked]`). These
-# kernels are JIT-compiled for the running architecture, so they run on both Ada
-# (SM89) and Hopper (SM90/H20). Blackwell (SM100) instead uses the TMA/UMMA
-# `*_asym_gemm_nt_*` kernels. The MoE runner detects the GPU architecture through
-# this flag and chooses the matching asym_gemm API.
-ASYMGEMM_NATIVE_FP8 = ENABLE_JIT_ASYMGEMM and (ASYMGEMM_SM89 or ASYMGEMM_SM90)
+def _compute_blackwell() -> bool:
+    """Ask the AsymGEMM library whether the running GPU is Blackwell.
+
+    The arch -> kernel decision lives in the library (see ``asym_gemm.dispatch``),
+    so SGLang never inspects raw SM numbers itself. The env knobs force the
+    non-Blackwell (SM89/SM90) FP8 path when validating on a different GPU.
+    """
+    if not ENABLE_JIT_ASYMGEMM:
+        return False
+    if os.environ.get("SGLANG_ASYMGEMM_SM89", "0") == "1":
+        return False
+    if os.environ.get("SGLANG_ASYMGEMM_SM90", "0") == "1":
+        return False
+    import asym_gemm
+
+    return asym_gemm.is_blackwell()
+
+
+# Blackwell (SM100+) uses the TMA/UMMA `*_asym_gemm_nt_*` kernels with packed
+# UE8M0 block scales; Ada (SM89) and Hopper (SM90/H20) use the `*_sm89` FP8
+# grouped-GEMM kernels. This is the single capability flag the MoE backend
+# branches on — matching DeepGEMM's `DEEPGEMM_BLACKWELL` / `DEEPGEMM_SCALE_UE8M0`.
+ASYMGEMM_BLACKWELL = _compute_blackwell()
+ASYMGEMM_SCALE_UE8M0 = ASYMGEMM_BLACKWELL

--- a/python/sglang/srt/layers/asym_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/configurer.py
@@ -2,7 +2,12 @@ import logging
 import os
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import get_device_sm, is_blackwell_supported, is_sm89_supported
+from sglang.srt.utils import (
+    get_device_sm,
+    is_blackwell_supported,
+    is_sm89_supported,
+    is_sm90_supported,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,3 +33,17 @@ ASYMGEMM_SM89 = ENABLE_JIT_ASYMGEMM and (
     (is_sm89_supported() and not ASYMGEMM_BLACKWELL)
     or os.environ.get("SGLANG_ASYMGEMM_SM89", "0") == "1"
 )
+# SM90 (Hopper / H20). The TMA/UMMA `*_asym_gemm_nt_*` kernels are compiled for
+# SM100 (Blackwell) only in the asym_gemm build, so Hopper cannot use them and
+# instead shares the native FP8 grouped-GEMM kernels with Ada (SM89).
+ASYMGEMM_SM90 = ENABLE_JIT_ASYMGEMM and (
+    (is_sm90_supported() and not ASYMGEMM_BLACKWELL and not ASYMGEMM_SM89)
+    or os.environ.get("SGLANG_ASYMGEMM_SM90", "0") == "1"
+)
+
+# Native FP8 grouped-GEMM path (`m_grouped_fp8_asym_gemm_sm89[_masked]`). These
+# kernels are JIT-compiled for the running architecture, so they run on both Ada
+# (SM89) and Hopper (SM90/H20). Blackwell (SM100) instead uses the TMA/UMMA
+# `*_asym_gemm_nt_*` kernels. The MoE runner detects the GPU architecture through
+# this flag and chooses the matching asym_gemm API.
+ASYMGEMM_NATIVE_FP8 = ENABLE_JIT_ASYMGEMM and (ASYMGEMM_SM89 or ASYMGEMM_SM90)

--- a/python/sglang/srt/layers/asym_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/entrypoint.py
@@ -7,8 +7,10 @@ import torch
 from sglang.srt.layers.asym_gemm_wrapper import compile_utils
 from sglang.srt.layers.asym_gemm_wrapper.configurer import (  # noqa: F401
     ASYMGEMM_BLACKWELL,
+    ASYMGEMM_NATIVE_FP8,
     ASYMGEMM_SCALE_UE8M0,
     ASYMGEMM_SM89,
+    ASYMGEMM_SM90,
     ENABLE_JIT_ASYMGEMM,
 )
 from sglang.srt.server_args import ServerArgs
@@ -51,7 +53,8 @@ def grouped_gemm_nt_f8f8bf16_masked(
                 out,
                 masked_m,
                 expected_m,
-                disable_ue8m0_cast=False,
+                # SM90 (Hopper) uses plain FP32 scales; Blackwell casts to UE8M0.
+                disable_ue8m0_cast=not ASYMGEMM_SCALE_UE8M0,
             )
         
 def grouped_gemm_nt_f8f8bf16_contig(
@@ -71,7 +74,8 @@ def grouped_gemm_nt_f8f8bf16_contig(
 
     with compile_utils.asym_gemm_execution_hook(m, n, k, num_groups, kernel_type):
         asym_gemm.m_grouped_fp8_asym_gemm_nt_contiguous(lhs, rhs, out, offsets, experts, list_size,
-            disable_ue8m0_cast=False,
+            # SM90 (Hopper) uses plain FP32 scales; Blackwell casts to UE8M0.
+            disable_ue8m0_cast=not ASYMGEMM_SCALE_UE8M0,
         )
 
 

--- a/python/sglang/srt/layers/asym_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/entrypoint.py
@@ -7,10 +7,7 @@ import torch
 from sglang.srt.layers.asym_gemm_wrapper import compile_utils
 from sglang.srt.layers.asym_gemm_wrapper.configurer import (  # noqa: F401
     ASYMGEMM_BLACKWELL,
-    ASYMGEMM_NATIVE_FP8,
     ASYMGEMM_SCALE_UE8M0,
-    ASYMGEMM_SM89,
-    ASYMGEMM_SM90,
     ENABLE_JIT_ASYMGEMM,
 )
 from sglang.srt.server_args import ServerArgs
@@ -144,43 +141,6 @@ def grouped_gemm_nt_fp4fp4bf16_contig(
             recipe=recipe if recipe is not None else _FP4_RECIPE,
             disable_ue8m0_cast=True,
         )
-
-
-def grouped_gemm_sm89_f8f8bf16_contig(
-    a: torch.Tensor,
-    b: torch.Tensor,
-    out: torch.Tensor,
-    offsets: torch.Tensor,
-    experts: torch.Tensor,
-    list_size: int,
-    scale_a: float = 1.0,
-    scale_b: float = 1.0,
-    scale_a_tensor: Optional[torch.Tensor] = None,
-    scale_b_tensor: Optional[torch.Tensor] = None,
-):
-    asym_gemm.m_grouped_fp8_asym_gemm_sm89(
-        a, b, out, offsets, experts, list_size,
-        scale_a=scale_a, scale_b=scale_b,
-        scale_a_tensor=scale_a_tensor, scale_b_tensor=scale_b_tensor,
-    )
-
-
-def grouped_gemm_sm89_f8f8bf16_masked(
-    a: torch.Tensor,
-    b: torch.Tensor,
-    out: torch.Tensor,
-    masked_m: torch.Tensor,
-    expected_m: int,
-    scale_a: float = 1.0,
-    scale_b: float = 1.0,
-    scale_a_tensor: Optional[torch.Tensor] = None,
-    scale_b_tensor: Optional[torch.Tensor] = None,
-):
-    asym_gemm.m_grouped_fp8_asym_gemm_sm89_masked(
-        a, b, out, masked_m, expected_m,
-        scale_a=scale_a, scale_b=scale_b,
-        scale_a_tensor=scale_a_tensor, scale_b_tensor=scale_b_tensor,
-    )
 
 
 def grouped_gemm_nt_bf16bf16bf16_masked(

--- a/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
@@ -521,9 +521,11 @@ class AsymGemmRunnerCore(MoeRunnerCore):
         quant_info: AsymGemmMoeQuantInfo,
         running_state: dict,
     ) -> torch.Tensor:
-        from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_SM89
+        from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_NATIVE_FP8
 
-        if ASYMGEMM_SM89:
+        # SM89 (Ada) and SM90 (Hopper) share the native FP8 grouped-GEMM kernels;
+        # only Blackwell (SM100) uses the TMA/UMMA `*_nt_*` path below.
+        if ASYMGEMM_NATIVE_FP8:
             return self._run_contiguous_gemm_sm89(
                 runner_input, quant_info, running_state
             )
@@ -797,9 +799,11 @@ class AsymGemmRunnerCore(MoeRunnerCore):
         quant_info: AsymGemmMoeQuantInfo,
         running_state: dict,
     ) -> torch.Tensor:
-        from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_SM89
+        from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_NATIVE_FP8
 
-        if ASYMGEMM_SM89:
+        # SM89 (Ada) and SM90 (Hopper) share the native FP8 grouped-GEMM kernels;
+        # only Blackwell (SM100) uses the TMA/UMMA `*_nt_*` path below.
+        if ASYMGEMM_NATIVE_FP8:
             return self._run_masked_gemm_sm89(
                 runner_input, quant_info, running_state
             )
@@ -1121,11 +1125,12 @@ def _pre_permute_standard_to_asym_gemm_fp8(
     hidden_states_device = hidden_states.device
     hidden_states_ref = hidden_states
 
-    from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_SM89
+    from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_NATIVE_FP8
 
-    # SM89 uses per-token quantization (group_size=K) instead of per-token-group
+    # The native FP8 path (SM89/SM90) uses per-token quantization (group_size=K)
+    # instead of the per-token-group scales the SM100 `*_nt_*` kernels expect.
     K = hidden_states.shape[1]
-    act_block_shape = [1, K] if ASYMGEMM_SM89 else quant_info.block_shape
+    act_block_shape = [1, K] if ASYMGEMM_NATIVE_FP8 else quant_info.block_shape
 
     # PreReorder
     masked_m, expected_m, src2dst, hidden_states, hidden_states_scale = (
@@ -1136,7 +1141,7 @@ def _pre_permute_standard_to_asym_gemm_fp8(
             runner_config.top_k,
             act_block_shape,
             scale_ue8m0=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0
-            and not ASYMGEMM_SM89,
+            and not ASYMGEMM_NATIVE_FP8,
         )
     )
 

--- a/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
@@ -477,16 +477,15 @@ class AsymGemmRunnerCore(MoeRunnerCore):
             (all_tokens, N), device=hidden_states_device, dtype=torch.bfloat16,
         )
 
-        # Fuse per-token and per-expert scales into GEMM epilogue
-        asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_contig(
-            hidden_fp8,
-            quant_info.w13_weight,
+        # Per-token activation scale + per-expert weight scale, carried through the
+        # unified pair API; the library routes to the native FP8 kernel.
+        asym_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
+            (hidden_fp8, token_scale),
+            (quant_info.w13_weight, quant_info.w13_scale),
             gateup_output,
             offsets,
             experts,
             list_size_val,
-            scale_a_tensor=token_scale.view(-1).contiguous(),
-            scale_b_tensor=quant_info.w13_scale,
         )
         del hidden_fp8
         del token_scale
@@ -500,15 +499,13 @@ class AsymGemmRunnerCore(MoeRunnerCore):
             (all_tokens, K), device=hidden_states_device, dtype=torch.bfloat16,
         )
 
-        asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_contig(
-            down_input_fp8,
-            quant_info.w2_weight,
+        asym_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
+            (down_input_fp8, down_token_scale),
+            (quant_info.w2_weight, quant_info.w2_scale),
             down_output,
             offsets,
             experts,
             list_size_val,
-            scale_a_tensor=down_token_scale.view(-1).contiguous(),
-            scale_b_tensor=quant_info.w2_scale,
         )
         del down_input_fp8
         del down_token_scale
@@ -521,11 +518,10 @@ class AsymGemmRunnerCore(MoeRunnerCore):
         quant_info: AsymGemmMoeQuantInfo,
         running_state: dict,
     ) -> torch.Tensor:
-        from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_NATIVE_FP8
-
-        # SM89 (Ada) and SM90 (Hopper) share the native FP8 grouped-GEMM kernels;
-        # only Blackwell (SM100) uses the TMA/UMMA `*_nt_*` path below.
-        if ASYMGEMM_NATIVE_FP8:
+        # The library decides which FP8 kernel family the GPU uses; SGLang only
+        # branches on the resulting capability flag to prepare matching scales
+        # (per-token for the SM89/SM90 path, block/UE8M0 for the Blackwell path).
+        if not asym_gemm_wrapper.ASYMGEMM_BLACKWELL:
             return self._run_contiguous_gemm_sm89(
                 runner_input, quant_info, running_state
             )
@@ -692,14 +688,12 @@ class AsymGemmRunnerCore(MoeRunnerCore):
                 gc = gateup_chunk[:c]
 
                 sa_c = hidden_states_scale[g_start:g_end].reshape(c * m).contiguous()
-                asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_masked(
-                    hidden_states[g_start:g_end],
-                    w13_weight[g_start:g_end],
+                asym_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
+                    (hidden_states[g_start:g_end], sa_c),
+                    (w13_weight[g_start:g_end], w13_scale[g_start:g_end]),
                     gc,
                     masked_m_c,
                     expected_m,
-                    scale_a_tensor=sa_c,
-                    scale_b_tensor=w13_scale[g_start:g_end],
                 )
 
                 down_input_c, down_input_scale_c = _fused_silu_mul_fp8_quant(
@@ -716,14 +710,12 @@ class AsymGemmRunnerCore(MoeRunnerCore):
                     out_c = down_output[g_start:g_end]
 
                 down_sa_c = down_input_scale_c.reshape(c * m).contiguous()
-                asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_masked(
-                    down_input_c,
-                    w2_weight[g_start:g_end],
+                asym_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
+                    (down_input_c, down_sa_c),
+                    (w2_weight[g_start:g_end], w2_scale[g_start:g_end]),
                     out_c,
                     masked_m_c,
                     expected_m,
-                    scale_a_tensor=down_sa_c,
-                    scale_b_tensor=w2_scale[g_start:g_end],
                 )
                 del down_input_c, down_input_scale_c
 
@@ -751,16 +743,15 @@ class AsymGemmRunnerCore(MoeRunnerCore):
             (num_groups, m, n), device=hidden_states_device, dtype=torch.bfloat16
         )
 
-        # Fuse per-token and per-expert scales into the GEMM epilogue
+        # Per-token activation scale + per-expert weight scale through the unified
+        # pair API; the library routes to the native FP8 masked kernel.
         sa_flat = hidden_states_scale.view(num_groups * m).contiguous()
-        asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_masked(
-            hidden_states,
-            w13_weight,
+        asym_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
+            (hidden_states, sa_flat),
+            (w13_weight, w13_scale),
             gateup_output,
             masked_m,
             expected_m,
-            scale_a_tensor=sa_flat,
-            scale_b_tensor=w13_scale,
         )
         dispose_tensor(hidden_states)
         dispose_tensor(hidden_states_scale)
@@ -779,14 +770,12 @@ class AsymGemmRunnerCore(MoeRunnerCore):
         )
 
         down_sa_flat = down_input_scale.view(num_groups * m).contiguous()
-        asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_masked(
-            down_input_fp8,
-            w2_weight,
+        asym_gemm_wrapper.grouped_gemm_nt_f8f8bf16_masked(
+            (down_input_fp8, down_sa_flat),
+            (w2_weight, w2_scale),
             down_output,
             masked_m,
             expected_m,
-            scale_a_tensor=down_sa_flat,
-            scale_b_tensor=w2_scale,
         )
         del down_input_fp8
         del down_input_scale
@@ -799,16 +788,13 @@ class AsymGemmRunnerCore(MoeRunnerCore):
         quant_info: AsymGemmMoeQuantInfo,
         running_state: dict,
     ) -> torch.Tensor:
-        from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_NATIVE_FP8
-
-        # SM89 (Ada) and SM90 (Hopper) share the native FP8 grouped-GEMM kernels;
-        # only Blackwell (SM100) uses the TMA/UMMA `*_nt_*` path below.
-        if ASYMGEMM_NATIVE_FP8:
+        # The library decides which FP8 kernel family the GPU uses; SGLang only
+        # branches on the resulting capability flag to prepare matching scales.
+        if not asym_gemm_wrapper.ASYMGEMM_BLACKWELL:
             return self._run_masked_gemm_sm89(
                 runner_input, quant_info, running_state
             )
 
-        from sglang.srt.layers import asym_gemm_wrapper
         from sglang.srt.layers.moe.ep_moe.kernels import (
             silu_and_mul_masked_post_quant_fwd,
         )
@@ -1125,12 +1111,11 @@ def _pre_permute_standard_to_asym_gemm_fp8(
     hidden_states_device = hidden_states.device
     hidden_states_ref = hidden_states
 
-    from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_NATIVE_FP8
-
-    # The native FP8 path (SM89/SM90) uses per-token quantization (group_size=K)
-    # instead of the per-token-group scales the SM100 `*_nt_*` kernels expect.
+    # The SM89/SM90 path uses per-token quantization (group_size=K) instead of the
+    # per-token-group scales the Blackwell `*_nt_*` kernels expect.
+    blackwell = asym_gemm_wrapper.ASYMGEMM_BLACKWELL
     K = hidden_states.shape[1]
-    act_block_shape = [1, K] if ASYMGEMM_NATIVE_FP8 else quant_info.block_shape
+    act_block_shape = quant_info.block_shape if blackwell else [1, K]
 
     # PreReorder
     masked_m, expected_m, src2dst, hidden_states, hidden_states_scale = (
@@ -1140,8 +1125,7 @@ def _pre_permute_standard_to_asym_gemm_fp8(
             hidden_states,
             runner_config.top_k,
             act_block_shape,
-            scale_ue8m0=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0
-            and not ASYMGEMM_NATIVE_FP8,
+            scale_ue8m0=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0 and blackwell,
         )
     )
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1180,10 +1180,16 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer, quantize=not self.quant_config.is_checkpoint_fp8_serialized
             )
         elif self.runner.runner_backend.is_asym_gemm():
-            from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_SM89
+            from sglang.srt.layers.asym_gemm_wrapper.configurer import (
+                ASYMGEMM_NATIVE_FP8,
+            )
 
             weight_block_size = self.quant_config.weight_block_size
-            if ASYMGEMM_SM89:
+            if ASYMGEMM_NATIVE_FP8:
+                # SM89 (Ada) and SM90 (Hopper/H20) both use the native FP8
+                # grouped-GEMM kernels, which consume per-expert (per-tensor)
+                # FP8 weight scales. Requantize the block-scaled checkpoint
+                # weights accordingly; no UE8M0 cast.
                 requant_weight_per_expert_inplace(
                     layer.w13_weight,
                     layer.w13_weight_scale_inv,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1181,28 +1181,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
         elif self.runner.runner_backend.is_asym_gemm():
             from sglang.srt.layers.asym_gemm_wrapper.configurer import (
-                ASYMGEMM_NATIVE_FP8,
+                ASYMGEMM_BLACKWELL,
             )
 
             weight_block_size = self.quant_config.weight_block_size
-            if ASYMGEMM_NATIVE_FP8:
-                # SM89 (Ada) and SM90 (Hopper/H20) both use the native FP8
-                # grouped-GEMM kernels, which consume per-expert (per-tensor)
-                # FP8 weight scales. Requantize the block-scaled checkpoint
-                # weights accordingly; no UE8M0 cast.
-                requant_weight_per_expert_inplace(
-                    layer.w13_weight,
-                    layer.w13_weight_scale_inv,
-                    weight_block_size,
-                )
-                requant_weight_per_expert_inplace(
-                    layer.w2_weight,
-                    layer.w2_weight_scale_inv,
-                    weight_block_size,
-                )
-                layer.w13_weight_scale_inv.format_ue8m0 = False
-                layer.w2_weight_scale_inv.format_ue8m0 = False
-            else:
+            if ASYMGEMM_BLACKWELL:
                 requant_weight_ue8m0_inplace(
                     layer.w13_weight,
                     layer.w13_weight_scale_inv,
@@ -1215,6 +1198,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 )
                 layer.w13_weight_scale_inv.format_ue8m0 = True
                 layer.w2_weight_scale_inv.format_ue8m0 = True
+            else:
+                # Ada (SM89) and Hopper (SM90/H20) use the `*_sm89` FP8 grouped-GEMM
+                # kernels, which consume per-expert (per-tensor) FP8 weight scales.
+                # Requantize the block-scaled checkpoint weights accordingly; no
+                # UE8M0 cast.
+                requant_weight_per_expert_inplace(
+                    layer.w13_weight,
+                    layer.w13_weight_scale_inv,
+                    weight_block_size,
+                )
+                requant_weight_per_expert_inplace(
+                    layer.w2_weight,
+                    layer.w2_weight_scale_inv,
+                    weight_block_size,
+                )
+                layer.w13_weight_scale_inv.format_ue8m0 = False
+                layer.w2_weight_scale_inv.format_ue8m0 = False
             return
         else:
             # For fp8 moe run with deepgemm, the expert weights and scales need be requantized to ue8m0

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1971,6 +1971,16 @@ class ServerArgs:
                     logger.info(
                         "Use asym_gemm as MoE runner backend on SM89 for DeepseekV3ForCausalLM"
                     )
+            elif is_sm90_supported():
+                if (
+                    self.moe_a2a_backend == "none"
+                    and self.moe_runner_backend == "auto"
+                    and self.quantization in ["fp8", "modelopt_fp8"]
+                ):
+                    self.moe_runner_backend = "asym_gemm"
+                    logger.info(
+                        "Use asym_gemm as MoE runner backend on SM90 for DeepseekV3ForCausalLM"
+                    )
             elif is_hip():
                 if not self.enable_dp_attention and self.nnodes == 1:
                     # TODO (Hubert): Put this back later


### PR DESCRIPTION
This PR: 
1. simplifies the integration with AsymGemm by using new arch-agnostic API provided in AsymGemm. 
2. verified working with SM80/SM90/SM100, with new support of SM90. 

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->