### PR TITLE
[HiCache][DSV4] Backport UnifiedTree L2 accuracy fixes

### DIFF
--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -606,12 +606,9 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if full_indices.numel() == 0:
             return
         assert full_indices.numel() == swa_indices.numel()
-        if _is_npu:
-            self.full_to_swa_index_mapping[full_indices.to(torch.int64)] = (
-                swa_indices.to(torch.int64)
-            )
-        else:
-            self.full_to_swa_index_mapping[full_indices] = swa_indices
+        full_indices = full_indices.to(torch.int64)
+        swa_indices = swa_indices.to(self.full_to_swa_index_mapping.dtype)
+        self.full_to_swa_index_mapping[full_indices] = swa_indices
 
     def free_swa(self, free_index: torch.Tensor):
         if free_index.numel() == 0:

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -1135,27 +1135,50 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                     ), f"swa_evicted_seqlen must be page aligned, {swa_evicted_seqlen=}, {self.page_size=}"
                     if swa_evicted_seqlen <= total_prefix_length:
                         # Branch 1: all swa tokens of value[:prefix_len] are not evicted, so we can insert it to the tree directly.
-                        # Free full tokens in the original tree node.
-                        self.token_to_kv_pool_allocator.free(node.value[:prefix_len])
-                        # Overwrite the new value in request to the tree node.
-                        node.value = value[:prefix_len].clone()
-                        node.swa_tombstone = False
-                        self.swa_lru_list.insert_mru(node)
-                        self.swa_evictable_size_ += len(node.value)
+                        if node.full_lock_ref > 0:
+                            # Full KV is still locked by a running request. Keep it
+                            # and adopt the incoming SWA instead of freeing in-flight
+                            # Full slots.
+                            self._recover_tombstone_keeping_locked_full(
+                                node, value[:prefix_len]
+                            )
+                        else:
+                            # Free full tokens in the original tree node.
+                            self.token_to_kv_pool_allocator.free(
+                                node.value[:prefix_len]
+                            )
+                            # Overwrite the new value in request to the tree node.
+                            node.value = value[:prefix_len].clone()
+                            node.swa_tombstone = False
+                            self.swa_lru_list.insert_mru(node)
+                            self.swa_evictable_size_ += len(node.value)
                     elif swa_evicted_seqlen < total_prefix_length + prefix_len:
                         # Branch 2: part of swa tokens of value[:prefix_len] are evicted, so we need to split the node and insert the value to new node.
                         start_update_idx = swa_evicted_seqlen - total_prefix_length
-                        self.token_to_kv_pool_allocator.free(
-                            node.value[start_update_idx:prefix_len]
-                        )
-                        self._split_node(node.key, node, start_update_idx)
-                        # Here node is the new node after split, so we can overwrite the value to the new node.
-                        # The old node is still swa tombstone and the full token is not freed.
-                        node.value = value[start_update_idx:prefix_len].clone()
-                        self.token_to_kv_pool_allocator.free(value[:start_update_idx])
-                        node.swa_tombstone = False
-                        self.swa_lru_list.insert_mru(node)
-                        self.swa_evictable_size_ += len(node.value)
+                        if node.full_lock_ref > 0:
+                            # Split first so the recovered suffix keeps the locked
+                            # Full slots, then adopt the incoming SWA for that suffix.
+                            self._split_node(node.key, node, start_update_idx)
+                            self._recover_tombstone_keeping_locked_full(
+                                node, value[start_update_idx:prefix_len]
+                            )
+                            self.token_to_kv_pool_allocator.free(
+                                value[:start_update_idx]
+                            )
+                        else:
+                            self.token_to_kv_pool_allocator.free(
+                                node.value[start_update_idx:prefix_len]
+                            )
+                            self._split_node(node.key, node, start_update_idx)
+                            # Here node is the new node after split, so we can overwrite the value to the new node.
+                            # The old node is still swa tombstone and the full token is not freed.
+                            node.value = value[start_update_idx:prefix_len].clone()
+                            self.token_to_kv_pool_allocator.free(
+                                value[:start_update_idx]
+                            )
+                            node.swa_tombstone = False
+                            self.swa_lru_list.insert_mru(node)
+                            self.swa_evictable_size_ += len(node.value)
                     else:
                         # Branch 3: all swa tokens of value[:prefix_len] are evicted, so we don't need to update the node.
                         self.token_to_kv_pool_allocator.free(value[:prefix_len])
@@ -1213,6 +1236,30 @@ class SWARadixCache(KVCacheEventMixin, BasePrefixCache):
                 self._maybe_split_leaf_for_swa_lock(new_leaf)
 
         return total_prefix_length
+
+    def _recover_tombstone_keeping_locked_full(
+        self, node: TreeNode, incoming_full: torch.Tensor
+    ) -> None:
+        """Recover a tombstoned node whose Full KV is locked by a running request.
+
+        Keep node.value, the locked Full slots, and re-point its full->SWA
+        mapping at the incoming request's fresh SWA. Free only the incoming
+        redundant Full slots, not their SWA slots.
+        """
+        assert len(node.value) == len(incoming_full), (
+            f"locked-full recover size mismatch: {len(node.value)=}, "
+            f"{len(incoming_full)=}"
+        )
+
+        allocator = self.token_to_kv_pool_allocator
+        swa_value = allocator.translate_loc_from_full_to_swa(incoming_full)
+        allocator.set_full_to_swa_mapping(node.value, swa_value)
+        allocator.full_to_swa_index_mapping[incoming_full.to(torch.int64)] = 0
+        allocator.full_attn_allocator.free(incoming_full)
+
+        node.swa_tombstone = False
+        self.swa_lru_list.insert_mru(node)
+        self.swa_evictable_size_ += len(node.value)
 
     def _add_new_node(
         self,

--- a/python/sglang/srt/mem_cache/unified_cache_components/README.md
+++ b/python/sglang/srt/mem_cache/unified_cache_components/README.md
@@ -125,9 +125,8 @@ Insert a key-value pair into the tree.
      - If partially within window: **splits node** at boundary, recovers SWA on the window portion (returns `start_idx`)
      - If entirely outside window: returns `prefix_len` (no consumption)
    - Mamba: returns `prefix_len` (no consumption, default behavior)
-4. Before creating a new leaf, checks `should_skip_leaf_creation()` per component — any veto aborts leaf creation and frees remaining value
-5. Creates leaf via `_add_new_node` (clones value tensor, inserts into Full LRU)
-6. Calls `commit_insert_component_data()` per component on the final target node (SWA may trigger a secondary split for window boundary; Mamba sets mamba pool indices and inserts into Mamba LRU)
+4. Creates leaf via `_add_new_node` (clones value tensor, inserts into Full LRU). A leaf survives on its Full value alone, so it is materialized even when an auxiliary component holds only a tombstone for the span (e.g. the whole leaf is outside the SWA window)
+5. Calls `commit_insert_component_data()` per component on the final target node (SWA may trigger a secondary split for window boundary; Mamba sets mamba pool indices and inserts into Mamba LRU)
 
 ---
 
@@ -262,7 +261,7 @@ Each component implements these hooks. See `tree_component.py` for the ABC and d
 | Hook | Purpose | Called By | Default |
 |------|---------|-----------|----------|
 | `update_component_on_insert_overlap()` | Handle key overlap with an existing node during insert. Returns the index within `value_slice` from which this component consumed (took ownership of) pool slots. Full/Mamba: no consumption (`prefix_len`). SWA: may recover tombstoned nodes within the sliding window boundary. | `_insert_helper` | returns `prefix_len` |
-| `should_skip_leaf_creation()` | Veto leaf creation when the entire new leaf would be a tombstone for this component. SWA: vetoes if `swa_evicted_seqlen ≥ total_prefix_len + key_len`. | `_insert_helper` | `False` |
+| `recover_after_unevict()` | Rebuild auxiliary component data after `_unevict_node_on_insert()` restores a Full device value from fresh KV indices. SWA uses this to rebuild in-window SWA data. | `_insert_helper` | no-op |
 | `commit_insert_component_data()` | Finalize component data on the target node after the insert walk completes. Full: no-op (handled by `_add_new_node`). SWA: checks window boundary, may split node — parent becomes tombstone, child gets SWA data. Mamba: sets mamba pool indices and inserts into Mamba LRU. | `_insert_helper` | no-op |
 
 ### Node Split

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -69,6 +69,19 @@ class SWAComponent(TreeComponent):
         self.cache.lru_lists[ct].insert_mru(node)
         self.cache.component_evictable_size_[ct] += len(value)
 
+    def _restore_device_value_with_locked_full(
+        self,
+        node: UnifiedTreeNode,
+        full_value: torch.Tensor,
+        incoming_full_value: torch.Tensor,
+    ) -> None:
+        allocator = self.cache.token_to_kv_pool_allocator
+        swa_value = self._translate_full_to_swa(incoming_full_value)
+        allocator.set_full_to_swa_mapping(full_value, swa_value)
+        allocator.full_to_swa_index_mapping[incoming_full_value.to(torch.int64)] = 0
+        allocator.full_attn_allocator.free(incoming_full_value)
+        self._restore_device_value(node, swa_value)
+
     def create_match_validator(
         self, match_device_only: bool = False
     ) -> Callable[[UnifiedTreeNode], bool]:
@@ -128,6 +141,7 @@ class SWAComponent(TreeComponent):
         if not is_tombstone:
             return prefix_len
 
+        full_cd = node.component_data[BASE_COMPONENT_TYPE]
         swa_evicted_seqlen = params.swa_evicted_seqlen
         assert (
             node.component_data[self.component_type].lock_ref == 0
@@ -138,21 +152,27 @@ class SWAComponent(TreeComponent):
 
         if swa_evicted_seqlen <= total_prefix_len:
             # Branch 1: entire value_slice is within SWA window — recover
-            self.cache.token_to_kv_pool_allocator.free(
-                node.component_data[BASE_COMPONENT_TYPE].value
-            )
-            node.component_data[BASE_COMPONENT_TYPE].value = value_slice.clone()
-            swa_value = self._translate_full_to_swa(
-                node.component_data[BASE_COMPONENT_TYPE].value
-            )
+            if full_cd.lock_ref > 0:
+                self._restore_device_value_with_locked_full(
+                    node, full_cd.value, value_slice
+                )
+                return 0
+            self.cache.token_to_kv_pool_allocator.free(full_cd.value)
+            full_cd.value = value_slice.clone()
+            swa_value = self._translate_full_to_swa(full_cd.value)
             self._restore_device_value(node, swa_value)
             return 0
         elif swa_evicted_seqlen < total_prefix_len + prefix_len:
             # Branch 2: value_slice[start_idx:] is within SWA window — partial recover
             start_idx = swa_evicted_seqlen - total_prefix_len
-            self.cache.token_to_kv_pool_allocator.free(
-                node.component_data[BASE_COMPONENT_TYPE].value[start_idx:]
-            )
+            if full_cd.lock_ref > 0:
+                self.cache._split_node(node.key, node, start_idx)
+                full_cd = node.component_data[BASE_COMPONENT_TYPE]
+                self._restore_device_value_with_locked_full(
+                    node, full_cd.value, value_slice[start_idx:]
+                )
+                return start_idx
+            self.cache.token_to_kv_pool_allocator.free(full_cd.value[start_idx:])
             self.cache._split_node(node.key, node, start_idx)
             node.component_data[BASE_COMPONENT_TYPE].value = value_slice[
                 start_idx:

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -166,13 +166,6 @@ class SWAComponent(TreeComponent):
             # Branch 3: entire value_slice is outside SWA window — not consumed
             return prefix_len
 
-    def should_skip_leaf_creation(
-        self, total_prefix_len: int, key_len: int, params: InsertParams
-    ) -> bool:
-        if params.force_leaf_creation:
-            return False
-        return params.swa_evicted_seqlen >= total_prefix_len + key_len
-
     def recover_after_unevict(
         self,
         node: UnifiedTreeNode,

--- a/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
@@ -160,13 +160,6 @@ class TreeComponent(ABC):
         portion: value_slice[dup_start:consumed_from]."""
         return prefix_len
 
-    def should_skip_leaf_creation(
-        self, total_prefix_len: int, key_len: int, params: InsertParams
-    ) -> bool:
-        """Return True to veto leaf creation when the entire new leaf would
-        be a tombstone for this component."""
-        return False
-
     def recover_after_unevict(
         self,
         node: UnifiedTreeNode,

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -993,21 +993,11 @@ class UnifiedRadixCache(BasePrefixCache):
                 child_key = key.child_key(self.page_size)
 
         is_new_leaf = False
-        # Create new leaf for remaining suffix
+        # Create new leaf for remaining suffix. A leaf survives on its Full
+        # value alone; auxiliary components (SWA, Mamba) may legitimately hold
+        # only a tombstone for this span (e.g. the whole leaf is outside the SWA
+        # window). Materialize it anyway so the Full KV stays cacheable.
         if len(key):
-            if any(
-                comp.should_skip_leaf_creation(
-                    total_prefix_len=total_prefix_length,
-                    key_len=len(key),
-                    params=params,
-                )
-                for comp in self._components_tuple
-            ):
-                # TODO: When leaf creation is skipped, We should release all component
-                # resources here or propagate a flag so that
-                # cleanup_after_caching_req can free them properly.
-                self.token_to_kv_pool_allocator.free(value)
-                return InsertResult(prefix_len=total_prefix_length)
             target_node = self._add_new_node(node, key, value)
             is_new_leaf = True
         else:

--- a/test/registered/unit/disaggregation/test_dsv4_decode_radix_cache.py
+++ b/test/registered/unit/disaggregation/test_dsv4_decode_radix_cache.py
@@ -11,7 +11,6 @@ from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchResult
 from sglang.srt.mem_cache.common import maybe_cache_unfinished_req
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.kv_cache_builder import is_supported_dsv4_decode_radix_mtp
-from sglang.srt.mem_cache.unified_cache_components.swa_component import SWAComponent
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
@@ -231,23 +230,6 @@ def test_dsv4_swa_release_tail_len_falls_back_to_page():
             processor, protected_len=100, page_size=2
         )
         == 2
-    )
-
-
-def test_swa_component_force_leaf_creation_allows_full_only_leaf():
-    component = SWAComponent.__new__(SWAComponent)
-
-    assert SWAComponent.should_skip_leaf_creation(
-        component,
-        total_prefix_len=0,
-        key_len=256,
-        params=InsertParams(swa_evicted_seqlen=256),
-    )
-    assert not SWAComponent.should_skip_leaf_creation(
-        component,
-        total_prefix_len=0,
-        key_len=256,
-        params=InsertParams(swa_evicted_seqlen=256, force_leaf_creation=True),
     )
 
 

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -813,6 +813,75 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(len(m.device_indices), len(seq))
         tree.sanity_check()
 
+    def test_swa_unfinished_recovery_preserves_locked_full_value(self):
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
+            self.skipTest("requires page_size=1, sliding_window_size=4")
+        tree, allocator, req_to_token_pool = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 4)
+        self._insert(tree, allocator, req_to_token_pool, tokens)
+        self._insert(
+            tree, allocator, req_to_token_pool, tokens + self._make_seq(100, 1)
+        )
+
+        node = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", tokens)))
+        ).last_device_node
+        old_full_value = node.component_data[ComponentType.FULL].value.clone()
+        swa_component = tree.components[ComponentType.SWA]
+        tracker = {ct: 0 for ct in tree.tree_components}
+        tree._evict_component_and_detach_lru(node, swa_component, tracker=tracker)
+        self.assertIsNone(node.component_data[ComponentType.SWA].value)
+
+        lock_result = tree.inc_lock_ref(node)
+        req = self._make_req(req_to_token_pool)
+        req.origin_input_ids = array("q", tokens)
+        req.output_ids = []
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.set_extend_range(0, len(req.full_untruncated_fill_ids))
+        kv_len = len(tokens)
+        fresh_value = self._alloc(allocator, kv_len)
+        req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), fresh_value)
+        req.kv_committed_len = kv_len
+        req.last_node = tree.root_node
+        req.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        req.swa_evicted_seqlen = 0
+
+        full_available_before_insert = allocator.full_attn_allocator.available_size()
+
+        tree.cache_unfinished_req(req)
+
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(),
+            full_available_before_insert + len(tokens),
+        )
+        self.assertTrue(
+            torch.equal(
+                node.component_data[ComponentType.FULL].value,
+                old_full_value,
+            )
+        )
+        swa_value = node.component_data[ComponentType.SWA].value
+        self.assertIsNotNone(swa_value)
+        self.assertTrue(
+            torch.equal(
+                allocator.translate_loc_from_full_to_swa(old_full_value),
+                swa_value,
+            )
+        )
+        self.assertEqual(req.cache_protected_len, len(tokens))
+
+        tree.dec_lock_ref(
+            req.last_node,
+            DecLockRefParams(swa_uuid_for_lock=getattr(req, "swa_uuid_for_lock", None)),
+        )
+        tree.dec_lock_ref(node, lock_result.to_dec_params())
+        tree.sanity_check()
+
     def test_swa_insert_keeps_full_leaf_when_entire_span_is_outside_window(self):
         # A leaf survives on its Full value alone: even when the whole span is
         # past the SWA window (swa_evicted_seqlen >= total), the Full leaf must

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -813,6 +813,41 @@ class UnifiedRadixCacheSuite:
         self.assertEqual(len(m.device_indices), len(seq))
         tree.sanity_check()
 
+    def test_swa_insert_keeps_full_leaf_when_entire_span_is_outside_window(self):
+        # A leaf survives on its Full value alone: even when the whole span is
+        # past the SWA window (swa_evicted_seqlen >= total), the Full leaf must
+        # be materialized (and the Full KV kept) so the prefix stays cacheable.
+        # Runs across all SWA configs, including page_size > sliding_window_size
+        # (the dsv4-style edge case).
+        if not self.cfg.has_swa or self.cfg.has_mamba:
+            self.skipTest("requires SWA without Mamba")
+        tree, allocator, _ = build_fixture(self.cfg)
+
+        tokens = self._make_seq(1, 2)
+        value = self._alloc(allocator, len(tokens))
+        if value is None:
+            self.skipTest("insufficient pool for this config")
+        full_available_before = allocator.full_attn_allocator.available_size()
+
+        tree.insert(
+            InsertParams(
+                key=RadixKey(array("q", tokens)),
+                value=value,
+                prev_prefix_len=0,
+                swa_evicted_seqlen=len(tokens),
+            )
+        )
+
+        self.assertEqual(
+            allocator.full_attn_allocator.available_size(), full_available_before
+        )
+        node = next(iter(tree.root_node.children.values()))
+        self.assertTrue(
+            torch.equal(node.component_data[ComponentType.FULL].value, value)
+        )
+        self.assertIsNone(node.component_data[ComponentType.SWA].value)
+        tree.sanity_check()
+
     def test_swa_evict_cascades(self):
         """Evict SWA tokens via swa_num_tokens — cascades to lower-priority components."""
         if not self.cfg.has_swa:


### PR DESCRIPTION
## Motivation

Backport the two upstream UnifiedTree/SWA L2 correctness fixes required by `bytedance/deepseek_v4`:

- sgl-project/sglang#29351 (`1c2523b719d1e8a55c43bf1a9526b0c52b05e118`)
- sgl-project/sglang#29352 (`53c61bd5e62ca90a8e488821917abf9303c8b94d`)

Without these fixes, an SWA tombstone can either suppress a valid Full-KV leaf or recover by freeing Full-KV slots that are still locked by an in-flight request. Under L2 eviction/recovery churn, the latter can allow those slots to be reused and silently corrupt model output.

This PR is intentionally limited to HiCache L2 correctness. It does not include L3 sidecar/storage changes, request-scoped C128 state (#28612), PP changes, or the open overlap-scheduling work.

## Modifications

- Always materialize the Full-KV radix leaf even when SWA has no cacheable data for that span.
- Remove the obsolete auxiliary-component leaf-creation veto and adapt the DSV4 decode-radix test.
- When recovering an SWA tombstone whose Full component is locked:
  - preserve the existing Full-KV slots;
  - adopt the incoming request's SWA slots;
  - rebuild the old Full-to-new SWA mapping;
  - free only the redundant incoming Full-KV slots.
- Normalize Full/SWA mapping index dtypes in the V4 branch's legacy `swa_memory_pool.py` allocator location.
- Add regressions for Full-only leaf creation and locked-Full SWA recovery.

The backports are kept as two commits with their upstream cherry-pick provenance.

## Accuracy Tests

Passed locally:

```text
git diff --check origin/bytedance/deepseek_v4...HEAD
python3 -m compileall -q <all modified Python files>
```

Added unit regressions:

- `test_swa_insert_keeps_full_leaf_when_entire_span_is_outside_window`
- `test_swa_unfinished_recovery_preserves_locked_full_value`

The focused pytest run could not execute in the local worktree because the available Python environment does not contain `pytest` or `torch`; it should run in CUDA CI:

```bash
python3 -m pytest -q \
  test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py \
  -k 'swa_insert_keeps_full_leaf_when_entire_span_is_outside_window or swa_unfinished_recovery_preserves_locked_full_value'
```

## Speed Tests and Profiling

Not run. This is an ownership/lifetime correctness backport and does not change attention kernels or the steady-state inference path.

## Checklist

- [ ] Format your code according to the contribution guide.
- [x] Add unit tests.
- [x] Update affected UnifiedTree component documentation.
- [ ] Run the focused CUDA unit tests in CI.
- [x] Keep the backport scoped to L2 correctness.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->