### PR TITLE
[HiCache][DSV4] Pin host buffers during async L2 load-back

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/mamba_component.py
@@ -521,9 +521,9 @@ class MambaComponent(TreeComponent):
         Host leaves: atomic eviction via _evict_host_leaf."""
         ct = self.component_type
         host_lru = self.cache.host_lru_lists[ct]
-        x = host_lru.get_lru_no_lock()
+        x = host_lru.get_lru_no_host_lock()
         while tracker[ct] < num_tokens and x is not None and host_lru.in_list(x):
-            x_next = host_lru.get_prev_no_lock(x)
+            x_next = host_lru.get_prev_no_host_lock(x)
             cd = x.component_data[ct]
             if x in self.cache.evictable_host_leaves:
                 # Host leaf: atomic eviction (all components host + delete)

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -550,9 +550,9 @@ class SWAComponent(TreeComponent):
         Host leaves: atomic eviction via _evict_host_leaf."""
         ct = self.component_type
         host_lru = self.cache.host_lru_lists[ct]
-        x = host_lru.get_lru_no_lock()
+        x = host_lru.get_lru_no_host_lock()
         while tracker[ct] < num_tokens and x is not None and host_lru.in_list(x):
-            x_next = host_lru.get_prev_no_lock(x)
+            x_next = host_lru.get_prev_no_host_lock(x)
             cd = x.component_data[ct]
             if x in self.cache.evictable_host_leaves:
                 self.cache._evict_host_leaf(x, tracker)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -212,11 +212,27 @@ class UnifiedLRUList:
             return None
         return x
 
+    def get_prev_no_host_lock(self, node: UnifiedTreeNode, check_id: bool = True):
+        """Host-LRU walker: skip nodes whose component host_lock_ref > 0."""
+        if check_id:
+            assert node.id in self.cache
+        pt = self._pt
+        ct = self.component_type
+        x = node.lru_prev[pt]
+        while x.component_data[ct].host_lock_ref > 0:
+            x = x.lru_prev[pt]
+        if x == self.head:
+            return None
+        return x
+
     def get_lru_no_lock(self):
         return self.get_prev_no_lock(self.tail, check_id=False)
 
     def get_leaf_lru_no_lock(self):
         return self.get_prev_leaf_no_lock(self.tail, check_id=False)
+
+    def get_lru_no_host_lock(self):
+        return self.get_prev_no_host_lock(self.tail, check_id=False)
 
 
 COMPONENT_REGISTRY: dict[ComponentType, type[TreeComponent]] = {
@@ -315,7 +331,10 @@ class UnifiedRadixCache(BasePrefixCache):
         self.ongoing_write_through: dict[
             int, tuple[UnifiedTreeNode, Optional[DecLockRefParams]]
         ] = {}
-        self.ongoing_load_back: dict[int, tuple[UnifiedTreeNode, DecLockRefParams]] = {}
+        self.ongoing_load_back: dict[
+            int,
+            tuple[UnifiedTreeNode, DecLockRefParams, DecLockRefParams],
+        ] = {}
         self.enable_storage = False
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
         self.ongoing_prefetch: dict = {}
@@ -1410,6 +1429,7 @@ class UnifiedRadixCache(BasePrefixCache):
         if self.cache_controller is None:
             return False
 
+        host_anchor_params = self.inc_host_lock_ref(best_match_node).to_dec_params()
         # Build KV transfer
         kv_xfer = self.components[BASE_COMPONENT_TYPE].build_hicache_transfers(
             best_match_node, CacheTransferPhase.LOAD_BACK
@@ -1441,6 +1461,7 @@ class UnifiedRadixCache(BasePrefixCache):
             mem_quota is not None and kv_tokens > mem_quota + result.delta
         ):
             self.dec_lock_ref(best_match_node, ancestor_lock_params)
+            self.dec_host_lock_ref(best_match_node, host_anchor_params)
             return False
 
         if self.supports_swa():
@@ -1452,6 +1473,7 @@ class UnifiedRadixCache(BasePrefixCache):
             result = self.evict(EvictParams(num_tokens=needed))
             if result.num_tokens_evicted < needed:
                 self.dec_lock_ref(best_match_node, ancestor_lock_params)
+                self.dec_host_lock_ref(best_match_node, host_anchor_params)
                 return False
 
         # Load H→D
@@ -1465,6 +1487,7 @@ class UnifiedRadixCache(BasePrefixCache):
 
         self.dec_lock_ref(best_match_node, ancestor_lock_params)
         if device_indices is None:
+            self.dec_host_lock_ref(best_match_node, host_anchor_params)
             return False
 
         # Commit: each component gets only its own transfers
@@ -1485,6 +1508,7 @@ class UnifiedRadixCache(BasePrefixCache):
         self.ongoing_load_back[best_match_node.id] = (
             best_match_node,
             self.inc_lock_ref(best_match_node).to_dec_params(),
+            host_anchor_params,
         )
         return True
 
@@ -2113,9 +2137,11 @@ class UnifiedRadixCache(BasePrefixCache):
             if not finish_event.query():
                 break
             finish_count += 1
+            finish_event.synchronize()
             for ack_id in ack_list:
-                node, lock_params = self.ongoing_load_back.pop(ack_id)
+                node, lock_params, host_lock_params = self.ongoing_load_back.pop(ack_id)
                 self.dec_lock_ref(node, lock_params)
+                self.dec_host_lock_ref(node, host_lock_params)
         del cc.ack_load_queue[:finish_count]
 
     # ---- HiCache: Scheduler Entry Points ----
@@ -2557,7 +2583,7 @@ class UnifiedRadixCache(BasePrefixCache):
                 E(
                     f"[Ongoing] write_through node {nid} lock_ref={n.component_data[FCT].lock_ref}"
                 )
-        for nid, (n, _) in self.ongoing_load_back.items():
+        for nid, (n, _, _) in self.ongoing_load_back.items():
             if n not in all_node_set:
                 E(f"[Ongoing] load_back node {nid} not in tree")
             elif n.component_data[FCT].lock_ref <= 0:

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1802,8 +1802,11 @@ class UnifiedRadixCacheSuite:
         return chain
 
     def _release_ongoing_load_back_locks(self, tree):
-        for node, lock_params in list(tree.ongoing_load_back.values()):
+        for node, lock_params, host_lock_params in list(
+            tree.ongoing_load_back.values()
+        ):
             tree.dec_lock_ref(node, lock_params)
+            tree.dec_host_lock_ref(node, host_lock_params)
         tree.ongoing_load_back.clear()
 
     def _finish_pending_loads(self, tree):


### PR DESCRIPTION
## Motivation

Backport [sgl-project/sglang#27444](https://github.com/sgl-project/sglang/pull/27444) (`8ce05e8a203579ce73196e7e61b02697a9fdd724`) to `bytedance/deepseek_v4`.

`cache_controller.load()` enqueues H2D work asynchronously and returns device indices before the load stream has finished reading the source host pages. The existing V4 path only keeps a device lock in `ongoing_load_back`; host eviction is controlled by `host_lock_ref`. Under host-pool pressure, the source page can therefore be evicted, reused, and overwritten while H2D is still in flight, causing intermittent KV/sidecar corruption.

## Modifications

- Add host-lock-aware LRU walkers for host eviction.
- Make SWA and Mamba host eviction skip nodes with `host_lock_ref > 0`.
- Pin the matched host path before constructing/enqueuing load-back transfers.
- Release the host lock on all synchronous failure paths.
- Carry the host unlock parameters in `ongoing_load_back` and release them only after the H2D finish event is synchronized.
- Update the UnifiedTree test helper for the extended ongoing-load tuple.

The V4 branch keeps its existing query-and-bulk-delete ack loop. The conflict resolution adds an explicit `finish_event.synchronize()` before releasing the host lock, preserving the upstream completion invariant without importing unrelated metrics/PP code.

This PR is scoped to L2 async load-back lifetime correctness and does not add L3/storage behavior.

## Accuracy Tests

Passed locally:

```text
git range-diff 8ce05e8a^..8ce05e8a origin/bytedance/deepseek_v4..HEAD
git diff --check origin/bytedance/deepseek_v4...HEAD
python3 -m compileall -q <all modified Python files>
```

The focused pytest command could not run in the local worktree because the available Python environment does not contain `pytest` or `torch`; CUDA CI should run the UnifiedRadixCache suite:

```bash
python3 -m pytest -q \
  test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py \
  -k 'load_back or host_lock'
```

## Speed Tests and Profiling

Not run. The change only affects host-lock bookkeeping around asynchronous L2 load-back and host eviction.

## Checklist

- [ ] Format code with pre-commit.
- [x] Preserve the full upstream #27444 correctness semantics.
- [x] Update the affected unit-test helper.
- [ ] Run the focused CUDA unit tests in CI.
- [x] Keep the backport scoped to L2 load-back correctness.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->