### PR TITLE
[codex] Install curl before get-pip download in Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ fi
 # Ubuntu 24.04 ships Python 3.12 in main, so we no longer need the deadsnakes
 # PPA. Dropping it avoids transient Launchpad 504s in `add-apt-repository`.
 RUN --mount=type=cache,target=/var/cache/apt,id=base-apt \
-    apt update && apt install -y --no-install-recommends wget software-properties-common \
+    apt update && apt install -y --no-install-recommends wget curl software-properties-common \
     && apt install -y --no-install-recommends python3.12-full python3.12-dev \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 \
     && update-alternatives --set python3 /usr/bin/python3.12 \


### PR DESCRIPTION
## Summary
- fix DeepSeek V4 nightly Docker build failure from `/bin/sh: 1: curl: not found` in `docker/Dockerfile` base stage
- install `curl` before the retrying `get-pip.py` download added by the previous hardening change
- leave kernel wheel workflow, proxy build args, image tag logic, and runtime stage unchanged

## Evidence
- failing run: https://github.com/bytedance-iaas/sglang/actions/runs/27576662572
- failing job: `build-nightly / build-and-publish` / `Build and push AMD64 image`
- exact failure: `Dockerfile:50` base stage, `/bin/sh: 1: curl: not found`, exit code 127

## Verification
- `git diff --check`
- checked both `get-pip.py` download sites: early base stage now installs `curl`; runtime stage already had `curl`

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->