### PR TITLE
[codex] Harden just install in Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -416,9 +416,19 @@ RUN CMAKE_VERSION=3.31.1 \
     && mkdir -p /tools/share && cp -r "/tmp/${CMAKE_INSTALLER}/share/"* /tools/share/ \
     && rm -rf "/tmp/${CMAKE_INSTALLER}" "/tmp/${CMAKE_INSTALLER}.tar.gz"
 
-RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://just.systems/install.sh | \
-    sed "s|https://github.com|https://${GITHUB_ARTIFACTORY}|g" | \
-    bash -s -- --tag 1.42.4 --to /tools
+RUN JUST_VERSION=1.42.4 \
+    && case "$(uname -m)" in \
+        x86_64) JUST_TARGET=x86_64-unknown-linux-musl ;; \
+        aarch64) JUST_TARGET=aarch64-unknown-linux-musl ;; \
+        *) echo "Unsupported architecture for just: $(uname -m)" && exit 1 ;; \
+    esac \
+    && curl --proto '=https' --tlsv1.2 --retry 5 --retry-all-errors --retry-delay 2 -fsSL \
+        -o /tmp/just.tar.gz \
+        "https://${GITHUB_ARTIFACTORY}/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_TARGET}.tar.gz" \
+    && tar -xzf /tmp/just.tar.gz -C /tools just \
+    && chmod +x /tools/just \
+    && /tools/just --version \
+    && rm -f /tmp/just.tar.gz
 
 # Install oh-my-zsh and plugins
 RUN sh -c "$(curl --retry 3 --retry-delay 2 -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended \


### PR DESCRIPTION
## Summary
- replace the just.systems installer pipe with a fixed GitHub release tarball download through GITHUB_ARTIFACTORY
- add architecture mapping for Linux x86_64/aarch64 and run /tools/just --version in the Docker layer
- use retry-all-errors so transient 5xx responses fail accurately instead of surfacing later as missing /tools/just

## Root cause
Run 27503692568 failed after the README metadata fix because https://just.systems/install.sh returned HTTP 504 in devtools_builder. The installer was in a pipe, so the layer continued without creating /tools/just, and the later framework stage failed at COPY --from=devtools_builder /tools/just /usr/local/bin/.

## Verification
- git diff --check
- locally exercised the new download/extract path for just 1.42.4 and confirmed: just 1.42.4

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->