### PR TITLE
Enable conversion and runtime support for DeepSeek-V4-Flash FP4 experts with group size 128 

### DIFF
--- a/check_fp4_conversion.py
+++ b/check_fp4_conversion.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""检查 FP4 重量化前后的 tensor 结构和抽样反量化误差。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import safe_open
+
+
+FP4_TABLE = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def is_fp4_expert_weight_name(name: str) -> bool:
+    return (
+        name.endswith(".weight")
+        and (".ffn.experts." in name or ".ffn.shared_experts." in name)
+    )
+
+
+def choose_tensor_name(weight_map: dict[str, str]) -> str:
+    routed = sorted(
+        name for name in weight_map if name.endswith(".weight") and ".ffn.experts." in name
+    )
+    if routed:
+        return routed[0]
+    shared = sorted(
+        name
+        for name in weight_map
+        if name.endswith(".weight") and ".ffn.shared_experts." in name
+    )
+    if shared:
+        return shared[0]
+    raise KeyError("no expert weight tensor found in index")
+
+
+def unpack_fp4_values(packed: torch.Tensor) -> torch.Tensor:
+    if packed.dtype != torch.int8 or packed.ndim != 2:
+        raise ValueError(f"expected int8 2D packed tensor, got {packed.dtype}, {tuple(packed.shape)}")
+
+    out_dim, packed_in_dim = packed.shape
+    packed_u8 = packed.view(torch.uint8)
+    low = packed_u8 & 0x0F
+    high = (packed_u8 >> 4) & 0x0F
+    return torch.stack(
+        (FP4_TABLE[low.long()], FP4_TABLE[high.long()]),
+        dim=-1,
+    ).reshape(out_dim, packed_in_dim * 2)
+
+
+def dequant_fp4_grouped(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    fp4 = unpack_fp4_values(packed)
+    out_dim, in_dim = fp4.shape
+    expected_shape = (out_dim, in_dim // group_size)
+    if tuple(scale.shape) != expected_shape:
+        raise ValueError(
+            f"scale shape mismatch: got {tuple(scale.shape)}, expected {expected_shape}"
+        )
+    full_scale = scale.float().repeat_interleave(group_size, dim=1)
+    return fp4 * full_scale
+
+
+def quantize_real_to_fp4(real: torch.Tensor, group_size: int, eps: float = 1e-12) -> tuple[torch.Tensor, torch.Tensor]:
+    if real.ndim != 2:
+        raise ValueError(f"expected 2D tensor, got shape {tuple(real.shape)}")
+
+    out_dim, in_dim = real.shape
+    if in_dim % group_size != 0:
+        raise ValueError(f"in_dim={in_dim} must be divisible by group_size={group_size}")
+
+    num_groups = in_dim // group_size
+    grouped = real.view(out_dim, num_groups, group_size)
+    max_abs = grouped.abs().amax(dim=-1)
+    scale = torch.clamp(max_abs / 6.0, min=eps)
+
+    normalized = grouped / scale.unsqueeze(-1)
+    codebook = FP4_TABLE.view(1, 1, 1, 16)
+    nibble = (normalized.unsqueeze(-1) - codebook).abs().argmin(dim=-1).to(torch.uint8)
+    nibble = nibble.view(out_dim, in_dim)
+
+    low = nibble[:, 0::2]
+    high = nibble[:, 1::2]
+    packed = (low | (high << 4)).view(torch.int8)
+    return packed, scale.float()
+
+
+def infer_group_size_from_shapes(weight: torch.Tensor, scale: torch.Tensor) -> int:
+    if weight.ndim != 2 or scale.ndim != 2:
+        raise ValueError(
+            f"expected 2D weight/scale, got {tuple(weight.shape)} and {tuple(scale.shape)}"
+        )
+    out_dim, packed_in_dim = weight.shape
+    real_in_dim = packed_in_dim * 2
+    if scale.shape[0] != out_dim:
+        raise ValueError(
+            f"scale first dim mismatch: weight out_dim={out_dim}, scale shape={tuple(scale.shape)}"
+        )
+    if scale.shape[1] == 0 or real_in_dim % scale.shape[1] != 0:
+        raise ValueError(
+            f"cannot infer group_size from weight {tuple(weight.shape)} and scale {tuple(scale.shape)}"
+        )
+    return real_in_dim // scale.shape[1]
+
+
+def sample_abs_error(
+    src_weight: torch.Tensor,
+    src_scale: torch.Tensor,
+    src_group_size: int,
+    dst_weight: torch.Tensor,
+    dst_scale: torch.Tensor,
+    dst_group_size: int,
+    samples: int,
+    seed: int,
+) -> dict[str, Any]:
+    if tuple(src_weight.shape) != tuple(dst_weight.shape):
+        raise ValueError(
+            f"weight shape mismatch: src={tuple(src_weight.shape)} dst={tuple(dst_weight.shape)}"
+        )
+
+    out_dim, packed_in_dim = src_weight.shape
+    in_dim = packed_in_dim * 2
+    total = out_dim * in_dim
+    actual_samples = min(samples, total)
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    flat_idx = torch.randint(total, (actual_samples,), generator=generator, device="cpu")
+    rows = flat_idx // in_dim
+    cols = flat_idx % in_dim
+
+    src_dequant = dequant_fp4_grouped(src_weight, src_scale, src_group_size)
+    dst_dequant = dequant_fp4_grouped(dst_weight, dst_scale, dst_group_size)
+
+    src_values = src_dequant[rows, cols]
+    dst_values = dst_dequant[rows, cols]
+    abs_error = (src_values - dst_values).abs()
+    worst_idx = int(abs_error.argmax().item()) if actual_samples > 0 else 0
+    return {
+        "samples": actual_samples,
+        "max_abs_error": float(abs_error.max().item()) if actual_samples > 0 else 0.0,
+        "mean_abs_error": float(abs_error.mean().item()) if actual_samples > 0 else 0.0,
+        "worst": {
+            "row": int(rows[worst_idx]) if actual_samples > 0 else None,
+            "col": int(cols[worst_idx]) if actual_samples > 0 else None,
+            "src": float(src_values[worst_idx]) if actual_samples > 0 else None,
+            "dst": float(dst_values[worst_idx]) if actual_samples > 0 else None,
+            "abs_error": float(abs_error[worst_idx]) if actual_samples > 0 else None,
+        },
+    }
+
+
+def format_tensor_info(prefix: str, weight: torch.Tensor, scale: torch.Tensor, group_size: int) -> list[str]:
+    real_in_dim = weight.shape[1] * 2
+    return [
+        f"{prefix} weight dtype: {weight.dtype}",
+        f"{prefix} weight shape: {tuple(weight.shape)}",
+        f"{prefix} real in_dim: {real_in_dim}",
+        f"{prefix} scale dtype: {scale.dtype}",
+        f"{prefix} scale shape: {tuple(scale.shape)}",
+        f"{prefix} inferred group_size: {group_size}",
+    ]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="检查 FP4 转换前后的 tensor 结构和抽样反量化误差。"
+    )
+    parser.add_argument("--src-dir", type=Path, required=True)
+    parser.add_argument("--dst-dir", type=Path, required=True)
+    parser.add_argument("--tensor-name", type=str, default=None)
+    parser.add_argument("--samples", type=int, default=64)
+    parser.add_argument("--seed", type=int, default=1234)
+    args = parser.parse_args()
+
+    src_index = load_json(args.src_dir / "model.safetensors.index.json")["weight_map"]
+    dst_index = load_json(args.dst_dir / "model.safetensors.index.json")["weight_map"]
+
+    tensor_name = args.tensor_name or choose_tensor_name(src_index)
+    if not is_fp4_expert_weight_name(tensor_name):
+        raise ValueError(f"tensor_name does not look like an expert FP4 weight: {tensor_name}")
+    if tensor_name not in src_index:
+        raise KeyError(f"{tensor_name} not found in src index")
+    if tensor_name not in dst_index:
+        raise KeyError(f"{tensor_name} not found in dst index")
+
+    scale_name = tensor_name.removesuffix(".weight") + ".scale"
+    if scale_name not in src_index:
+        raise KeyError(f"{scale_name} not found in src index")
+    if scale_name not in dst_index:
+        raise KeyError(f"{scale_name} not found in dst index")
+
+    src_shard = args.src_dir / src_index[tensor_name]
+    dst_shard = args.dst_dir / dst_index[tensor_name]
+
+    with safe_open(src_shard, framework="pt", device="cpu") as src_reader:
+        src_weight = src_reader.get_tensor(tensor_name)
+        src_scale = src_reader.get_tensor(scale_name)
+
+    with safe_open(dst_shard, framework="pt", device="cpu") as dst_reader:
+        dst_weight = dst_reader.get_tensor(tensor_name)
+        dst_scale = dst_reader.get_tensor(scale_name)
+
+    src_group_size = infer_group_size_from_shapes(src_weight, src_scale)
+    dst_group_size = infer_group_size_from_shapes(dst_weight, dst_scale)
+
+    print(f"tensor name: {tensor_name}")
+    print(f"src shard: {src_shard.name}")
+    print(f"dst shard: {dst_shard.name}")
+    print()
+    for line in format_tensor_info("src", src_weight, src_scale, src_group_size):
+        print(line)
+    print()
+    for line in format_tensor_info("dst", dst_weight, dst_scale, dst_group_size):
+        print(line)
+    print()
+
+    stats = sample_abs_error(
+        src_weight=src_weight,
+        src_scale=src_scale,
+        src_group_size=src_group_size,
+        dst_weight=dst_weight,
+        dst_scale=dst_scale,
+        dst_group_size=dst_group_size,
+        samples=args.samples,
+        seed=args.seed,
+    )
+    print(f"samples: {stats['samples']}")
+    print(f"max_abs_error: {stats['max_abs_error']}")
+    print(f"mean_abs_error: {stats['mean_abs_error']}")
+    print(f"worst_sample: {stats['worst']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/convert_deepseek_fp4_to_group128.py
+++ b/convert_deepseek_fp4_to_group128.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""把 DeepSeek 风格的 packed FP4 权重重新量化为 group_size=128。
+
+这个脚本对应的是：
+1. 源权重仍然是 FP4（E2M1-like codebook，两个 4-bit 打包到一个 int8 字节）
+2. 源 scale 是按较小 group（默认 32）提供
+3. 目标仍然输出 FP4，只是把 scale 粒度改成更大的 group（默认 128）
+
+脚本会处理：
+- `layers.*.ffn.experts.*.weight`
+- `layers.*.ffn.shared_experts.*.weight`
+
+注意：
+- 这不是 AWQ/GPTQ/Marlin 那类 `bits=4, group_size=128` 的线性 INT4 格式转换。
+- 如果目标后端期待的是 `qweight/qzeros/scales/g_idx` 一类张量布局，本脚本不能直接满足，
+  那种场景需要“反量化到浮点 -> 走目标量化器重新量化”。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import safe_open, save_file
+
+
+FP4_TABLE = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: Path, payload: dict[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def looks_like_fp8_config(src_dir: Path) -> bool:
+    config_path = src_dir / "config.json"
+    if not config_path.exists():
+        return False
+    config = load_json(config_path)
+    quant_config = config.get("quantization_config", {})
+    return (
+        quant_config.get("quant_method") == "fp8"
+        or quant_config.get("fmt") == "e4m3"
+        or quant_config.get("weight_block_size") == [128, 128]
+    )
+
+
+def is_fp4_expert_weight(name: str, tensor: torch.Tensor) -> bool:
+    return (
+        (".ffn.experts." in name or ".ffn.shared_experts." in name)
+        and name.endswith(".weight")
+        and tensor.dtype == torch.int8
+        and tensor.ndim == 2
+    )
+
+
+def unpack_fp4_values(packed: torch.Tensor) -> torch.Tensor:
+    """把 packed int8 中的两个 nibble 解成 FP4 码本值。"""
+    if packed.dtype != torch.int8 or packed.ndim != 2:
+        raise ValueError(f"expected int8 2D packed tensor, got {packed.dtype}, {packed.shape}")
+
+    out_dim, packed_in_dim = packed.shape
+    packed_u8 = packed.view(torch.uint8)
+    low = packed_u8 & 0x0F
+    high = (packed_u8 >> 4) & 0x0F
+    values = torch.stack(
+        (FP4_TABLE[low.long()], FP4_TABLE[high.long()]),
+        dim=-1,
+    ).reshape(out_dim, packed_in_dim * 2)
+    return values
+
+
+def dequant_fp4_grouped(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+    src_group_size: int,
+) -> torch.Tensor:
+    """按源 group_size 反量化得到实值张量。"""
+    fp4 = unpack_fp4_values(packed)
+    out_dim, in_dim = fp4.shape
+    expected_scale_shape = (out_dim, in_dim // src_group_size)
+    if tuple(scale.shape) != expected_scale_shape:
+        raise ValueError(
+            f"scale shape mismatch: got {tuple(scale.shape)}, expected {expected_scale_shape}"
+        )
+
+    full_scale = scale.float().repeat_interleave(src_group_size, dim=1)
+    return fp4 * full_scale
+
+
+def quantize_real_to_fp4(
+    real: torch.Tensor,
+    dst_group_size: int,
+    eps: float = 1e-12,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """把实值重新量化到 FP4，并生成新的 group scale。"""
+    if real.ndim != 2:
+        raise ValueError(f"expected 2D tensor, got shape {tuple(real.shape)}")
+
+    out_dim, in_dim = real.shape
+    if in_dim % dst_group_size != 0:
+        raise ValueError(f"in_dim={in_dim} must be divisible by dst_group_size={dst_group_size}")
+
+    num_groups = in_dim // dst_group_size
+    grouped = real.view(out_dim, num_groups, dst_group_size)
+
+    # FP4_TABLE 的最大幅值是 6.0，所以新的 scale 用 max_abs / 6。
+    max_abs = grouped.abs().amax(dim=-1)
+    new_scale = torch.clamp(max_abs / 6.0, min=eps)
+
+    normalized = grouped / new_scale.unsqueeze(-1)
+    codebook = FP4_TABLE.view(1, 1, 1, 16)
+    dist = (normalized.unsqueeze(-1) - codebook).abs()
+    nibble = dist.argmin(dim=-1).to(torch.uint8)
+
+    # 打包回 int8：偶数列放低 4 bit，奇数列放高 4 bit。
+    nibble = nibble.view(out_dim, in_dim)
+    if in_dim % 2 != 0:
+        raise ValueError(f"in_dim={in_dim} must be even for nibble packing")
+    low = nibble[:, 0::2]
+    high = nibble[:, 1::2]
+    packed_u8 = low | (high << 4)
+    packed_i8 = packed_u8.view(torch.int8)
+    return packed_i8, new_scale.float()
+
+
+def regroup_fp4_tensor(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+    src_group_size: int,
+    dst_group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    real = dequant_fp4_grouped(packed, scale, src_group_size=src_group_size)
+    return quantize_real_to_fp4(real, dst_group_size=dst_group_size)
+
+
+def convert_config(src_dir: Path, out_dir: Path, dst_group_size: int) -> None:
+    config_path = src_dir / "config.json"
+    if not config_path.exists():
+        return
+
+    config = load_json(config_path)
+    quant_config = config.setdefault("quantization_config", {})
+    quant_config["group_size"] = dst_group_size
+    quant_config["quant_method"] = "fp8"
+    quant_config.pop("weight_block_size", None)
+    quant_config.pop("activation_scheme", None)
+    quant_config.pop("fmt", None)
+    quant_config.pop("scale_fmt", None)
+    save_json(out_dir / "config.json", config)
+
+
+def should_skip_copy(rel_path: Path) -> bool:
+    name = rel_path.name
+    if rel_path == Path("config.json"):
+        return True
+    if rel_path == Path("model.safetensors.index.json"):
+        return True
+    if name.startswith("model-") and name.endswith(".safetensors"):
+        return True
+    return False
+
+
+def copy_non_weight_artifacts(src_dir: Path, out_dir: Path) -> None:
+    for path in sorted(src_dir.rglob("*")):
+        rel = path.relative_to(src_dir)
+        if rel == Path("."):
+            continue
+        if should_skip_copy(rel):
+            continue
+
+        dst = out_dir / rel
+        if path.is_dir():
+            dst.mkdir(parents=True, exist_ok=True)
+            continue
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, dst)
+
+
+def read_existing_shard_keys_and_size(path: Path) -> tuple[set[str], int]:
+    with safe_open(path, framework="pt", device="cpu") as reader:
+        keys = set(reader.keys())
+        total_size = 0
+        for key in keys:
+            tensor = reader.get_tensor(key)
+            total_size += tensor.numel() * tensor.element_size()
+    return keys, total_size
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert packed FP4 tensors to group_size=128 FP4.")
+    parser.add_argument("--input-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--src-group-size", type=int, default=32)
+    parser.add_argument("--dst-group-size", type=int, default=128)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="断点续跑。若输出 shard 已存在且包含该 shard 所需全部 tensor，则直接跳过。",
+    )
+    parser.add_argument(
+        "--progress-every",
+        type=int,
+        default=1,
+        help="每处理多少个 shard 打印一次进度，默认每个 shard 都打印。",
+    )
+    parser.add_argument(
+        "--skip-input-format-check",
+        action="store_true",
+        help="跳过 config.json 的输入格式检查。仅当你确认目录虽然写着 fp8，但实际 expert 权重仍是 packed FP4 时使用。",
+    )
+    args = parser.parse_args()
+
+    src_dir = args.input_dir.resolve()
+    out_dir = args.output_dir.resolve()
+
+    index_path = src_dir / "model.safetensors.index.json"
+    if not index_path.exists():
+        raise FileNotFoundError(index_path)
+
+    if looks_like_fp8_config(src_dir) and not args.skip_input_format_check:
+        raise ValueError(
+            "input config.json looks like an FP8 checkpoint already. "
+            "If your actual expert weights are still packed FP4 and only config.json is misleading, "
+            "rerun with --skip-input-format-check."
+        )
+
+    if args.overwrite and args.resume:
+        raise ValueError("--overwrite and --resume are mutually exclusive")
+
+    if out_dir.exists() and any(out_dir.iterdir()) and not args.overwrite and not args.resume:
+        raise FileExistsError(f"{out_dir} is not empty; pass --overwrite to continue")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    index = load_json(index_path)
+    weight_map = index["weight_map"]
+    by_file: dict[str, list[str]] = {}
+    for name, file_name in weight_map.items():
+        by_file.setdefault(file_name, []).append(name)
+
+    emitted_map: dict[str, str] = {}
+    ordered_files = sorted(by_file)
+    total_files = len(ordered_files)
+    print(f"starting conversion: {total_files} shard(s)", flush=True)
+
+    for file_idx, file_name in enumerate(ordered_files, start=1):
+        src_file = src_dir / file_name
+        out_file = out_dir / file_name
+        expected_names = set(by_file[file_name])
+
+        if args.resume and out_file.exists():
+            existing_keys, _ = read_existing_shard_keys_and_size(out_file)
+            if expected_names.issubset(existing_keys):
+                emitted_map.update({name: file_name for name in expected_names})
+                if file_idx == 1 or file_idx % args.progress_every == 0 or file_idx == total_files:
+                    print(
+                        f"[{file_idx}/{total_files}] skipping existing completed shard: {file_name}",
+                        flush=True,
+                    )
+                continue
+            print(
+                f"[{file_idx}/{total_files}] existing shard incomplete, regenerating: {file_name}",
+                flush=True,
+            )
+        elif file_idx == 1 or file_idx % args.progress_every == 0 or file_idx == total_files:
+            print(f"[{file_idx}/{total_files}] converting shard: {file_name}", flush=True)
+
+        state_dict: dict[str, torch.Tensor] = {}
+        with safe_open(src_file, framework="pt", device="cpu") as reader:
+            key_set = set(reader.keys())
+            consumed: set[str] = set()
+            for name in by_file[file_name]:
+                if name in consumed:
+                    continue
+                if name not in key_set:
+                    continue
+                tensor = reader.get_tensor(name)
+
+                if is_fp4_expert_weight(name, tensor):
+                    scale_name = name.removesuffix(".weight") + ".scale"
+                    if scale_name not in key_set:
+                        raise KeyError(f"missing scale tensor for {name}: {scale_name}")
+                    new_weight, new_scale = regroup_fp4_tensor(
+                        tensor,
+                        reader.get_tensor(scale_name),
+                        src_group_size=args.src_group_size,
+                        dst_group_size=args.dst_group_size,
+                    )
+                    state_dict[name] = new_weight
+                    state_dict[scale_name] = new_scale
+                    emitted_map[name] = file_name
+                    emitted_map[scale_name] = file_name
+                    consumed.add(scale_name)
+                    continue
+
+                if name.endswith(".scale"):
+                    # 非 expert 的 scale 先原样保留；如果目标后端也要求改布局，需要再单独处理。
+                    state_dict[name] = tensor.float()
+                else:
+                    state_dict[name] = tensor
+                emitted_map[name] = file_name
+
+        save_file(state_dict, out_file, metadata={"format": "pt"})
+
+    total_size = 0
+    for file_name in sorted(set(emitted_map.values())):
+        _, shard_size = read_existing_shard_keys_and_size(out_dir / file_name)
+        total_size += shard_size
+
+    save_json(
+        out_dir / "model.safetensors.index.json",
+        {
+            "metadata": {"total_size": total_size},
+            "weight_map": dict(sorted(emitted_map.items())),
+        },
+    )
+    convert_config(src_dir, out_dir, args.dst_group_size)
+    copy_non_weight_artifacts(src_dir, out_dir)
+
+    print(f"converted checkpoint written to {out_dir}")
+
+
+if __name__ == "__main__":
+    torch.set_num_threads(min(8, os.cpu_count() or 1))
+    main()

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -5,6 +5,40 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import einops
 import torch
+def _expand_fp4_scale_for_deepgemm_runtime(
+    scale: torch.Tensor,
+    logical_k: int,
+    gran_k_b: int = 32,
+    ) -> torch.Tensor:
+        """Expand FP4 expert scale on K dimension for DeepGEMM runtime ABI.
+
+        Checkpoint may store FP4 scales with group_size=128, while current DeepGEMM
+        sm90 fp8×fp4 kernel expects scale groups indexed with gran_k_b=32.
+        In that case, repeat each stored scale along the last dim so that:
+            scale.shape[-1] == ceil_div(logical_k, gran_k_b)
+
+        This does not change checkpoint semantics: one g128 scale is reused for the
+        four contiguous g32 sub-groups it covers.
+        """
+        if scale is None:
+            return scale
+
+        expected_k_groups = (logical_k + gran_k_b - 1) // gran_k_b
+        current_k_groups = scale.shape[2]
+
+        if current_k_groups == expected_k_groups:
+            return scale
+
+        if expected_k_groups % current_k_groups != 0:
+            raise ValueError(
+                f"Cannot expand FP4 scale for DeepGEMM runtime: "
+                f"current shape={tuple(scale.shape)}, "
+                f"logical_k={logical_k}, gran_k_b={gran_k_b}, "
+                f"expected_k_groups={expected_k_groups}"
+            )
+
+        repeat = expected_k_groups // current_k_groups
+        return scale.repeat_interleave(repeat, dim=2).contiguous()
 
 from sglang.jit_kernel.dsv4 import silu_and_mul_masked_post_quant
 from sglang.srt.environ import envs
@@ -183,7 +217,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         quant_info: DeepGemmMoeQuantInfo,
         running_state: dict,
     ) -> torch.Tensor:
-        from sglang.jit_kernel.deepseek_v4 import silu_and_mul_contig_post_quant
+        from sglang.jit_kernel.dsv4 import silu_and_mul_contig_post_quant
         from sglang.srt.layers.moe.ep_moe.kernels import tma_align_input_scale
         from sglang.srt.layers.quantization.fp8_kernel import (
             create_per_token_group_quant_fp8_output_scale,
@@ -438,6 +472,23 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                 w13_scale_for_gemm = quant_info.w13_scale_e8m0
             else:
                 w13_scale_for_gemm = w13_scale
+
+            w13_scale_for_gemm = _expand_fp4_scale_for_deepgemm_runtime(
+                w13_scale_for_gemm,
+                logical_k=k,
+                gran_k_b=32,
+            )
+
+            # print(
+            #     "[g128-debug] gemm0-input",
+            #     "lhs_act=", tuple(hidden_states.shape),
+            #     "lhs_scale=", tuple(hidden_states_scale.shape) if hidden_states_scale is not None else None,
+            #     "rhs_weight=", tuple(w13_weight.shape),
+            #     "rhs_scale=", tuple(w13_scale_for_gemm.shape),
+            #     "expected_rhs_scale_kgroups=", (k + 32 - 1) // 32,
+            #     flush=True,
+            # )
+
             deep_gemm_wrapper.grouped_gemm_nt_f8fp4bf16_masked(
                 (hidden_states, hidden_states_scale),
                 (w13_weight, w13_scale_for_gemm),
@@ -543,6 +594,23 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                 w2_scale_for_gemm = quant_info.w2_scale_e8m0
             else:
                 w2_scale_for_gemm = w2_scale
+            
+            w2_scale_for_gemm = _expand_fp4_scale_for_deepgemm_runtime(
+                w2_scale_for_gemm,
+                logical_k=down_k,
+                gran_k_b=32,
+            )
+
+            # print(
+            #     "[g128-debug] gemm1-input",
+            #     "lhs_act=", tuple(down_input.shape),
+            #     "lhs_scale=", tuple(down_input_scale.shape) if down_input_scale is not None else None,
+            #     "rhs_weight=", tuple(w2_weight.shape),
+            #     "rhs_scale=", tuple(w2_scale_for_gemm.shape),
+            #     "expected_rhs_scale_kgroups=", (down_k + 32 - 1) // 32,
+            #     flush=True,
+            # )
+            
             deep_gemm_return_value = deep_gemm_wrapper.grouped_gemm_nt_f8fp4bf16_masked(
                 (down_input, down_input_scale),
                 (w2_weight, w2_scale_for_gemm),

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -152,11 +152,13 @@ class Fp8Config(QuantizationConfig):
         packed_modules_mapping: Optional[Dict[str, List[str]]] = None,
         use_mxfp8: bool = False,
         is_fp4_experts: bool = False,
+        fp4_group_size: int = 32,
     ) -> None:
         super().__init__()
         # DSV4 mxfp4-packed (True) vs converted FP8 (False); injected by
         # model_loader from ModelConfig. Default False off the DSV4 path.
         self.is_fp4_experts = is_fp4_experts
+        self.fp4_group_size = fp4_group_size
         self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
         if is_checkpoint_fp8_serialized:
             log_info_on_rank0(logger, "Detected fp8 checkpoint.")
@@ -193,6 +195,9 @@ class Fp8Config(QuantizationConfig):
             elif weight_block_size != [1, 32]:
                 raise ValueError("MXFP8 requires weight_block_size=[1, 32].")
         self.weight_block_size = weight_block_size
+
+        if self.fp4_group_size <= 0:
+            raise ValueError(f"fp4_group_size must be positive, got {self.fp4_group_size}")
 
     def get_name(self) -> str:
         return "mxfp8" if self.use_mxfp8 else "fp8"
@@ -231,12 +236,18 @@ class Fp8Config(QuantizationConfig):
                 normalized.append(base)
                 normalized.append(f"model.{base}")
             ignored_layers = normalized
+
         weight_block_size = cls.get_from_keys_or(config, ["weight_block_size"], None)
+        fp4_group_size = cls.get_from_keys_or(
+            config, ["expert_group_size", "group_size"], 32
+        )
+
         if use_mxfp8 and weight_block_size is not None:
             logger.warning(
                 "MXFP8 ignoring incoming weight_block_size in config.json; it is fixed to [1, 32]."
             )
             weight_block_size = [1, 32]
+
         return cls(
             is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
             activation_scheme=activation_scheme,
@@ -244,6 +255,7 @@ class Fp8Config(QuantizationConfig):
             weight_block_size=weight_block_size,
             packed_modules_mapping=packed_modules_mapping,
             use_mxfp8=use_mxfp8,
+            fp4_group_size=fp4_group_size,
         )
 
     def get_quant_method(
@@ -1015,7 +1027,17 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         # WEIGHT_SCALES
         if self.is_fp4_expert:
-            fp4_block_k = 32
+            fp4_block_k = self.quant_config.fp4_group_size
+            if hidden_size % fp4_block_k != 0:
+                raise ValueError(
+                    f"hidden_size={hidden_size} must be divisible by fp4_group_size={fp4_block_k}"
+                )
+            if intermediate_size_per_partition % fp4_block_k != 0:
+                raise ValueError(
+                    f"intermediate_size_per_partition={intermediate_size_per_partition} "
+                    f"must be divisible by fp4_group_size={fp4_block_k}"
+                )
+
             fp4_scale_dtype = torch.float8_e8m0fnu if _use_aiter else torch.float32
             w13_weight_scale = torch.nn.Parameter(
                 torch.ones(
@@ -1158,7 +1180,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
             if padded_inter != inter_per_part:
                 pad_amount = padded_inter - inter_per_part
-                fp4_block_k = 32
+                fp4_block_k = self.quant_config.fp4_group_size
 
                 # Pad w13_weight: (E, 2*inter, K_packed) → (E, 2*padded, K_packed)
                 old_w13 = layer.w13_weight.data
@@ -1324,21 +1346,71 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 ):
                     from deep_gemm import transform_sf_into_required_layout
 
+                    fp4_group_size = self.quant_config.fp4_group_size
+                    deepgemm_gran_k = 32
+
+                    if fp4_group_size % deepgemm_gran_k != 0:
+                        raise ValueError(
+                            f"fp4_group_size={fp4_group_size} must be divisible by "
+                            f"DeepGEMM gran_k={deepgemm_gran_k}"
+                        )
+
+                    expand_ratio = fp4_group_size // deepgemm_gran_k
+
                     for scale_param, weight_param in [
                         (layer.w13_weight_scale_inv, layer.w13_weight),
                         (layer.w2_weight_scale_inv, layer.w2_weight),
                     ]:
-                        num_experts, n, _ = scale_param.data.shape
+                        num_experts, n, k_groups_loaded = scale_param.data.shape
                         k = weight_param.shape[2] * 2
+
+                        expected_loaded_k_groups = k // fp4_group_size
+                        if k_groups_loaded != expected_loaded_k_groups:
+                            raise ValueError(
+                                f"Loaded FP4 scale shape mismatch: got last dim={k_groups_loaded}, "
+                                f"expected {expected_loaded_k_groups} for k={k}, "
+                                f"fp4_group_size={fp4_group_size}"
+                            )
+
+                        # DeepGEMM sm90 fp8×fp4 kernel still expects scale layout indexed
+                        # with granularity 32 on K dimension. For a g128 checkpoint, each
+                        # scale should be repeated across 4 contiguous 32-sized subgroups.
+                        runtime_scale = scale_param.data.repeat_interleave(
+                            expand_ratio, dim=2
+                        ).contiguous()
+                        # print(
+                        #     "[g128-debug] after-expand",
+                        #     "runtime_scale=",
+                        #     tuple(runtime_scale.shape),
+                        #     "expected_runtime_k_groups=",
+                        #     expected_runtime_k_groups,
+                        #     flush=True,
+                        # )
+
+                        expected_runtime_k_groups = k // deepgemm_gran_k
+                        if runtime_scale.shape[2] != expected_runtime_k_groups:
+                            raise ValueError(
+                                f"Expanded runtime FP4 scale shape mismatch: got last dim="
+                                f"{runtime_scale.shape[2]}, expected {expected_runtime_k_groups} "
+                                f"for k={k}, deepgemm_gran_k={deepgemm_gran_k}"
+                            )
+
                         tma_aligned_n_e8m0 = ((n + 15) // 16) * 16
                         scale_data = transform_sf_into_required_layout(
-                            scale_param.data,
+                            runtime_scale,
                             mn=n,
                             k=k,
-                            recipe=(1, 32),
+                            recipe=(1, deepgemm_gran_k),
                             num_groups=num_experts,
                             disable_ue8m0_cast=False,
                         )
+                        # print(
+                        #     "[g128-debug] after-transform",
+                        #     "scale_data=",
+                        #     tuple(scale_data.shape),
+                        #     flush=True,
+                        # )
+
                         e8m0_scale_data = torch.empty_strided(
                             scale_data.shape,
                             (
@@ -1354,8 +1426,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                                 torch.uint8
                             )
                         )
+
                         scale_param.scale_e8m0_data = e8m0_scale_data
                         scale_param.data = scale_data
+                        
                     layer.w13_weight_scale_inv.format_ue8m0 = True
                     layer.w2_weight_scale_inv.format_ue8m0 = True
 


### PR DESCRIPTION
## Motivation
Co-authored-by:@zhangxiaolei123456

DeepSeek-V4-Flash stores expert FP4 scales with group_size=32 in the original checkpoint. This PR enables a converted checkpoint format with expert group_size=128 and adds the corresponding SGLang runtime support.

Specifically, this PR:
- converts DeepSeek-V4-Flash expert FP4 weights from group_size=32 to group_size=128,
- validates conversion correctness,
- updates FP4 expert scale allocation/loading logic,
- and makes the Hopper DeepGEMM FP8xFP4 runtime path compatible with the converted checkpoint.

| Variant       | Group Size | Hardware | Input | Output | Chunked Prefill Size | Mappings       | QPS | Max Concurrency | Num Prompts | TPOT (ms) | Decode |
|---------------|------------|----------|-------|--------|----------------------|----------------|-----|-----------------|-------------|-----------|--------|
| W4A8 DeepGEMM | 32        | H20      | 16000 | 1500   | 8192                | Linear and GQA | 40   | 512              | 2048         | 33.05     | 1709    |
| W4A8 DeepGEMM | 128        | H20      | 3500 | 1500   | 8192              | Linear and GQA | 40   | 512              | 2048         | 11.10     | 3584    |
| W4A8 DeepGEMM | 128        | H20      | 16000 | 1500   | 8192              | Linear and GQA | 40   | 512              | 2048         | 14.57     | 3307    |
## Conversion Validation

We validated the converted checkpoint against the original DeepSeek-V4-Flash expert weights using `check_fp4_conversion.py`.

Example result for `layers.0.ffn.experts.0.w1.weight`:

- source weight dtype: `torch.int8`
- source weight shape: `(2048, 2048)`
- source scale shape: `(2048, 128)`
- source inferred group size: `32`

- converted weight dtype: `torch.int8`
- converted weight shape: `(2048, 2048)`
- converted scale shape: `(2048, 32)`
- converted inferred group size: `128`

Validation on 64 sampled elements:
- max abs error: `0.0052083320915699005`
- mean abs error: `0.001180012826807797`

Worst sample:
- row: `1501`
- col: `3125`
- src: `0.046875`
- dst: `0.0416666679084301`
- abs error: `0.0052083320915699005`

## Runtime Validation

### Prefill
The original FP8 checkpoint is used on the prefill side:

```bash
SGLANG_DSV4_FP4_EXPERTS=0 \
SGLANG_DEFAULT_THINKING=1 \
SGLANG_JIT_DEEPGEMM_PRECOMPILE=1 \
GLOO_SOCKET_IFNAME=eth0 \
NCCL_MIN_NCHANNELS=24 \
NCCL_IB_QPS_PER_CONNECTION=8 \
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
sglang serve \
  --trust-remote-code \
  --model-path $V4_FLASH_FP8 \
  --tp 8 \
  --chunked-prefill-size 8192 \
  --mem-fraction-static 0.8 \
  --max-running-requests 128 \
  --moe-a2a-backend deepep \
  --enable-nsa-prefill-context-parallel \
  --nsa-prefill-cp-mode round-robin-split \
  --tool-call-parser deepseekv4 \
  --reasoning-parser deepseek-v4 \
  --host 0.0.0.0 \
  --port 31000 \
  --disaggregation-mode prefill \
  --disaggregation-bootstrap-port 31500 \
  --disaggregation-transfer-backend mooncake
```

### Decode
The converted FP4-g128 checkpoint is used on the decode side:
```bash
SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=256 \
DG_W4_SCALE_B_E8M0_ONLY=1 \
DG_W4_SCALE_B_E8M0=1 \
SGLANG_DSV4_FP4_EXPERTS=1 \
SGLANG_DEFAULT_THINKING=1 \
SGLANG_JIT_DEEPGEMM_PRECOMPILE=1 \
GLOO_SOCKET_IFNAME=eth0 \
NCCL_MIN_NCHANNELS=24 \
NCCL_IB_QPS_PER_CONNECTION=8 \
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
sglang serve \
  --trust-remote-code \
  --model-path $V4_FLASH_fp4_g128 \
  --tp 8 \
  --dp-size 8 \
  --enable-dp-attention \
  --cuda-graph-max-bs 64 \
  --chunked-prefill-size 8192 \
  --mem-fraction-static 0.8 \
  --max-running-requests 512 \
  --enable-metrics \
  --tool-call-parser deepseekv4 \
  --reasoning-parser deepseek-v4 \
  --moe-runner-backend deep_gemm \
  --moe-a2a-backend deepep \
  --deepep-mode low_latency \
  --host 0.0.0.0 \
  --port 30000 \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-ib-device "mlx5_1,mlx5_2,mlx5_3,mlx5_4" \
  --speculative-algo EAGLE \
  --speculative-num-steps 2 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 3
```
### Benchmark
```bash
HF_ENDPOINT=https://hf-mirror.com \
python3 -m sglang.bench_serving \
  --host 127.0.0.1 \
  --port 8090 \
  --model /sgl-workspace/sglang/DeepSeek-V4-Flash-fp4-g128 \
  --dataset-name generated-shared-prefix \
  --gsp-system-prompt-len 16000 \
  --gsp-question-len 64 \
  --gsp-output-len 1500 \
  --random-range-ratio 1 \
  --gsp-num-groups 1 \
  --gsp-prompts-per-group 2048 \
  --max-concurrency 512 \
  --request-rate 40
```

The decode server successfully reaches the ready state and runs the FP8xFP4 DeepGEMM path with the converted `group_size=128` expert scales.





<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->