### PR TITLE
[HiCache][DSV4] Fix PP-local SWA allocation and layer mapping

### DIFF
--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -428,6 +428,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             self._stage_start = 0
             self._stage_end = len(compression_ratios)
         stage_ratios = compression_ratios[self._stage_start : self._stage_end]
+        stage_layer_num = len(stage_ratios)
 
         assert page_size % swa_page_size == 0
 
@@ -450,7 +451,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             dtype,
             qk_nope_head_dim,
             qk_rope_head_dim,
-            layer_num,
+            stage_layer_num,
             device,
             enable_memory_saver,
         )

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -283,27 +283,33 @@ def build_deepseek_v4_hicache_stack(
     pp_size: int = 1,
     enable_storage_metrics: bool = False,
 ) -> tuple[HostPoolGroup, HybridCacheController]:
-    # TODO(hzh0425): Support PP for deepseek v4 with hicache
     transfer_layer_num = kvcache.end_layer - kvcache.start_layer
     full_layer_mapping = {layer_id: layer_id for layer_id in range(transfer_layer_num)}
-    swa_layer_mapping = {
-        layer_id: layer_id for layer_id in range(len(kvcache.swa_kv_pool.kv_buffer))
-    }
+    if len(kvcache.swa_kv_pool.kv_buffer) != transfer_layer_num:
+        raise ValueError(
+            "DeepSeek V4 SWA KV pool must be PP-stage-local: "
+            f"got {len(kvcache.swa_kv_pool.kv_buffer)} buffers for "
+            f"{transfer_layer_num} local layers"
+        )
+    swa_layer_mapping = {layer_id: layer_id for layer_id in range(transfer_layer_num)}
 
     c4_layer_mapping = {}
     c128_layer_mapping = {}
+    c4_state_local_layers = []
     c4_state_global_layers = []
-    for layer_id, layer_item in enumerate(
+    for local_layer_id, layer_item in enumerate(
         kvcache.layer_mapping[kvcache.start_layer : kvcache.end_layer]
     ):
+        global_layer_id = kvcache.start_layer + local_layer_id
         if layer_item.compress_ratio == 4:
-            c4_layer_mapping[layer_id] = layer_item.compress_layer_id
-            c4_state_global_layers.append(layer_id)
+            c4_layer_mapping[local_layer_id] = layer_item.compress_layer_id
+            c4_state_local_layers.append(local_layer_id)
+            c4_state_global_layers.append(global_layer_id)
         elif layer_item.compress_ratio == 128:
-            c128_layer_mapping[layer_id] = layer_item.compress_layer_id
+            c128_layer_mapping[local_layer_id] = layer_item.compress_layer_id
 
     c4_state_mapping = {
-        layer_id: local_id for local_id, layer_id in enumerate(c4_state_global_layers)
+        layer_id: local_id for local_id, layer_id in enumerate(c4_state_local_layers)
     }
     num_host_pages, swa_num_host_pages = _deepseek_v4_num_host_pages(
         params=params,
@@ -371,7 +377,7 @@ def build_deepseek_v4_hicache_stack(
         c4_state_host_pool = DeepSeekV4StateHostPool(
             pool_name=str(PoolName.DEEPSEEK_V4_C4_STATE),
             state_pools=[
-                kvcache.compress_state_pools[kvcache.start_layer + layer_id]
+                kvcache.compress_state_pools[layer_id]
                 for layer_id in c4_state_global_layers
             ],
             num_host_pages=swa_num_host_pages,
@@ -382,7 +388,7 @@ def build_deepseek_v4_hicache_stack(
         c4_indexer_state_host_pool = DeepSeekV4StateHostPool(
             pool_name=str(PoolName.DEEPSEEK_V4_C4_INDEXER_STATE),
             state_pools=[
-                kvcache.indexer_compress_state_pools[kvcache.start_layer + layer_id]
+                kvcache.indexer_compress_state_pools[layer_id]
                 for layer_id in c4_state_global_layers
             ],
             num_host_pages=swa_num_host_pages,


### PR DESCRIPTION
## Summary

Backport the DeepSeek-V4 PP + HiCache correctness fixes from sgl-project/sglang#29106 (upstream commit `c1b5c7e49959d2259c9fadb6b12c534613343048`) onto `bytedance/deepseek_v4`.

- allocate the SWA KV pool with the current PP stage's local layer count
- validate that the HiCache SWA pool is stage-local
- keep transfer-layer mappings local while using global layer IDs to select C4 and indexer state pools

## Scope

This is a target-compatible logical backport, not a blind cherry-pick. The V4 branch has already refactored model writes through `set_swa_*()`, which performs the same global-to-PP-local conversion as upstream's new `get_swa_raw_buffer()`; therefore no model-file change is needed here.

The upstream service test depends on a UnifiedRadixTree DSV4 base test that is absent from this fork, so this PR does not import that unrelated test-layout change.

## Validation

- `git diff --check`
- `python3 -m compileall -q python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py`
- confirmed all active DSV4 SWA accesses in this branch pass through PP-local layer mapping

Local runtime tests were not run because this environment does not provide `torch` or `pytest`. Before marking ready, please run the upstream-equivalent DeepSeek-V4 Flash `PP4 × TP2` HiCache accuracy test.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->