### PR TITLE
[codex] Harden get-pip download in Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,9 @@ RUN --mount=type=cache,target=/var/cache/apt,id=base-apt \
     && apt install -y --no-install-recommends python3.12-full python3.12-dev \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 \
     && update-alternatives --set python3 /usr/bin/python3.12 \
-    && wget -q https://bootstrap.pypa.io/get-pip.py \
+    && curl --proto '=https' --tlsv1.2 --fail --show-error --location \
+        --retry 5 --retry-all-errors --retry-delay 2 \
+        -o get-pip.py https://bootstrap.pypa.io/get-pip.py \
     && python3 get-pip.py --break-system-packages \
     && rm get-pip.py \
     # Allow pip to install packages globally (PEP 668 workaround for Ubuntu 24.04)
@@ -814,7 +816,9 @@ RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 \
     && update-alternatives --set python3 /usr/bin/python3.12 \
     && ln -sf /usr/bin/python3.12 /usr/bin/python \
-    && wget -q https://bootstrap.pypa.io/get-pip.py \
+    && curl --proto '=https' --tlsv1.2 --fail --show-error --location \
+        --retry 5 --retry-all-errors --retry-delay 2 \
+        -o get-pip.py https://bootstrap.pypa.io/get-pip.py \
     && python3 get-pip.py --break-system-packages \
     && rm get-pip.py \
     # Allow pip to install packages globally (PEP 668 workaround for Ubuntu 24.04)


### PR DESCRIPTION
## Summary
- replace quiet `wget` downloads of `get-pip.py` with retrying `curl` downloads
- cover both Python setup locations in `docker/Dockerfile`
- keep the existing `python3 get-pip.py --break-system-packages` behavior unchanged

## Context
Run https://github.com/bytedance-iaas/sglang/actions/runs/27536228375/job/81388230028 failed while building `bytedance/deepseek_v4@34e13430a7049144e41d397f45be97409eae3f76`:

```text
Dockerfile:50
&& wget -q https://bootstrap.pypa.io/get-pip.py \
... did not complete successfully: exit code: 4
```

`wget -q` hides the concrete network error and has no retry behavior. This mirrors the previous external-download failures in the nightly image build path.

## Verification
- `git diff --check`
- confirmed no remaining `wget -q https://bootstrap.pypa.io/get-pip.py` in `docker/Dockerfile`
- downloaded `https://bootstrap.pypa.io/get-pip.py` locally with the new curl flags and verified the script was non-empty

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->