### PR TITLE
ci: publish release docker variants for byted tags

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -4,6 +4,7 @@ name: Release Docker Images
 #   - v{sglang}.byted.{internal_release}.{timestamp} (CUDA 13)
 #   - v{sglang}.byted.{internal_release}.{timestamp}-cu130
 #   - v{sglang}.byted.{internal_release}.{timestamp}-cu129
+#   - v{sglang}.byted.{internal_release}.{timestamp}-{sbo,w4a8}[-cu130|-cu129]
 #
 on:
   push:
@@ -118,10 +119,44 @@ jobs:
             cuda_version: 12.9.1
             cuda_suffix: cu129
             publish_default_cuda_alias: false
+            hopper_sbo: 0
+            w4a8_per_tensor_transfer: 0
+            variant_suffix: ""
+          - cuda_key: cu129
+            cuda_version: 12.9.1
+            cuda_suffix: cu129
+            publish_default_cuda_alias: false
+            hopper_sbo: 1
+            w4a8_per_tensor_transfer: 0
+            variant_suffix: sbo
+          - cuda_key: cu129
+            cuda_version: 12.9.1
+            cuda_suffix: cu129
+            publish_default_cuda_alias: false
+            hopper_sbo: 0
+            w4a8_per_tensor_transfer: 1
+            variant_suffix: w4a8
           - cuda_key: cu130
             cuda_version: 13.0.1
             cuda_suffix: cu130
             publish_default_cuda_alias: true
+            hopper_sbo: 0
+            w4a8_per_tensor_transfer: 0
+            variant_suffix: ""
+          - cuda_key: cu130
+            cuda_version: 13.0.1
+            cuda_suffix: cu130
+            publish_default_cuda_alias: true
+            hopper_sbo: 1
+            w4a8_per_tensor_transfer: 0
+            variant_suffix: sbo
+          - cuda_key: cu130
+            cuda_version: 13.0.1
+            cuda_suffix: cu130
+            publish_default_cuda_alias: true
+            hopper_sbo: 0
+            w4a8_per_tensor_transfer: 1
+            variant_suffix: w4a8
     uses: ./.github/workflows/_docker-build-and-publish.yml
     with:
       docker_target: framework_final
@@ -129,6 +164,7 @@ jobs:
       cuda_version: ${{ matrix.cuda_version }}
       cuda_suffix: ${{ matrix.cuda_suffix }}
       publish_default_cuda_alias: ${{ matrix.publish_default_cuda_alias }}
+      variant_suffix: ${{ matrix.variant_suffix }}
       sgl_version: ${{ needs.resolve-volcengine-release.outputs.community-version }}
       tag_mode: version
       tag_value: ${{ needs.resolve-volcengine-release.outputs.internal-version }}
@@ -137,6 +173,8 @@ jobs:
         --build-arg HTTP_PROXY=http://100.68.162.211:3128
         --build-arg HTTPS_PROXY=http://100.68.162.211:3128
         --build-arg ALL_PROXY=http://100.68.162.211:3128
+        --build-arg HOPPER_SBO=${{ matrix.hopper_sbo }}
+        --build-arg W4A8_PER_TENSOR_TRANSFER=${{ matrix.w4a8_per_tensor_transfer }}
         --build-arg NO_PROXY=localhost,127.0.0.1,::1,mirrors.ivolces.com,.ivolces.com,.volceapi.com,.byted.org,eic-sdk-release.tos-cn-beijing.ivolces.com,scqq9isgq31i0fb8nt4eg.apigateway-cn-beijing.volceapi.com,bytedpypi.byted.org,mirrors.byted.org,iaas-gpu-cn-beijing.cr.volces.com
         --build-arg BYTED_INTERNAL_EXTRA_TOOLS_APT_URL=${{ vars.BYTED_INTERNAL_EXTRA_TOOLS_APT_URL || 'http://mirrors.ivolces.com/extra-tools/ubuntu' }}
         --build-arg BYTED_INTERNAL_EXTRA_TOOLS_GPG_URL=${{ vars.BYTED_INTERNAL_EXTRA_TOOLS_GPG_URL || 'https://mirrors.ivolces.com/extra-tools/ubuntu/GPG-KEY-system' }}


### PR DESCRIPTION
## Summary
- expand the Byted Volcengine release Docker matrix from normal-only CUDA builds to normal/sbo/w4a8 variants for both cu129 and cu130
- pass variant_suffix into the shared image-tag resolver so tag-triggered releases publish variant tags
- pass HOPPER_SBO and W4A8_PER_TENSOR_TRANSFER build args for release builds, matching the manual dev build variants

## Expected tag-triggered outputs
For internal version 0.0.11, tag pushes now expand to six build jobs:
- cu129 normal -> v{community}.byted.0.0.11.{timestamp}-cu129
- cu129 sbo -> v{community}.byted.0.0.11.{timestamp}-sbo-cu129
- cu129 w4a8 -> v{community}.byted.0.0.11.{timestamp}-w4a8-cu129
- cu130 normal -> v{community}.byted.0.0.11.{timestamp} and -cu130
- cu130 sbo -> v{community}.byted.0.0.11.{timestamp}-sbo and -sbo-cu130
- cu130 w4a8 -> v{community}.byted.0.0.11.{timestamp}-w4a8 and -w4a8-cu130

## Validation
- python3 yaml.safe_load(.github/workflows/release-docker.yml)
- git diff --check
- parsed build-and-publish-volcengine matrix contains 6 entries: cu129/cu130 x normal/sbo/w4a8
- generated sample tags with scripts/ci/get_volcengine_image_tag.py for normal, sbo, and w4a8 CUDA suffix combinations

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->