### PR TITLE
Fixes to make PR #27831 (decode radix cache for SWA models) work on DeepSeek-V4, MiMo-V2, and Gemma4.

### DIFF
--- a/python/sglang/jit_kernel/flash_attention_v3.py
+++ b/python/sglang/jit_kernel/flash_attention_v3.py
@@ -128,6 +128,7 @@ def flash_attn_with_kvcache(
     scheduler_metadata=None,
     num_splits=0,  # Can be tuned for speed
     pack_gqa=None,  # Can be tuned for speed
+    only_qv=False,  # Skip K matmul when qk rope dim is 0 (requires qv)
     sm_margin=0,  # Can be tuned if some SMs are used for communication
     return_softmax_lse=False,
     sinks=None,
@@ -138,7 +139,11 @@ def flash_attn_with_kvcache(
             "flash_attn at sgl-kernel is only supported on sm90 and above"
         )
 
-    assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
+    # When only_qv=True the caller may pass k_cache=None (synthetic K is
+    # allocated inside the sgl-kernel wrapper). Skip the stride check in that
+    # case so the rope=0 path doesn't trip the assertion.
+    if k_cache is not None:
+        assert k_cache.stride(-1) == 1, "k_cache must have contiguous last dimension"
     assert v_cache.stride(-1) == 1, "v_cache must have contiguous last dimension"
 
     return _call_fa3_kernel(
@@ -171,9 +176,10 @@ def flash_attn_with_kvcache(
         scheduler_metadata,
         num_splits,
         pack_gqa,
-        sm_margin,
-        return_softmax_lse,
-        sinks,
+        sm_margin=sm_margin,
+        only_qv=only_qv,
+        return_softmax_lse=return_softmax_lse,
+        sinks=sinks,
         out=out,
     )
 
@@ -201,6 +207,7 @@ def flash_attn_varlen_func(
     softcap=0.0,
     num_splits=1,
     pack_gqa=None,
+    only_qv=False,
     sm_margin=0,
     return_softmax_lse=False,
     sinks=None,
@@ -265,6 +272,7 @@ def flash_attn_varlen_func(
         softcap=softcap,
         num_splits=num_splits,
         pack_gqa=pack_gqa,
+        only_qv=only_qv,
         sm_margin=sm_margin,
         return_softmax_lse=return_softmax_lse,
         sinks=sinks,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -236,10 +236,15 @@ def build_kv_cache(
                             "path. Set SGLANG_OPT_USE_ONLINE_COMPRESS=1 and "
                             "SGLANG_EXPERIMENTAL_ONLINE_C128_MTP=1."
                         )
+            # SWA-compress models (MiMo-V2, Gemma4) use different head dims for
+            # SWA vs full layers but do NOT use latent KV compression like DSV4.
+            # The generic SWA decode-radix path (SWA prefix cap, regular radix
+            # match, dual-pool allocation) handles them without model-specific
+            # sidecars. Previously blocked out of caution; now allowed.
             if getattr(model_config, "is_hybrid_swa_compress", False):
-                raise ValueError(
-                    "--disaggregation-decode-enable-radix-cache does not support "
-                    "SWA-compress models (e.g. Gemma4 / MiMo-V2) yet."
+                logger.warning(
+                    "--disaggregation-decode-enable-radix-cache with "
+                    "SWA-compress models (e.g. Gemma4 / MiMo-V2) is experimental."
                 )
         if is_hybrid_ssm:
             raise ValueError(


### PR DESCRIPTION
- Fix FA3 keyword arg alignment for sgl-kernel only_qv parameter (crashed MiMo-V2)
- Allow SWA-compress models (MiMo-V2, Gemma4) through decode radix cache guard — they use SWAKVPool and the generic SWA path works correctly


Verified: P/D + decode radix cache + MMLU 200 on all three models:
- DSV4: 0.895 | MiMo-V2: 0.855 | Gemma4: 0.910

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->