### PR TITLE
[codex] Avoid comma proxy values in BuildKit driver opts

### DIFF
--- a/sgl-kernel/build.sh
+++ b/sgl-kernel/build.sh
@@ -29,16 +29,21 @@ BUILDER_PROXY_CONFIG="${CACHE_DIR}/buildx-proxy.env"
 
 PROXY_DRIVER_OPTS=()
 PROXY_BUILD_ARGS=()
-PROXY_CONFIG_LINES=()
+PROXY_DRIVER_CONFIG_LINES=()
+
 for PROXY_ENV_NAME in HTTP_PROXY HTTPS_PROXY NO_PROXY ALL_PROXY http_proxy https_proxy no_proxy all_proxy; do
   PROXY_ENV_VALUE="${!PROXY_ENV_NAME:-}"
   if [ -n "${PROXY_ENV_VALUE}" ]; then
-    PROXY_DRIVER_OPTS+=(--driver-opt "env.${PROXY_ENV_NAME}=${PROXY_ENV_VALUE}")
+    if [[ "${PROXY_ENV_VALUE}" != *","* ]]; then
+      PROXY_DRIVER_OPTS+=(--driver-opt "env.${PROXY_ENV_NAME}=${PROXY_ENV_VALUE}")
+      PROXY_DRIVER_CONFIG_LINES+=("${PROXY_ENV_NAME}=${PROXY_ENV_VALUE}")
+    else
+      echo "Skipping buildx driver env ${PROXY_ENV_NAME}: buildx --driver-opt cannot parse comma-separated values"
+    fi
     PROXY_BUILD_ARGS+=(--build-arg "${PROXY_ENV_NAME}=${PROXY_ENV_VALUE}")
-    PROXY_CONFIG_LINES+=("${PROXY_ENV_NAME}=${PROXY_ENV_VALUE}")
   fi
 done
-CURRENT_PROXY_CONFIG="$(printf "%s\n" "${PROXY_CONFIG_LINES[@]}")"
+CURRENT_PROXY_CONFIG="$(printf "%s\n" "${PROXY_DRIVER_CONFIG_LINES[@]}")"
 
 # RESET_BUILDER=1 removes and recreates the builder to clear corrupted internal
 # state (e.g. stale containerd snapshots from base image layer GC).


### PR DESCRIPTION
## Summary
- avoid passing comma-separated proxy values such as `NO_PROXY` into `docker buildx create --driver-opt`
- keep `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` in the BuildKit driver environment
- keep the full proxy set, including `NO_PROXY`, as Docker build args for Dockerfile `RUN` steps

## Context
Run https://github.com/bytedance-iaas/sglang/actions/runs/27550433320 failed after #589 was merged. The target commit included the BuildKit proxy change, but builder creation failed before the Docker build started:

```text
docker buildx create ... --driver-opt env.NO_PROXY=localhost,127.0.0.1,...
ERROR: invalid value "127.0.0.1", expecting k=v
```

`buildx --driver-opt` parses values as comma-separated driver options, so comma-separated `NO_PROXY` values cannot be passed there directly.

## Verification
- `bash -n sgl-kernel/build.sh`
- `git diff --check`
- mock-ran `sgl-kernel/build.sh` with proxy env and verified:
  - `docker buildx create` includes `env.HTTP_PROXY`, `env.HTTPS_PROXY`, and `env.ALL_PROXY`
  - comma-separated `NO_PROXY`/`no_proxy` are skipped for `--driver-opt`
  - full `NO_PROXY`/`no_proxy` are still passed as `docker buildx build --build-arg`
- checked real `docker buildx create` parsing with only non-comma driver opts; it passed option parsing and only failed locally at Docker daemon permission access

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->