### PR TITLE
[codex] Harden rustup install in Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -195,8 +195,11 @@ WORKDIR /sgl-workspace
 # Rust toolchain for setuptools-rust extensions (e.g. sglang-grpc).
 # Requires >= 1.85 (edition 2024). Inherited by framework via FROM torch_deps.
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --no-modify-path --profile minimal \
+RUN curl --proto '=https' --tlsv1.2 --fail --show-error --location \
+        --retry 5 --retry-all-errors --retry-delay 2 \
+        -o /tmp/rustup-init.sh https://sh.rustup.rs \
+    && sh /tmp/rustup-init.sh -y --no-modify-path --profile minimal \
+    && rm /tmp/rustup-init.sh \
     && rustc --version && cargo --version
 
 # Install sgl-kernel (from pre-built wheel)
@@ -454,7 +457,11 @@ COPY sgl-model-gateway /build/sgl-model-gateway
 
 # Install Rust, build gateway binary and Python bindings, then clean up Rust toolchain
 RUN --mount=type=cache,target=/root/.cache/pip \
-    curl --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    curl --proto '=https' --tlsv1.2 --fail --show-error --location \
+        --retry 5 --retry-all-errors --retry-delay 2 \
+        -o /tmp/rustup-init.sh https://sh.rustup.rs \
+    && sh /tmp/rustup-init.sh -y \
+    && rm /tmp/rustup-init.sh \
     && export PATH="/root/.cargo/bin:${PATH}" \
     && python3 -m pip install maturin \
     && cd /build/sgl-model-gateway/bindings/python \


### PR DESCRIPTION
## Summary
- harden rustup installer downloads in `torch_deps` and `gateway_builder`
- avoid streaming `https://sh.rustup.rs` directly into `sh`
- match the more resilient `ep_main` pattern with `--location`, `--retry 5`, and `--retry-all-errors`

## Context
Run https://github.com/bytedance-iaas/sglang/actions/runs/27509944863 failed while building `bytedance/deepseek_v4@b28267a1ad9702bba792bfccdb024d4471248d8f`:

```text
curl: (22) The requested URL returned error: 504
/bin/sh: 1: rustc: not found
```

The branch still used `curl ... https://sh.rustup.rs | sh ...`, so a transient 504 left Rust uninstalled and surfaced as `rustc: not found`.

## Verification
- `git diff --check`
- confirmed no remaining `sh.rustup.rs | sh` rustup install path in `docker/Dockerfile`
- downloaded `https://sh.rustup.rs` locally with the new curl flags and verified the script was non-empty

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->