### PR TITLE
Using architecture-agnostic APIs in sglang asym_gemm MoE backend

### DIFF
--- a/python/sglang/srt/layers/asym_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/compile_utils.py
@@ -13,7 +13,10 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     restore_symmetric_memory_context,
 )
 from sglang.srt.environ import envs
-from sglang.srt.layers.asym_gemm_wrapper.configurer import ENABLE_JIT_ASYMGEMM
+from sglang.srt.layers.asym_gemm_wrapper.configurer import (
+    ASYMGEMM_BLACKWELL,
+    ENABLE_JIT_ASYMGEMM,
+)
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import ceil_div, get_available_gpu_memory
 
@@ -272,18 +275,36 @@ class _GroupedContWarmupExecutor(_BaseWarmupExecutor):
         self.rhs_q, self.rhs_s = _empty_block_fp8((num_groups, n, k))
         self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
         # Single-expert offsets/experts list: all m rows belong to expert 0.
-        self.offsets = torch.empty((1,), device="cuda", dtype=torch.int32)
-        self.experts = torch.zeros((1,), device="cuda", dtype=torch.int32)
+        # The two backends use different ABIs (see the runner's pre-permute):
+        #   SM89/SM90: offsets = [end], experts = [0], list_size = host int 1.
+        #   Blackwell: offsets = [start, end] pair, experts = [0, -1] (sentinel-
+        #     terminated), list_size = 1-element int32 CUDA tensor counting the
+        #     experts entries including the sentinel (2).
+        if ASYMGEMM_BLACKWELL:
+            self.offsets = torch.empty((2,), device="cuda", dtype=torch.int32)
+            self.experts = torch.tensor(
+                [0, -1], device="cuda", dtype=torch.int32
+            )
+            self.list_size = torch.tensor([2], device="cuda", dtype=torch.int32)
+        else:
+            self.offsets = torch.empty((1,), device="cuda", dtype=torch.int32)
+            self.experts = torch.zeros((1,), device="cuda", dtype=torch.int32)
+            self.list_size = 1
 
     def execute(self, m):
-        self.offsets.fill_(m)
+        if ASYMGEMM_BLACKWELL:
+            self.offsets.copy_(
+                torch.tensor([0, m], device="cuda", dtype=torch.int32)
+            )
+        else:
+            self.offsets.fill_(m)
         asym_gemm.m_grouped_fp8_asym_gemm_nt_contiguous(
             (self.lhs_q[:m], self.lhs_s[:m]),
             (self.rhs_q, self.rhs_s),
             self.out[:m],
             self.offsets,
             self.experts,
-            1,
+            self.list_size,
         )
 
 

--- a/python/sglang/srt/layers/asym_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/compile_utils.py
@@ -270,15 +270,20 @@ class _GroupedContWarmupExecutor(_BaseWarmupExecutor):
     def __init__(self, max_m: int, n: int, k: int, num_groups: int):
         self.lhs_q, self.lhs_s = _empty_token_fp8((max_m, k))
         self.rhs_q, self.rhs_s = _empty_block_fp8((num_groups, n, k))
-        self.m_indices = torch.zeros((max_m,), device="cuda", dtype=torch.int32)
         self.out = torch.empty((max_m, n), device="cuda", dtype=torch.bfloat16)
+        # Single-expert offsets/experts list: all m rows belong to expert 0.
+        self.offsets = torch.empty((1,), device="cuda", dtype=torch.int32)
+        self.experts = torch.zeros((1,), device="cuda", dtype=torch.int32)
 
     def execute(self, m):
+        self.offsets.fill_(m)
         asym_gemm.m_grouped_fp8_asym_gemm_nt_contiguous(
             (self.lhs_q[:m], self.lhs_s[:m]),
             (self.rhs_q, self.rhs_s),
             self.out[:m],
-            m_indices=self.m_indices[:m],
+            self.offsets,
+            self.experts,
+            1,
         )
 
 

--- a/python/sglang/srt/layers/asym_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/configurer.py
@@ -1,8 +1,7 @@
 import logging
-import os
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import get_device_sm, is_blackwell_supported, is_sm89_supported
+from sglang.srt.utils import get_device_sm, is_blackwell_supported
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +21,9 @@ def _compute_enable_asym_gemm():
 
 ENABLE_JIT_ASYMGEMM = _compute_enable_asym_gemm()
 
+# The only architecture distinction sglang needs: Blackwell packs scales as
+# UE8M0. Kernel selection (SM89/SM90 vs Blackwell) happens inside AsymGEMM's
+# dispatch based on the actual GPU; all archs consume 1x128 / 128x128 block
+# scales.
 ASYMGEMM_BLACKWELL = ENABLE_JIT_ASYMGEMM and is_blackwell_supported()
 ASYMGEMM_SCALE_UE8M0 = ASYMGEMM_BLACKWELL
-ASYMGEMM_SM89 = ENABLE_JIT_ASYMGEMM and (
-    (is_sm89_supported() and not ASYMGEMM_BLACKWELL)
-    or os.environ.get("SGLANG_ASYMGEMM_SM89", "0") == "1"
-)

--- a/python/sglang/srt/layers/asym_gemm_wrapper/entrypoint.py
+++ b/python/sglang/srt/layers/asym_gemm_wrapper/entrypoint.py
@@ -8,7 +8,6 @@ from sglang.srt.layers.asym_gemm_wrapper import compile_utils
 from sglang.srt.layers.asym_gemm_wrapper.configurer import (  # noqa: F401
     ASYMGEMM_BLACKWELL,
     ASYMGEMM_SCALE_UE8M0,
-    ASYMGEMM_SM89,
     ENABLE_JIT_ASYMGEMM,
 )
 from sglang.srt.server_args import ServerArgs
@@ -140,43 +139,6 @@ def grouped_gemm_nt_fp4fp4bf16_contig(
             recipe=recipe if recipe is not None else _FP4_RECIPE,
             disable_ue8m0_cast=True,
         )
-
-
-def grouped_gemm_sm89_f8f8bf16_contig(
-    a: torch.Tensor,
-    b: torch.Tensor,
-    out: torch.Tensor,
-    offsets: torch.Tensor,
-    experts: torch.Tensor,
-    list_size: int,
-    scale_a: float = 1.0,
-    scale_b: float = 1.0,
-    scale_a_tensor: Optional[torch.Tensor] = None,
-    scale_b_tensor: Optional[torch.Tensor] = None,
-):
-    asym_gemm.m_grouped_fp8_asym_gemm_sm89(
-        a, b, out, offsets, experts, list_size,
-        scale_a=scale_a, scale_b=scale_b,
-        scale_a_tensor=scale_a_tensor, scale_b_tensor=scale_b_tensor,
-    )
-
-
-def grouped_gemm_sm89_f8f8bf16_masked(
-    a: torch.Tensor,
-    b: torch.Tensor,
-    out: torch.Tensor,
-    masked_m: torch.Tensor,
-    expected_m: int,
-    scale_a: float = 1.0,
-    scale_b: float = 1.0,
-    scale_a_tensor: Optional[torch.Tensor] = None,
-    scale_b_tensor: Optional[torch.Tensor] = None,
-):
-    asym_gemm.m_grouped_fp8_asym_gemm_sm89_masked(
-        a, b, out, masked_m, expected_m,
-        scale_a=scale_a, scale_b=scale_b,
-        scale_a_tensor=scale_a_tensor, scale_b_tensor=scale_b_tensor,
-    )
 
 
 def grouped_gemm_nt_bf16bf16bf16_masked(

--- a/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
@@ -1280,20 +1280,40 @@ def _pre_permute_deepep_normal_to_asym_gemm_fp8(
     running_state["output_index"] = output_index
 
     # Build the contiguous-GEMM expert list host-side from the dispatcher's CPU
-    # token counts: no device sync, and list_size stays a host int (the SM89/
-    # SM90 kernel needs it for grid sizing). Layout: experts = active expert
-    # ids, offsets = cumulative end-row indices (SM89/SM90 kernel format; the
-    # Blackwell contiguous kernel expects start/end pairs instead and would
-    # need its own builder).
-    ends, active_experts = [], []
+    # token counts so there is no device sync. The two backends use different
+    # offsets/list_size ABIs, so emit the format the target kernel expects:
+    #
+    #   SM89/SM90: offsets = cumulative end-row indices, experts = active expert
+    #     ids, list_size = a host int (the kernel reads it for grid sizing).
+    #   Blackwell: offsets = flat (start, end) row pairs, experts = active ids
+    #     terminated by a -1 sentinel, list_size = a 1-element int32 CUDA tensor
+    #     counting the experts entries *including* the sentinel. This mirrors
+    #     AsymGEMM's canonical build_offsets_experts_from_m_indices.
+    offsets_list, active_experts = [], []
     acc = 0
     for expert_id, cnt in enumerate(num_recv_tokens_per_expert):
+        start = acc
         acc += cnt
         if cnt == 0:
             continue
         active_experts.append(expert_id)
-        ends.append(acc)
-    offsets = torch.tensor(ends, dtype=torch.int32, device=hidden_states_device)
+        if asym_gemm_wrapper.ASYMGEMM_BLACKWELL:
+            offsets_list.append(start)
+            offsets_list.append(acc)
+        else:
+            offsets_list.append(acc)
+
+    if asym_gemm_wrapper.ASYMGEMM_BLACKWELL:
+        active_experts.append(-1)  # sentinel terminating the experts list
+        list_size = torch.tensor(
+            [len(active_experts)], dtype=torch.int32, device=hidden_states_device
+        )
+    else:
+        list_size = len(active_experts)
+
+    offsets = torch.tensor(
+        offsets_list, dtype=torch.int32, device=hidden_states_device
+    )
     experts = torch.tensor(
         active_experts, dtype=torch.int32, device=hidden_states_device
     )
@@ -1305,7 +1325,7 @@ def _pre_permute_deepep_normal_to_asym_gemm_fp8(
         m_indices=m_indices,
         offsets=offsets,
         experts=experts,
-        list_size=len(active_experts),
+        list_size=list_size,
     )
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/asym_gemm.py
@@ -139,69 +139,6 @@ def _scatter_chunk_to_output(
     )
 
 
-@triton.jit
-def _fused_silu_mul_fp8_quant_kernel(
-    gateup_ptr,
-    out_fp8_ptr,
-    out_scale_ptr,
-    stride_gateup_m,
-    stride_out_m,
-    HALF_N: tl.constexpr,
-    FP8_MAX: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-):
-    row = tl.program_id(0).to(tl.int64)
-    gateup_row = gateup_ptr + row * stride_gateup_m
-    out_row = out_fp8_ptr + row * stride_out_m
-
-    amax = tl.zeros([BLOCK_K], dtype=tl.float32)
-    for start_k in tl.range(0, HALF_N, BLOCK_K):
-        k_offs = start_k + tl.arange(0, BLOCK_K)
-        mask = k_offs < HALF_N
-        gate = tl.load(gateup_row + k_offs, mask=mask, other=0.0).to(tl.float32)
-        up = tl.load(gateup_row + HALF_N + k_offs, mask=mask, other=0.0).to(tl.float32)
-        act = (gate * tl.sigmoid(gate)) * up
-        amax = tl.maximum(amax, tl.where(mask, tl.abs(act), 0.0))
-
-    row_max = tl.max(amax)
-    scale = row_max / FP8_MAX
-    scale = tl.where(scale > 0, scale, 1.0)
-    tl.store(out_scale_ptr + row, scale)
-
-    for start_k in tl.range(0, HALF_N, BLOCK_K):
-        k_offs = start_k + tl.arange(0, BLOCK_K)
-        mask = k_offs < HALF_N
-        gate = tl.load(gateup_row + k_offs, mask=mask, other=0.0).to(tl.float32)
-        up = tl.load(gateup_row + HALF_N + k_offs, mask=mask, other=0.0).to(tl.float32)
-        act = (gate * tl.sigmoid(gate)) * up
-        quantized = tl.clamp(act / scale, -FP8_MAX, FP8_MAX)
-        tl.store(out_row + k_offs, quantized.to(tl.float8e4nv), mask=mask)
-
-
-def _fused_silu_mul_fp8_quant(
-    gateup: torch.Tensor,
-) -> tuple:
-    """Fused SiLU+Mul+FP8Quant: [M, N] bf16 → [M, N//2] fp8 + [M, 1] scale."""
-    M = gateup.shape[0]
-    N = gateup.shape[1]
-    half_n = N // 2
-
-    out_fp8 = torch.empty((M, half_n), device=gateup.device, dtype=torch.float8_e4m3fn)
-    out_scale = torch.empty((M, 1), device=gateup.device, dtype=torch.float32)
-
-    _fused_silu_mul_fp8_quant_kernel[(M,)](
-        gateup,
-        out_fp8,
-        out_scale,
-        gateup.stride(0),
-        out_fp8.stride(0),
-        HALF_N=half_n,
-        FP8_MAX=448.0,
-        BLOCK_K=min(1024, triton.next_power_of_2(half_n)),
-    )
-    return out_fp8, out_scale
-
-
 # TODO(kaixih@nvidia): ideally we should merge this logic into
 # `fill_gateup_input_triton_kernel` to directly generate e8m0 scale.
 @torch.compile(disable=_is_hip or _is_npu)
@@ -328,28 +265,6 @@ def build_offsets_experts_from_masked_m(
     return offsets_fixed, experts_fixed, list_size
 
 
-def _expand_expert_scale_to_tokens(
-    expert_scale: torch.Tensor,
-    offsets: torch.Tensor,
-    experts: torch.Tensor,
-    list_size: int,
-    total_tokens: int,
-) -> torch.Tensor:
-    """Expand [num_experts] per-expert scales to [total_tokens, 1] per-token scales.
-
-    Uses offsets/experts from the contiguous MoE layout to map each token
-    to its serving expert's scale.
-    """
-    result = torch.empty(total_tokens, 1, dtype=torch.float32, device=expert_scale.device)
-    prev = 0
-    for i in range(list_size):
-        end = offsets[i].item()
-        eid = experts[i].item()
-        result[prev:end, 0] = expert_scale[eid]
-        prev = end
-    return result
-
-
 @dataclass
 class AsymGemmRunnerInput(RunnerInput):
     hidden_states: torch.Tensor
@@ -360,7 +275,9 @@ class AsymGemmRunnerInput(RunnerInput):
     m_indices: Optional[torch.Tensor] = None
     offsets: Optional[torch.Tensor] = None
     experts: Optional[torch.Tensor] = None
-    list_size: Optional[torch.Tensor] = None
+    # Host int (preferred — no sync, the SM89/SM90 kernel needs a host value
+    # for grid sizing) or a 1-element int32 tensor (Blackwell contiguous).
+    list_size: Optional[Any] = None
 
     @property
     def runner_backend(self) -> MoeRunnerBackend:
@@ -436,99 +353,12 @@ class AsymGemmRunnerCore(MoeRunnerCore):
             )
         return AsymGemmRunnerOutput(hidden_states=hidden_states)
 
-    def _run_contiguous_gemm_sm89(
-        self,
-        runner_input: AsymGemmRunnerInput,
-        quant_info: AsymGemmMoeQuantInfo,
-        running_state: dict,
-    ) -> torch.Tensor:
-        from sglang.srt.layers.quantization.fp8_kernel import (
-            sglang_per_token_group_quant_fp8,
-        )
-
-        hidden_states = runner_input.hidden_states
-        hidden_states_scale = runner_input.hidden_states_scale
-        all_tokens = running_state["all_tokens"]
-        hidden_states_device = running_state["hidden_states_device"]
-        hidden_states_shape = running_state["hidden_states_shape"]
-
-        N = quant_info.w13_weight.size(1)
-        K = hidden_states_shape[1]
-
-        offsets = runner_input.offsets
-        experts = runner_input.experts
-        list_size_val = int(runner_input.list_size.item())
-
-        # Activations arrive with per-token-group scales from DeepEP.
-        # Dequant to BF16, then requant per-token for SM89.
-        from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
-
-        hidden_bf16 = block_quant_dequant(
-            hidden_states, hidden_states_scale, [1, 128], torch.bfloat16
-        )
-        dispose_tensor(hidden_states)
-        dispose_tensor(hidden_states_scale)
-
-        hidden_fp8, token_scale = sglang_per_token_group_quant_fp8(hidden_bf16, K)
-        del hidden_bf16
-
-        # ── GEMM-0: gateup projection ────────────────────────────────
-        gateup_output = torch.empty(
-            (all_tokens, N), device=hidden_states_device, dtype=torch.bfloat16,
-        )
-
-        # Fuse per-token and per-expert scales into GEMM epilogue
-        asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_contig(
-            hidden_fp8,
-            quant_info.w13_weight,
-            gateup_output,
-            offsets,
-            experts,
-            list_size_val,
-            scale_a_tensor=token_scale.view(-1).contiguous(),
-            scale_b_tensor=quant_info.w13_scale,
-        )
-        del hidden_fp8
-        del token_scale
-
-        # ── Fused SiLU + Mul + FP8 Quant ─────────────────────────────
-        down_input_fp8, down_token_scale = _fused_silu_mul_fp8_quant(gateup_output)
-        del gateup_output
-
-        # ── GEMM-1: down projection ──────────────────────────────────
-        down_output = torch.empty(
-            (all_tokens, K), device=hidden_states_device, dtype=torch.bfloat16,
-        )
-
-        asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_contig(
-            down_input_fp8,
-            quant_info.w2_weight,
-            down_output,
-            offsets,
-            experts,
-            list_size_val,
-            scale_a_tensor=down_token_scale.view(-1).contiguous(),
-            scale_b_tensor=quant_info.w2_scale,
-        )
-        del down_input_fp8
-        del down_token_scale
-
-        return down_output
-
     def _run_contiguous_gemm(
         self,
         runner_input: AsymGemmRunnerInput,
         quant_info: AsymGemmMoeQuantInfo,
         running_state: dict,
     ) -> torch.Tensor:
-        from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_SM89
-
-        if ASYMGEMM_SM89:
-            return self._run_contiguous_gemm_sm89(
-                runner_input, quant_info, running_state
-            )
-
-        from sglang.srt.layers.moe.ep_moe.kernels import tma_align_input_scale
         from sglang.srt.layers.quantization.fp8_kernel import (
             sglang_per_token_group_quant_fp8,
         )
@@ -561,8 +391,8 @@ class AsymGemmRunnerCore(MoeRunnerCore):
                 hidden_states, hidden_states_scale = _rescale_fp8_for_ue8m0(
                     hidden_states, hidden_states_scale
                 )
-        else:
-            hidden_states_scale = tma_align_input_scale(hidden_states_scale)
+        # SM89/SM90: 1x128 float32 scales pass through as-is; the AsymGEMM
+        # dispatch routes (data, block-scale) pairs to the block-scale kernel.
 
         asym_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
             (hidden_states, hidden_states_scale),
@@ -601,8 +431,6 @@ class AsymGemmRunnerCore(MoeRunnerCore):
             device=hidden_states_device,
             dtype=torch.bfloat16,
         )
-        if not asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0:
-            down_input_scale = tma_align_input_scale(down_input_scale)
 
         asym_gemm_wrapper.grouped_gemm_nt_f8f8bf16_contig(
             (down_input_fp8, down_input_scale),
@@ -615,195 +443,12 @@ class AsymGemmRunnerCore(MoeRunnerCore):
 
         return down_output
 
-    def _run_masked_gemm_sm89(
-        self,
-        runner_input: AsymGemmRunnerInput,
-        quant_info: AsymGemmMoeQuantInfo,
-        running_state: dict,
-    ) -> torch.Tensor:
-        from sglang.srt.layers.quantization.fp8_kernel import (
-            sglang_per_token_group_quant_fp8,
-        )
-
-        hidden_states = runner_input.hidden_states
-        hidden_states_scale = runner_input.hidden_states_scale
-        masked_m = runner_input.masked_m
-        expected_m = runner_input.expected_m
-
-        w13_weight = quant_info.w13_weight
-        w2_weight = quant_info.w2_weight
-        w13_scale = quant_info.w13_scale
-        w2_scale = quant_info.w2_scale
-
-        hidden_states_device = running_state["hidden_states_device"]
-
-        num_groups, m, k = hidden_states.shape
-        n = w13_weight.size(1)
-        K = w2_weight.shape[1]
-
-        # If scales are per-token-group (from DeepEP LL), dequant and requant per-token.
-        if hidden_states_scale.shape[-1] != 1:
-            from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
-
-            hidden_bf16 = block_quant_dequant(
-                hidden_states, hidden_states_scale, [1, 128], torch.bfloat16
-            )
-            dispose_tensor(hidden_states)
-            dispose_tensor(hidden_states_scale)
-            flat = hidden_bf16.reshape(-1, k)
-            hidden_states, hidden_states_scale = sglang_per_token_group_quant_fp8(
-                flat, k
-            )
-            del flat
-            hidden_states = hidden_states.view(num_groups, m, k)
-            hidden_states_scale = hidden_states_scale.view(num_groups, m, 1)
-            del hidden_bf16
-
-        chunk_size = _MASKED_GEMM_CHUNK_SIZE
-        if chunk_size > 0:
-            src2dst = running_state.get("src2dst", None)
-            use_scatter = src2dst is not None
-
-            if use_scatter:
-                num_tokens = running_state["hidden_states_shape"][0]
-                topk_ids = running_state["topk_ids"]
-                topk_weights = running_state["topk_weights"]
-                final_output = torch.zeros(
-                    (num_tokens, K), device=hidden_states_device, dtype=torch.bfloat16
-                )
-            else:
-                down_output = torch.empty(
-                    (num_groups, m, K),
-                    device=hidden_states_device,
-                    dtype=torch.bfloat16,
-                )
-
-            gateup_chunk = torch.empty(
-                (chunk_size, m, n), device=hidden_states_device, dtype=torch.bfloat16
-            )
-
-            for g_start in range(0, num_groups, chunk_size):
-                g_end = min(g_start + chunk_size, num_groups)
-                c = g_end - g_start
-
-                masked_m_c = masked_m[g_start:g_end]
-                gc = gateup_chunk[:c]
-
-                sa_c = hidden_states_scale[g_start:g_end].reshape(c * m).contiguous()
-                asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_masked(
-                    hidden_states[g_start:g_end],
-                    w13_weight[g_start:g_end],
-                    gc,
-                    masked_m_c,
-                    expected_m,
-                    scale_a_tensor=sa_c,
-                    scale_b_tensor=w13_scale[g_start:g_end],
-                )
-
-                down_input_c, down_input_scale_c = _fused_silu_mul_fp8_quant(
-                    gc.reshape(c * m, n)
-                )
-                down_input_c = down_input_c.view(c, m, n // 2)
-                down_input_scale_c = down_input_scale_c.view(c, m, 1)
-
-                if use_scatter:
-                    out_c = torch.empty(
-                        (c, m, K), device=hidden_states_device, dtype=torch.bfloat16
-                    )
-                else:
-                    out_c = down_output[g_start:g_end]
-
-                down_sa_c = down_input_scale_c.reshape(c * m).contiguous()
-                asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_masked(
-                    down_input_c,
-                    w2_weight[g_start:g_end],
-                    out_c,
-                    masked_m_c,
-                    expected_m,
-                    scale_a_tensor=down_sa_c,
-                    scale_b_tensor=w2_scale[g_start:g_end],
-                )
-                del down_input_c, down_input_scale_c
-
-                if use_scatter:
-                    _scatter_chunk_to_output(
-                        out_c, final_output, src2dst,
-                        topk_ids, topk_weights, g_start, m,
-                    )
-                    del out_c
-
-            dispose_tensor(hidden_states)
-            dispose_tensor(hidden_states_scale)
-            del gateup_chunk
-
-            if use_scatter:
-                running_state["is_scattered"] = True
-                return final_output
-            else:
-                return down_output
-
-        # ── Original (non-chunked) path ──────────────────────────────
-
-        # ── GEMM-0: gateup projection ────────────────────────────────
-        gateup_output = torch.empty(
-            (num_groups, m, n), device=hidden_states_device, dtype=torch.bfloat16
-        )
-
-        # Fuse per-token and per-expert scales into the GEMM epilogue
-        sa_flat = hidden_states_scale.view(num_groups * m).contiguous()
-        asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_masked(
-            hidden_states,
-            w13_weight,
-            gateup_output,
-            masked_m,
-            expected_m,
-            scale_a_tensor=sa_flat,
-            scale_b_tensor=w13_scale,
-        )
-        dispose_tensor(hidden_states)
-        dispose_tensor(hidden_states_scale)
-
-        # ── Fused SiLU + Mul + FP8 Quant ─────────────────────────────
-        down_input_fp8, down_input_scale = _fused_silu_mul_fp8_quant(
-            gateup_output.reshape(-1, n)
-        )
-        del gateup_output
-        down_input_fp8 = down_input_fp8.view(num_groups, m, n // 2)
-        down_input_scale = down_input_scale.view(num_groups, m, 1)
-
-        # ── GEMM-1: down projection ──────────────────────────────────
-        down_output = torch.empty(
-            (num_groups, m, K), device=hidden_states_device, dtype=torch.bfloat16
-        )
-
-        down_sa_flat = down_input_scale.view(num_groups * m).contiguous()
-        asym_gemm_wrapper.grouped_gemm_sm89_f8f8bf16_masked(
-            down_input_fp8,
-            w2_weight,
-            down_output,
-            masked_m,
-            expected_m,
-            scale_a_tensor=down_sa_flat,
-            scale_b_tensor=w2_scale,
-        )
-        del down_input_fp8
-        del down_input_scale
-
-        return down_output
-
     def _run_masked_gemm(
         self,
         runner_input: AsymGemmRunnerInput,
         quant_info: AsymGemmMoeQuantInfo,
         running_state: dict,
     ) -> torch.Tensor:
-        from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_SM89
-
-        if ASYMGEMM_SM89:
-            return self._run_masked_gemm_sm89(
-                runner_input, quant_info, running_state
-            )
-
         from sglang.srt.layers import asym_gemm_wrapper
         from sglang.srt.layers.moe.ep_moe.kernels import (
             silu_and_mul_masked_post_quant_fwd,
@@ -834,10 +479,8 @@ class AsymGemmRunnerCore(MoeRunnerCore):
                 hidden_states, hidden_states_scale = _rescale_fp8_for_ue8m0(
                     hidden_states, hidden_states_scale
                 )
-        else:
-            hidden_states_scale = asym_gemm_wrapper.get_mn_major_tma_aligned_tensor(
-                hidden_states_scale
-            )
+        # SM89/SM90: 1x128 float32 scales pass through as-is; the AsymGEMM
+        # dispatch routes (data, block-scale) pairs to the block-scale kernel.
 
         num_groups, m, k = hidden_states.shape
         n = w13_weight.size(1)   # 2 * ffn_dim (gateup output width)
@@ -904,8 +547,8 @@ class AsymGemmRunnerCore(MoeRunnerCore):
                         dst_dtype=torch.float8_e4m3fn,
                         group_size=scale_block_size,
                         masked_m=masked_m_c,
-                        column_major_scales=True,
-                        scale_tma_aligned=True,
+                        column_major_scales=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0,
+                        scale_tma_aligned=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0,
                         scale_ue8m0=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0,
                         fuse_silu_and_mul=True,
                         enable_v2=True,
@@ -928,11 +571,6 @@ class AsymGemmRunnerCore(MoeRunnerCore):
                         scale_block_size,
                         masked_m_c,
                         scale_ue8m0=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0,
-                    )
-
-                if not asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0:
-                    down_input_scale_c = asym_gemm_wrapper.get_mn_major_tma_aligned_tensor(
-                        down_input_scale_c
                     )
 
                 # GEMM-1: down_input_c → out_c
@@ -996,8 +634,8 @@ class AsymGemmRunnerCore(MoeRunnerCore):
                 dst_dtype=torch.float8_e4m3fn,
                 group_size=scale_block_size,
                 masked_m=masked_m,
-                column_major_scales=True,
-                scale_tma_aligned=True,
+                column_major_scales=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0,
+                scale_tma_aligned=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0,
                 scale_ue8m0=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0,
                 fuse_silu_and_mul=True,
                 enable_v2=True,
@@ -1032,11 +670,6 @@ class AsymGemmRunnerCore(MoeRunnerCore):
         del gateup_output
 
         # GroupGemm-1
-        if not asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0:
-            down_input_scale = asym_gemm_wrapper.get_mn_major_tma_aligned_tensor(
-                down_input_scale
-            )
-
         down_output = torch.empty(
             (num_groups, m, K), device=hidden_states_device, dtype=torch.bfloat16
         )
@@ -1121,12 +754,6 @@ def _pre_permute_standard_to_asym_gemm_fp8(
     hidden_states_device = hidden_states.device
     hidden_states_ref = hidden_states
 
-    from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_SM89
-
-    # SM89 uses per-token quantization (group_size=K) instead of per-token-group
-    K = hidden_states.shape[1]
-    act_block_shape = [1, K] if ASYMGEMM_SM89 else quant_info.block_shape
-
     # PreReorder
     masked_m, expected_m, src2dst, hidden_states, hidden_states_scale = (
         moe_ep_deepgemm_preprocess(
@@ -1134,9 +761,8 @@ def _pre_permute_standard_to_asym_gemm_fp8(
             runner_config.num_local_experts,
             hidden_states,
             runner_config.top_k,
-            act_block_shape,
-            scale_ue8m0=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0
-            and not ASYMGEMM_SM89,
+            quant_info.block_shape,
+            scale_ue8m0=asym_gemm_wrapper.ASYMGEMM_SCALE_UE8M0,
         )
     )
 
@@ -1653,11 +1279,33 @@ def _pre_permute_deepep_normal_to_asym_gemm_fp8(
 
     running_state["output_index"] = output_index
 
+    # Build the contiguous-GEMM expert list host-side from the dispatcher's CPU
+    # token counts: no device sync, and list_size stays a host int (the SM89/
+    # SM90 kernel needs it for grid sizing). Layout: experts = active expert
+    # ids, offsets = cumulative end-row indices (SM89/SM90 kernel format; the
+    # Blackwell contiguous kernel expects start/end pairs instead and would
+    # need its own builder).
+    ends, active_experts = [], []
+    acc = 0
+    for expert_id, cnt in enumerate(num_recv_tokens_per_expert):
+        acc += cnt
+        if cnt == 0:
+            continue
+        active_experts.append(expert_id)
+        ends.append(acc)
+    offsets = torch.tensor(ends, dtype=torch.int32, device=hidden_states_device)
+    experts = torch.tensor(
+        active_experts, dtype=torch.int32, device=hidden_states_device
+    )
+
     return AsymGemmRunnerInput(
         hidden_states=input_tensor,
         hidden_states_scale=input_tensor_scale,
         use_masked_gemm=False,
         m_indices=m_indices,
+        offsets=offsets,
+        experts=experts,
+        list_size=len(active_experts),
     )
 
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -64,7 +64,6 @@ from sglang.srt.layers.quantization.fp8_utils import (
     input_to_float8,
     mxfp8_group_quantize,
     normalize_e4m3fn_to_e4m3fnuz,
-    requant_weight_per_expert_inplace,
     requant_weight_ue8m0_inplace,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
@@ -1180,20 +1179,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer, quantize=not self.quant_config.is_checkpoint_fp8_serialized
             )
         elif self.runner.runner_backend.is_asym_gemm():
-            from sglang.srt.layers.asym_gemm_wrapper.configurer import ASYMGEMM_SM89
+            from sglang.srt.layers.asym_gemm_wrapper.configurer import (
+                ASYMGEMM_SCALE_UE8M0,
+            )
 
             weight_block_size = self.quant_config.weight_block_size
-            if ASYMGEMM_SM89:
-                requant_weight_per_expert_inplace(
-                    layer.w13_weight,
-                    layer.w13_weight_scale_inv,
-                    weight_block_size,
-                )
-                requant_weight_per_expert_inplace(
-                    layer.w2_weight,
-                    layer.w2_weight_scale_inv,
-                    weight_block_size,
-                )
+            if not ASYMGEMM_SCALE_UE8M0:
+                # SM89/SM90: the block-scale AsymGEMM kernels consume the
+                # checkpoint's 128x128 float32 scales directly — no requant.
                 layer.w13_weight_scale_inv.format_ue8m0 = False
                 layer.w2_weight_scale_inv.format_ue8m0 = False
             else:

--- a/test/registered/moe/test_asym_gemm_block_scale_runner.py
+++ b/test/registered/moe/test_asym_gemm_block_scale_runner.py
@@ -1,0 +1,182 @@
+"""Runner-level numerical tests for the unified AsymGEMM MoE runner on SM89/SM90.
+
+Exercises the merged `_run_contiguous_gemm` / `_run_masked_gemm` paths with
+native 1x128 activation + 128x128 weight block scales (no dequant-requant),
+comparing the full FFN (gateup GEMM -> SiLU*mul -> down GEMM) against an
+fp32 reference.
+
+Run:
+    SGLANG_ENABLE_JIT_ASYMGEMM=1 python test/registered/moe/test_asym_gemm_block_scale_runner.py
+"""
+
+import os
+import unittest
+
+os.environ.setdefault("SGLANG_ENABLE_JIT_ASYMGEMM", "1")
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner import asym_gemm as asym_gemm_runner
+from sglang.srt.layers.moe.moe_runner.asym_gemm import (
+    AsymGemmMoeQuantInfo,
+    AsymGemmRunnerCore,
+    AsymGemmRunnerInput,
+)
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.quantization.fp8_kernel import sglang_per_token_group_quant_fp8
+
+
+def calc_diff(a: torch.Tensor, b: torch.Tensor) -> float:
+    scale = b.abs().max().clamp(min=1e-6)
+    return (((a - b) / scale).norm() / (a.numel() ** 0.5)).item()
+
+
+def rand_fp8(shape):
+    return (torch.rand(shape, device="cuda") * 2 - 1).to(torch.float8_e4m3fn)
+
+
+def rand_scale(shape):
+    return (torch.rand(shape, device="cuda") * 1.5 + 0.5).float()
+
+
+def dequant_rows(x_fp8, sx):
+    """[.., R, K] fp8 with [.., R, ceil(K/128)] scales -> fp32."""
+    K = x_fp8.shape[-1]
+    return x_fp8.float() * sx.repeat_interleave(128, dim=-1)[..., :K]
+
+def dequant_w(w_fp8, sw):
+    """[E, N, K] fp8 with [E, ceil(N/128), ceil(K/128)] scales -> fp32."""
+    _, N, K = w_fp8.shape
+    sw_full = sw.repeat_interleave(128, dim=1)[:, :N, :]
+    sw_full = sw_full.repeat_interleave(128, dim=2)[:, :, :K]
+    return w_fp8.float() * sw_full
+
+
+def ref_ffn(x_deq, w13_deq, w2_deq):
+    """fp32 reference: gateup -> silu(gate)*up -> down. x_deq [M, K]."""
+    g = x_deq @ w13_deq.t()
+    half = g.shape[-1] // 2
+    act = torch.nn.functional.silu(g[..., :half]) * g[..., half:]
+    return act @ w2_deq.t()
+
+
+def make_quant_info(E, N, K):
+    """w13 [E, N, K] (gateup), w2 [E, K, N//2] (down)."""
+    w13 = rand_fp8((E, N, K))
+    w13_scale = rand_scale((E, (N + 127) // 128, (K + 127) // 128))
+    w2 = rand_fp8((E, K, N // 2))
+    w2_scale = rand_scale((E, (K + 127) // 128, (N // 2 + 127) // 128))
+    return AsymGemmMoeQuantInfo(
+        w13_weight=w13,
+        w2_weight=w2,
+        use_fp8=True,
+        w13_scale=w13_scale,
+        w2_scale=w2_scale,
+        block_shape=[128, 128],
+    )
+
+
+def make_core():
+    return AsymGemmRunnerCore(MoeRunnerConfig(activation="silu", is_gated=True))
+
+
+class TestAsymGemmBlockScaleRunner(unittest.TestCase):
+    TOL = 2e-2  # fp8 intermediate quant of the activation dominates
+
+    def test_contiguous_runner(self):
+        torch.manual_seed(0)
+        E, N, K = 4, 512, 512
+        token_counts = [40, 0, 130, 7]
+        quant_info = make_quant_info(E, N, K)
+
+        total = sum(token_counts)
+        x_bf16 = torch.randn(total, K, device="cuda", dtype=torch.bfloat16)
+        x_fp8, x_scale = sglang_per_token_group_quant_fp8(x_bf16, 128)
+
+        ends, active = [], []
+        acc = 0
+        for e, cnt in enumerate(token_counts):
+            acc += cnt
+            if cnt:
+                active.append(e)
+                ends.append(acc)
+        runner_input = AsymGemmRunnerInput(
+            hidden_states=x_fp8.clone(),
+            hidden_states_scale=x_scale.contiguous().clone(),
+            use_masked_gemm=False,
+            offsets=torch.tensor(ends, dtype=torch.int32, device="cuda"),
+            experts=torch.tensor(active, dtype=torch.int32, device="cuda"),
+            list_size=len(active),
+        )
+        running_state = {
+            "all_tokens": total,
+            "hidden_states_device": x_fp8.device,
+            "hidden_states_dtype": torch.bfloat16,
+            "hidden_states_shape": (total, K),
+        }
+
+        out = make_core()._run_contiguous_gemm(runner_input, quant_info, running_state)
+
+        x_deq = dequant_rows(x_fp8, x_scale.float())
+        w13_deq = dequant_w(quant_info.w13_weight, quant_info.w13_scale)
+        w2_deq = dequant_w(quant_info.w2_weight, quant_info.w2_scale)
+        start = 0
+        for e, end in zip(active, ends):
+            ref = ref_ffn(x_deq[start:end], w13_deq[e], w2_deq[e])
+            diff = calc_diff(out[start:end].float(), ref)
+            print(f"  contiguous expert {e} rows [{start}:{end}): diff={diff:.3e}")
+            self.assertLess(diff, self.TOL)
+            start = end
+
+    def _masked_case(self, chunk_size):
+        torch.manual_seed(1)
+        G, M_max, N, K = 4, 256, 512, 512
+        masked = torch.tensor([40, 0, 130, 256], dtype=torch.int32, device="cuda")
+        quant_info = make_quant_info(G, N, K)
+
+        x_bf16 = torch.randn(G, M_max, K, device="cuda", dtype=torch.bfloat16)
+        x_fp8, x_scale = sglang_per_token_group_quant_fp8(x_bf16.view(-1, K), 128)
+        x_fp8 = x_fp8.view(G, M_max, K)
+        x_scale = x_scale.view(G, M_max, -1).contiguous()
+
+        runner_input = AsymGemmRunnerInput(
+            hidden_states=x_fp8.clone(),
+            hidden_states_scale=x_scale.clone(),
+            use_masked_gemm=True,
+            masked_m=masked,
+            expected_m=int(masked.max()),
+        )
+        running_state = {
+            "hidden_states_device": x_fp8.device,
+            "hidden_states_dtype": torch.bfloat16,
+            "hidden_states_shape": (G * M_max, K),
+        }
+
+        old_chunk = asym_gemm_runner._MASKED_GEMM_CHUNK_SIZE
+        asym_gemm_runner._MASKED_GEMM_CHUNK_SIZE = chunk_size
+        try:
+            out = make_core()._run_masked_gemm(runner_input, quant_info, running_state)
+        finally:
+            asym_gemm_runner._MASKED_GEMM_CHUNK_SIZE = old_chunk
+
+        x_deq = dequant_rows(x_fp8, x_scale.float())
+        w13_deq = dequant_w(quant_info.w13_weight, quant_info.w13_scale)
+        w2_deq = dequant_w(quant_info.w2_weight, quant_info.w2_scale)
+        for g in range(G):
+            m = int(masked[g])
+            if m == 0:
+                continue
+            ref = ref_ffn(x_deq[g, :m], w13_deq[g], w2_deq[g])
+            diff = calc_diff(out[g, :m].float(), ref)
+            print(f"  masked(chunk={chunk_size}) group {g} m={m}: diff={diff:.3e}")
+            self.assertLess(diff, self.TOL)
+
+    def test_masked_runner_nonchunked(self):
+        self._masked_case(chunk_size=0)
+
+    def test_masked_runner_chunked(self):
+        self._masked_case(chunk_size=2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
As AsymGemm provides architecture-agnostic APIs now, this PR simplifies the code accordingly. 



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->