### PR TITLE
[codex] Fix gateway Python README metadata path

### DIFF
--- a/sgl-model-gateway/bindings/python/pyproject.toml
+++ b/sgl-model-gateway/bindings/python/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     {name = "Byron Hsu", email = "byronhsu1230@gmail.com"}
 ]
 requires-python = ">=3.8"
-readme = "../../README.md"
+readme = "README.md"
 license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
@@ -51,7 +51,7 @@ sglang-router = "sglang_router.cli:main"
 [tool.maturin]
 python-source = "src"
 module-name = "sglang_router.sglang_router_rs"
-# Exclude bindings/python/README.md to use root README only
+# Keep the README as package metadata, but do not include it in the wheel payload.
 exclude = ["README.md"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

- Fix the gateway Python package metadata README path on `bytedance/deepseek_v4`.
- Point `project.readme` at `bindings/python/README.md` so `maturin>=1.14` no longer rejects a path outside the metadata root.
- Keep excluding the README from the wheel payload while still using it for package metadata.

## Root Cause

The DeepSeek V4 CUDA 13 nightly image build failed in run https://github.com/bytedance-iaas/sglang/actions/runs/27402365413 during the `gateway_builder` stage:

```text
maturin failed
Caused by: `project.readme` path `../../README.md` resolves outside allowed metadata root `/build/sgl-model-gateway/bindings/python`
```

That workflow used the latest workflow from `ep_main`, but checked out `bytedance/deepseek_v4` for the Docker build. The target branch still had `readme = "../../README.md"`, while the Dockerfile only copies `sgl-model-gateway` into `/build/sgl-model-gateway` before running `maturin build` from `bindings/python`.

## Validation

```bash
git diff --check
/tmp/sglang-maturin-verify/bin/maturin --version
CARGO_HOME=/tmp/sglang-cargo-verify RUSTUP_HOME=/tmp/sglang-rustup-verify PATH="/tmp/sglang-cargo-verify/bin:$PATH" /tmp/sglang-maturin-verify/bin/maturin pep517 write-dist-info --metadata-directory /tmp/sglang-gateway-dist-info --features vendored-openssl
```

Result: `maturin 1.14.0` successfully generated `sglang_router-0.3.2.dist-info`, including `METADATA`, `WHEEL`, and `entry_points.txt`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->