### PR TITLE
[codex] Fix gateway Python readme metadata path

### DIFF
--- a/sgl-model-gateway/bindings/python/pyproject.toml
+++ b/sgl-model-gateway/bindings/python/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     {name = "Byron Hsu", email = "byronhsu1230@gmail.com"}
 ]
 requires-python = ">=3.8"
-readme = "../../README.md"
+readme = "README.md"
 license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
@@ -51,7 +51,7 @@ sglang-router = "sglang_router.cli:main"
 [tool.maturin]
 python-source = "src"
 module-name = "sglang_router.sglang_router_rs"
-# Exclude bindings/python/README.md to use root README only
+# Keep the README as package metadata, but do not include it in the wheel payload.
 exclude = ["README.md"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

- Point `sgl-model-gateway` Python package metadata at the local `README.md` instead of `../../README.md`.
- Update the stale maturin exclude comment to match the new metadata source.

## Root Cause

The development Docker image build installs the latest `maturin` (`1.14.0` in run 27399326877) and runs `maturin build` from `sgl-model-gateway/bindings/python`. `maturin` now rejects `project.readme` paths that resolve outside the metadata root, so `readme = "../../README.md"` fails before the gateway wheel can be built.

Failed run: https://github.com/bytedance-iaas/sglang/actions/runs/27399326877

## Validation

- `python3`/`tomllib` check: confirmed `project.readme == "README.md"` and that the file exists inside `sgl-model-gateway/bindings/python`.
- `git diff --check -- sgl-model-gateway/bindings/python/pyproject.toml`
- Attempted `maturin==1.14.0` metadata generation; it no longer reports the readme path error and instead stops because this local machine does not have `cargo` in `PATH`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->