### PR TITLE
Port SM90 FP4 MegaMoE adaptation from mega_moe_adapt_fp4

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/mega_moe_pre_dispatch_sm90.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/mega_moe_pre_dispatch_sm90.cuh
@@ -183,8 +183,11 @@ struct MegaMoEPreDispatchSM90Kernel {
         .with_dtype<float>()
         .with_device(device)
         .verify(topk_weights);
+    // DeepGEMM's SymmBuffer exposes FP8 storage through an int8 DLPack view.
+    // Direct unit tests may still pass a torch.float8_e4m3fn tensor, so accept
+    // either dtype and write the storage as E4M3 below.
     TensorMatcher({P, H})  // buf.x
-        .with_dtype<fp8_e4m3_t>()
+        .with_dtype<fp8_e4m3_t, int8_t>()
         .with_device(device)
         .verify(buf_x);
     // buf.x_sf is the contiguous row-major fp32 view from DeepGEMM's mega

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -979,6 +979,12 @@ def mega_moe_pre_dispatch_sm90(
     routed_scaling_factor: float = 1.0,
     quant_group_size: int = 128,
 ) -> None:
+    """SM90 variant of ``mega_moe_pre_dispatch``.
+
+    Writes per-128 raw FP32 scales into ``buf_x_sf`` and can fold
+    ``routed_scaling_factor`` into ``buf_topk_weights`` so callers can skip a
+    post-mega scale kernel. Pass 1.0 when the scale is already applied.
+    """
     module = _jit_mega_moe_pre_dispatch_sm90_module(quant_group_size)
     module.run(
         x,

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -110,10 +110,21 @@ def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bo
     except ImportError:
         return False
     if _device_sm == 90:
-        if not hasattr(deep_gemm, "fp8_mega_moe"):
-            return False
-        if not getattr(moe.experts, "_mega_moe_sm90_fp8_weights", False):
-            return False
+        # SM90 supports two paths:
+        #   * `fp8_mega_moe`     — FP8 weights + per-128 float SF (legacy)
+        #   * `fp8_fp4_mega_moe` — packed FP4 weights + per-32 UE8M0 SF (DSV4)
+        # The arch dispatch happens inside the C++ binding (mega.hpp): both
+        # entry points exist on SM90; we just have to pick the right one
+        # based on which weight tensors `build_mega_moe_experts_weights`
+        # produced for this layer.
+        if getattr(moe.experts, "_mega_moe_sm90_fp4_weights", False):
+            if not hasattr(deep_gemm, "fp8_fp4_mega_moe"):
+                return False
+        else:
+            if not hasattr(deep_gemm, "fp8_mega_moe"):
+                return False
+            if not getattr(moe.experts, "_mega_moe_sm90_fp8_weights", False):
+                return False
     elif _device_sm >= 100:
         if not hasattr(deep_gemm, "fp8_fp4_mega_moe"):
             return False
@@ -131,7 +142,17 @@ def should_use_mega_moe(moe: "DeepseekV2MoE", hidden_states: torch.Tensor) -> bo
     else:
         max_tokens_per_rank = hidden_states.shape[0]
     cap = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
-    return max_tokens_per_rank <= cap
+    if max_tokens_per_rank > cap:
+        if getattr(moe.experts, "_mega_moe_sm90_fp4_memory_shared", False):
+            raise RuntimeError(
+                "SM90 FP4 MegaMOE memory sharing replaced the fallback FP4 expert "
+                "layout, so requests cannot fall back to the non-MegaMOE path. "
+                f"max_tokens_per_rank={max_tokens_per_rank} exceeds "
+                "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK="
+                f"{cap}; raise the env var or reduce chunked/cuda-graph batch size."
+            )
+        return False
+    return True
 
 
 def forward_mega_moe(
@@ -239,8 +260,28 @@ def _run_mega_routed(
     use_sm90_fp8_mega = _device_sm == 90 and getattr(
         moe.experts, "_mega_moe_sm90_fp8_weights", False
     )
+    use_sm90_fp4_mega = _device_sm == 90 and getattr(
+        moe.experts, "_mega_moe_sm90_fp4_weights", False
+    )
+    # SM90 FP8/FP4 路径都通过 `mega_moe_pre_dispatch_sm90` 写入 E4M3 激活
+    # （per-128 FP32 SF）。如果用户错误地把 `SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS=1`
+    # 也打开，`SymmBuffer.x` 会被分配为 int8（packed FP4），buffer 字节大小
+    # 偶然匹配但 SF 张量按 per-32 分配，会让下游 GEMM 读到错误的缩放因子，
+    # 静默产出错误结果。这里显式拒绝该组合，强制用户走纯 SM100 路径。
+    if (use_sm90_fp8_mega or use_sm90_fp4_mega) and (
+        envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS.get()
+    ):
+        raise RuntimeError(
+            "SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS is incompatible with "
+            "the SM90 mega-MoE paths (FP8 weights or FP4 weights). SM90 only "
+            "supports FP8 activations with per-128 SF. Please disable "
+            "SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS or run on SM100."
+        )
     fused_routed_scaling = False
-    if use_sm90_fp8_mega:
+    if use_sm90_fp8_mega or use_sm90_fp4_mega:
+        # SM90 paths (both FP8 weights and FP4 weights) use FP8 activations
+        # with per-128 FP32 SF. The mega kernel itself dispatches on the
+        # weight dtype; only the *weight*-side recipe changes for FP4.
         if moe.experts.should_fuse_routed_scaling_factor_in_topk:
             scale = 1.0
         else:
@@ -305,6 +346,9 @@ def _run_mega_routed(
             fast_math=True,
         )
     else:
+        # SM90 FP4 + SM100 FP4/FP8 paths share the `fp8_fp4_mega_moe` entry;
+        # the C++ binding (mega.hpp) dispatches on `arch_major` and the FP4
+        # weight tensors carry their per-32 UE8M0 SF.
         deep_gemm.fp8_fp4_mega_moe(
             y,
             moe.experts.mega_l1_weights,
@@ -357,6 +401,14 @@ def build_mega_moe_experts_weights(experts) -> None:
         _device_sm == 90
         and w13.dtype == torch.float8_e4m3fn
         and w2.dtype == torch.float8_e4m3fn
+    )
+    # SM90 FP4: weights ship as packed E2M1 (two nibbles per byte stored as
+    # int8/uint8) with per-32 UE8M0 SFB. The packed tensor has last dim K//2.
+    use_sm90_fp4_mega = (
+        _device_sm == 90
+        and not use_sm90_fp8_mega
+        and w13.dtype in (torch.int8, torch.uint8)
+        and w2.dtype in (torch.int8, torch.uint8)
     )
     # FP4 weights are packed as int8 and have last dim K//2; FP8 weights use K.
     if use_sm90_fp8_mega:
@@ -414,6 +466,45 @@ def build_mega_moe_experts_weights(experts) -> None:
             experts.w2_weight.data,
             experts.w2_weight_scale_inv.data,
         )
+    elif use_sm90_fp4_mega:
+        # SM90 FP4 path: SFB stays as raw FP32 per-32 SF in checkpoint layout
+        # (`[E, N, K//32]`). The transform packs it into the k-major UE8M0
+        # uint32 layout the SM90 FP4 mega-MoE kernel directly ldgs. No
+        # `transform_sf_into_required_layout` step is needed (and would in
+        # fact fall through to `DG_HOST_UNREACHABLE` since the C++ helper has
+        # no `arch_major == 9 && gran_k == 32` branch).
+        from deep_gemm import transform_weights_for_mega_moe_sm90_fp4
+
+        l1_pair, l2_pair = transform_weights_for_mega_moe_sm90_fp4(
+            (w13, w13_sf_fp32), (w2, w2_sf_fp32)
+        )
+        if fix_mega_moe_memory:
+            # The SM90 FP4 MegaMOE kernel consumes an interleaved L1 FP4 tensor
+            # and packed UE8M0 scales. The non-MegaMOE FP4 runners consume the
+            # checkpoint layout, so there is no single layout that supports both
+            # paths. In memory-fix mode, prefer the intended MegaMOE path and
+            # replace the original parameters so the old checkpoint-layout
+            # tensors can be released before KV-pool sizing.
+            experts.w13_weight.data = l1_pair[0]
+            experts.w2_weight.data = l2_pair[0]
+            experts.w13_weight_scale_inv.data = l1_pair[1]
+            experts.w2_weight_scale_inv.data = l2_pair[1]
+            experts.w13_weight_scale_inv.format_ue8m0 = True
+            experts.w2_weight_scale_inv.format_ue8m0 = True
+
+            experts.mega_l1_weights = (
+                experts.w13_weight.data,
+                experts.w13_weight_scale_inv.data,
+            )
+            experts.mega_l2_weights = (
+                experts.w2_weight.data,
+                experts.w2_weight_scale_inv.data,
+            )
+            experts._mega_moe_sm90_fp4_memory_shared = True
+        else:
+            experts.mega_l1_weights = l1_pair
+            experts.mega_l2_weights = l2_pair
+            experts._mega_moe_sm90_fp4_memory_shared = False
     else:
         w13_sf = transform_sf_into_required_layout(
             w13_sf_fp32,
@@ -432,7 +523,7 @@ def build_mega_moe_experts_weights(experts) -> None:
             disable_ue8m0_cast=disable_ue8m0_cast,
         )
 
-    if fix_mega_moe_memory and not use_sm90_fp8_mega:
+    if fix_mega_moe_memory and not use_sm90_fp8_mega and not use_sm90_fp4_mega:
         # Build the interleaved L1 weight + scale once; share the weight buffer
         # between `w13_weight.data` (normal deep-ep path) and `mega_l1_weights[0]`
         # (mega moe path). Mega moe additionally needs a UTCCP-transposed scale;
@@ -451,7 +542,8 @@ def build_mega_moe_experts_weights(experts) -> None:
 
         experts.mega_l1_weights = (experts.w13_weight.data, w13_sf_utccp)
         experts.mega_l2_weights = (experts.w2_weight.data, w2_sf_utccp)
-    elif not fix_mega_moe_memory:
+    elif not fix_mega_moe_memory and not use_sm90_fp4_mega:
+        # SM90 FP4 already finalized `mega_l*_weights` in its own branch above.
         transform_fn = transform_weights_for_mega_moe
         if use_sm90_fp8_mega:
             from deep_gemm import transform_weights_for_mega_moe_sm90
@@ -464,4 +556,5 @@ def build_mega_moe_experts_weights(experts) -> None:
         experts.mega_l2_weights = l2_pair
 
     experts._mega_moe_sm90_fp8_weights = use_sm90_fp8_mega
+    experts._mega_moe_sm90_fp4_weights = use_sm90_fp4_mega
     experts._mega_moe_weights_built = True

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1305,11 +1305,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer.w13_weight.data = layer.w13_weight.data.view(fp4_weight_dtype)
                 layer.w2_weight.data = layer.w2_weight.data.view(fp4_weight_dtype)
 
-                # FP4 expert mega MoE requires SM100. All-FP8 mega MoE on
-                # SM90 is handled below in the non-fp4-expert branch.
+                # FP4 expert Mega-MoE has two DeepGEMM paths:
+                #   * SM90: software FP4-weight decode in fp8_fp4_mega_moe
+                #   * SM100: native FP4 block-scaled Mega-MoE
                 if (
                     get_moe_a2a_backend().is_megamoe()
-                    and is_sm100_supported()
+                    and (is_sm90_supported() or is_sm100_supported())
                 ):
                     from sglang.srt.layers.moe.mega_moe import (
                         build_mega_moe_experts_weights,


### PR DESCRIPTION
Sync the SM90 FP4 mega-MoE path from origin/mega_moe_adapt_fp4 (4 commits: 24fe58afb, bd3aedea4, ff4d3e895, b611b5748) into bytedance/deepseek_v4.

deepseek_v4 already had the SM100 FP4 path and the SM90 FP8 path; this adds the missing SM90 FP4 weight path:
- mega_moe.py: detect packed-int8 FP4 weights (_mega_moe_sm90_fp4_weights), route them through transform_weights_for_mega_moe_sm90_fp4 + fp8_fp4_mega_moe, reject the incompatible USE_FP4_ACTS combo, and guard the memory-shared fallback path.
- fp8.py: enable FP4-expert mega-MoE weight build on SM90 (not only SM100).
- jit_kernel/deepseek_v4.py: SM90 pre-dispatch docstring (empty-input guard already present).
- mega_moe_pre_dispatch_sm90.cuh: accept int8 buf.x view from DeepGEMM SymmBuffer.

Adapted to deepseek_v4's older module layout (jit_kernel.deepseek_v4 monolith, cuda_graph_runner import) instead of cherry-picking, since the source branch is on a newer upstream with the jit_kernel/dsv4 package refactor. DeepGEMM dependency (transform_weights_for_mega_moe_sm90_fp4) confirmed present in the current sgl_deep_gemm checkout.

## Accuracy
### GSK8K
python benchmark/gsm8k/bench_sglang.py --host http://0.0.0.0 --port 30000 --num-questions 2000

100%|███████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [01:47<00:00, 12.23it/s]
Accuracy: 0.950
Invalid: 0.000
Latency: 107.818 s
Output throughput: 1108.076 token/s

### GPQA
sgl-eval run gpqa \
  --n-repeats 1 --max-tokens 200000 \
  --temperature 1.0 --top-p 1.0 --thinking \
  --out-dir /sgl-workspace/logs \
  --base-url http://localhost:30000/v1 \
  2>&1 | tee /sgl-workspace/logs/gpqa_$(date +%Y%m%d_%H%M%S).console.log
Run directory: /sgl-workspace/logs/sgl_eval_gpqa_20260629-100208
gpqa: 100%|██████████| 198/198 [15:40<00:00,  4.75s/it, acc=86.87%]
== gpqa ==
198 examples (single-shot)  |  940.6s  |  2381 tok/s  |  2.2M tokens

* score           =  86.87%
  stop_rate       =  100.00%
  truncated_rate  =  0.00%
  error_rate      =  0.00%
  
## Performance
3500/1500
Track | 指标 | A: MegaMoE (deep_gemm/W4A4/EP8+deepep) | B: marlin (W4A16/no-EP) | A/B
-- | -- | -- | -- | --
SLO 合规 | RR / MC | 11.2 / 104 | 4.8 / 56 |  
  | 总吞吐 (tok/s) | 15011.8 | 8258.4 | 1.82×
  | 输出吞吐 | 4503.5 | 2477.5 | 1.82×
  | TTFT (ms) | 1123.8 | 1650.7 | A 更低 0.68×
  | TPOT (ms) | 19.60 | 19.09 | 都贴 20ms 上限

