### PR TITLE
[codex] fix EIC HiCache cache paths

### DIFF
--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -483,6 +483,42 @@ class EICCacheController(HiCacheController):
 
         return eic_prefix_len
 
+    def write(
+        self,
+        device_indices: torch.Tensor,
+        priority: Optional[int] = None,
+        node_id: int = -1,
+    ) -> Optional[torch.Tensor]:
+        """
+        Back up KV caches from device memory to host memory.
+        """
+        host_indices = self.mem_pool_host.alloc(len(device_indices))
+        if host_indices is None:
+            return None
+        self.write_queue.put(
+            EICCacheOperation(host_indices, device_indices, node_id, None, priority)
+        )
+        return host_indices
+
+    def load(
+        self,
+        host_indices: torch.Tensor,
+        priority: Optional[int] = None,
+        node_id: int = -1,
+    ) -> Optional[torch.Tensor]:
+        """
+        Load KV caches from host memory to device memory.
+        """
+        device_indices = self.mem_pool_device_allocator.alloc(len(host_indices))
+        if device_indices is None:
+            return None
+        # to ensure the device indices are ready before accessed by another CUDA stream
+        torch.cuda.current_stream().synchronize()
+        self.load_queue.put(
+            EICCacheOperation(host_indices, device_indices, node_id, None, priority)
+        )
+        return device_indices
+
     def write_page(
         self,
         device_indices: torch.Tensor,

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1044,6 +1044,11 @@ class EICPagedHiRadixCache(EICHiRadixCache):
                 continue
             fill_ids = req.origin_input_ids + req.output_ids
             req_tokens = fill_ids[: len(fill_ids) - 1]
+            if len(req_tokens) == 0:
+                logger.debug(
+                    f"req {req.rid} skip loading from eic: no committed tokens"
+                )
+                continue
             req_key = RadixKey(req_tokens, req.extra_key)
             local_prefix_len, local_evict_len, last_node = self._match_for_remote_fetch(
                 self.root_node, req_key

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -1,0 +1,93 @@
+import unittest
+from queue import Queue
+from unittest import mock
+
+import torch
+
+from sglang.srt.managers.eic_cache_controller import (
+    EICCacheController,
+    EICCacheOperation,
+)
+from sglang.srt.mem_cache.eic_hiradix_cache import EICPagedHiRadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
+
+
+class FakeHostPool:
+    def alloc(self, size: int):
+        return torch.arange(size, dtype=torch.int32)
+
+
+class FakeDeviceAllocator:
+    def alloc(self, size: int):
+        return torch.arange(100, 100 + size, dtype=torch.int32)
+
+
+class TestEICHiCacheRegression(unittest.TestCase):
+    def test_match_from_remote_skips_zero_committed_tokens(self):
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.match_req_set = []
+        cache.cache_controller = mock.Mock()
+        cache._match_for_remote_fetch = mock.Mock(
+            side_effect=AssertionError("empty remote key should be skipped")
+        )
+
+        req = mock.Mock(
+            rid="health-rid",
+            origin_input_ids=[0],
+            output_ids=[],
+            extra_key=None,
+        )
+
+        cache.match_from_remote([req])
+
+        cache._match_for_remote_fetch.assert_not_called()
+        cache.cache_controller.batch_find_longest_prefix_in_eic.assert_not_called()
+        self.assertEqual(cache.match_req_set, [])
+
+    def test_eic_controller_write_uses_queue_api(self):
+        controller = object.__new__(EICCacheController)
+        controller.mem_pool_host = FakeHostPool()
+        controller.write_queue = Queue()
+
+        device_indices = torch.tensor([7, 8, 9], dtype=torch.int32)
+        host_indices = controller.write(device_indices, priority=-2, node_id=11)
+
+        self.assertEqual(host_indices.tolist(), [0, 1, 2])
+        operation = controller.write_queue.get_nowait()
+        self.assertIsInstance(operation, EICCacheOperation)
+        self.assertEqual(operation.host_indices.tolist(), [0, 1, 2])
+        self.assertIs(operation.device_indices, device_indices)
+        self.assertEqual(operation.node_id, 11)
+        self.assertEqual(operation.node_ids, [11])
+        self.assertIsNone(operation.content_hash)
+        self.assertEqual(operation.priority, -2)
+
+    def test_eic_controller_load_uses_queue_api(self):
+        controller = object.__new__(EICCacheController)
+        controller.mem_pool_device_allocator = FakeDeviceAllocator()
+        controller.load_queue = Queue()
+
+        host_indices = torch.tensor([0, 1, 2], dtype=torch.int32)
+        with mock.patch(
+            "sglang.srt.managers.eic_cache_controller.torch.cuda.current_stream"
+        ) as current_stream:
+            stream = mock.Mock()
+            current_stream.return_value = stream
+            device_indices = controller.load(host_indices, priority=-3, node_id=12)
+
+        stream.synchronize.assert_called_once()
+        self.assertEqual(device_indices.tolist(), [100, 101, 102])
+        operation = controller.load_queue.get_nowait()
+        self.assertIsInstance(operation, EICCacheOperation)
+        self.assertIs(operation.host_indices, host_indices)
+        self.assertEqual(operation.device_indices.tolist(), [100, 101, 102])
+        self.assertEqual(operation.node_id, 12)
+        self.assertEqual(operation.node_ids, [12])
+        self.assertIsNone(operation.content_hash)
+        self.assertEqual(operation.priority, -3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix two EIC HiCache regressions seen with EIC-backed hierarchical cache:

- Skip EIC shared remote lookup when a request has zero committed/shareable KV tokens, such as the one-token health path. This prevents constructing an empty remote key and repeatedly probing EIC for a token=0 case.
- Override `EICCacheController.write()` and `load()` to use `queue.Queue.put()` instead of inheriting the base HiCache controller's list-based `.append()` path. This fixes non-shared EIC HiCache with `--disable-eic-shared`, including write-through and eviction/write-back paths.
- Add focused regression coverage for the empty remote key case and the EIC queue API behavior.

## Root Cause

`EICPagedHiRadixCache.match_from_remote()` builds the shared EIC lookup key from `(origin_input_ids + output_ids)[:-1]`. For a one-token request, this key is empty and should not enter the EIC remote lookup path.

Separately, `EICCacheController` stores write/load queues as `queue.Queue`, but inherited `HiCacheController.write()` / `load()` assume list queues and call `.append()`. Non-shared EIC HiCache therefore crashes as soon as the generic write/load path is used.

## Validation

- `python3 -m py_compile python/sglang/srt/managers/eic_cache_controller.py python/sglang/srt/mem_cache/eic_hiradix_cache.py test/registered/unit/mem_cache/test_eic_hicache_regression.py`
- `python3 -m ruff check python/sglang/srt/managers/eic_cache_controller.py python/sglang/srt/mem_cache/eic_hiradix_cache.py test/registered/unit/mem_cache/test_eic_hicache_regression.py`
- `git diff --cached --check`

Local direct unittest execution was blocked by the local macOS environment missing `partial_json_parser` during SGLang import; the new regression test is intended for the repo CI/runtime environment with full SGLang dependencies.



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->