### PR TITLE
fix(hiradix): wait for extra pool IO (#27550)

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1138,6 +1138,13 @@ class HiRadixCache(RadixCache):
             # unknown prefetch stop policy, just return True
             return True
 
+        if (
+            completed
+            and getattr(operation, "pool_transfers", None)
+            and not getattr(operation, "pool_transfers_done", True)
+        ):
+            can_terminate = False
+
         operation_terminated = operation.is_terminated()
         states = torch.tensor(
             [1 - int(can_terminate), int(operation_terminated)],


### PR DESCRIPTION
Syncs upstream PR sgl-project/sglang#27550 into `bytedance/deepseek_v4`.

Upstream PR: https://github.com/sgl-project/sglang/pull/27550
Upstream merged commit: `991689fd0d50f2de3bfbcda3323efa499a7305c7`

## Validation

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/private/tmp/sglang-pycache-27550 python3 -m py_compile python/sglang/srt/mem_cache/hiradix_cache.py`
- Patch matches the upstream merged commit (7 insertions in `hiradix_cache.py`)

Note: `pre-commit` is not installed in the local environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->