### PR TITLE
[HiCache][DSV4] Synchronize L2 completions across PP stages

### DIFF
--- a/python/sglang/srt/distributed/communication_tags.py
+++ b/python/sglang/srt/distributed/communication_tags.py
@@ -1,0 +1,9 @@
+from enum import IntEnum, unique
+
+
+@unique
+class P2PTag(IntEnum):
+    """Tags reserved for point-to-point communication protocols."""
+
+    DEFAULT = 0
+    HIRADIX_PP_SYNC = int.from_bytes(b"PpHi", byteorder="big")

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -447,6 +447,7 @@ class Scheduler(
             ),
             ps=self.ps,
             tp_group=self.tp_group,
+            pp_group=self.pp_group,
             enable_hierarchical_cache=self.enable_hierarchical_cache,
             enable_eic_cache=self.enable_eic_cache,
         )
@@ -993,6 +994,7 @@ class Scheduler(
                 context_len=self.model_config.context_len,
                 startup_available_gpu_memory_gb=avail_mem,
             )
+
     def init_running_status(self):
         self.waiting_queue: List[Req] = []
         # The running decoding batch for continuous batching

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -22,6 +22,7 @@ class CacheInitParams:
     tp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     attn_cp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     attn_tp_cache_group: Optional[torch.distributed.ProcessGroup] = None
+    pp_cache_group: Optional[torch.distributed.ProcessGroup] = None
     eviction_policy: str = "lru"
     disable_finished_insert: bool = False
 

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -157,6 +157,7 @@ def build_kv_cache(
     enable_kv_cache_events: bool,
     ps: "ParallelState",
     tp_group: "GroupCoordinator",
+    pp_group: "GroupCoordinator",
     enable_hierarchical_cache: bool,
     enable_eic_cache: bool = False,
 ) -> "KVCacheBuildResult":
@@ -261,6 +262,7 @@ def build_kv_cache(
         ),
         attn_cp_cache_group=attn_cp_cpu_group,
         attn_tp_cache_group=attn_tp_cpu_group,
+        pp_cache_group=pp_group.cpu_group,
         eviction_policy=server_args.radix_eviction_policy,
         enable_metrics=enable_metrics,
         enable_kv_cache_events=enable_kv_cache_events,

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import torch
 
+from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     DecLockRefParams,
@@ -285,11 +286,17 @@ class UnifiedRadixCache(BasePrefixCache):
         self.session = StreamingSession(inner=self)
 
         self.tp_group = params.tp_cache_group
+        self.attn_cp_group = params.attn_cp_cache_group
+        self.attn_tp_group = params.attn_tp_cache_group
+        self.pp_group = params.pp_cache_group
         self.tp_world_size = (
             1
             if self.tp_group is None
             else torch.distributed.get_world_size(group=self.tp_group)
         )
+        self.pp_rank = params.pp_rank
+        self.pp_size = params.pp_size
+        self.work_list: list[torch.distributed.Work] = []
 
         # HiCache D↔H defaults (overridden by init_hicache)
         self.cache_controller = None
@@ -302,6 +309,61 @@ class UnifiedRadixCache(BasePrefixCache):
 
         self.reset()
         logger.info(f"Init Unified RadixTree with components {self.tree_components}")
+
+    def _all_reduce_attn_groups(self, tensor: torch.Tensor, op) -> None:
+        reduced = False
+        for group in (self.attn_cp_group, self.attn_tp_group):
+            if group is not None and torch.distributed.get_world_size(group=group) > 1:
+                torch.distributed.all_reduce(tensor, op=op, group=group)
+                reduced = True
+        if not reduced and self.tp_world_size > 1:
+            torch.distributed.all_reduce(tensor, op=op, group=self.tp_group)
+
+    def _barrier_attn_groups(self) -> None:
+        waited = False
+        for group in (self.attn_cp_group, self.attn_tp_group):
+            if group is not None and torch.distributed.get_world_size(group=group) > 1:
+                torch.distributed.barrier(group=group)
+                waited = True
+        if not waited and self.tp_world_size > 1:
+            torch.distributed.barrier(group=self.tp_group)
+
+    def _drain_async_work(self) -> None:
+        """Wait for the previous round's PP sends before issuing new ones."""
+        for work in self.work_list:
+            work.wait()
+        self.work_list.clear()
+
+    def _all_reduce(
+        self,
+        data: torch.Tensor,
+        tp_reduce_op: torch.distributed.ReduceOp,
+    ) -> None:
+        """Reduce on PP0's attention groups, then propagate across PP stages."""
+        if self.pp_rank == 0:
+            self._all_reduce_attn_groups(data, tp_reduce_op)
+        self._pp_sync(data)
+
+    def _pp_sync(self, data: torch.Tensor) -> None:
+        """Propagate PP0's completion count through the PP pipeline."""
+        if self.pp_size <= 1 or self.pp_group is None:
+            return
+        if self.pp_rank > 0:
+            torch.distributed.recv(
+                data,
+                group_src=self.pp_rank - 1,
+                group=self.pp_group,
+                tag=P2PTag.HIRADIX_PP_SYNC,
+            )
+        if self.pp_rank + 1 < self.pp_size:
+            copied_data = data.clone()
+            send_work = torch.distributed.isend(
+                copied_data,
+                group_dst=self.pp_rank + 1,
+                group=self.pp_group,
+                tag=P2PTag.HIRADIX_PP_SYNC,
+            )
+            self.work_list.append(send_work)
 
     def reset(self) -> None:
         self._reset_full()
@@ -2103,18 +2165,15 @@ class UnifiedRadixCache(BasePrefixCache):
         # Every rank must enter the all_reduce below; ongoing_write_through can
         # diverge across ranks (e.g. write_backup returning 0 on a subset).
         finish_count = 0
-        for _, finish_event, ack_list in cc.ack_write_queue:
-            if not finish_event.query():
-                break
-            finish_count += 1
+        if self.pp_rank == 0:
+            for _, finish_event, ack_list in cc.ack_write_queue:
+                if not finish_event.query():
+                    break
+                finish_count += 1
 
-        # TP sync: MIN across all ranks for consistent tree updates
-        queue_size = torch.tensor(finish_count, dtype=torch.int, device="cpu")
-        if self.tp_world_size > 1:
-            torch.distributed.all_reduce(
-                queue_size, op=torch.distributed.ReduceOp.MIN, group=self.tp_group
-            )
-        finish_count = int(queue_size.item())
+        finish_count_tensor = torch.tensor(finish_count, dtype=torch.int, device="cpu")
+        self._all_reduce(finish_count_tensor, torch.distributed.ReduceOp.MIN)
+        finish_count = int(finish_count_tensor.item())
 
         # Process completed acks
         while finish_count > 0:
@@ -2130,19 +2189,27 @@ class UnifiedRadixCache(BasePrefixCache):
     def loading_check(self) -> None:
         """Poll load-back completions."""
         cc = self.cache_controller
-        if cc is None or not self.ongoing_load_back:
+        if cc is None:
             return
         finish_count = 0
-        for _, finish_event, ack_list in cc.ack_load_queue:
-            if not finish_event.query():
-                break
-            finish_count += 1
+        if self.pp_rank == 0:
+            for _, finish_event, ack_list in cc.ack_load_queue:
+                if not finish_event.query():
+                    break
+                finish_count += 1
+
+        finish_count_tensor = torch.tensor(finish_count, dtype=torch.int, device="cpu")
+        self._all_reduce(finish_count_tensor, torch.distributed.ReduceOp.MIN)
+        finish_count = int(finish_count_tensor.item())
+
+        while finish_count > 0:
+            _, finish_event, ack_list = cc.ack_load_queue.pop(0)
             finish_event.synchronize()
             for ack_id in ack_list:
                 node, lock_params, host_lock_params = self.ongoing_load_back.pop(ack_id)
                 self.dec_lock_ref(node, lock_params)
                 self.dec_host_lock_ref(node, host_lock_params)
-        del cc.ack_load_queue[:finish_count]
+            finish_count -= 1
 
     # ---- HiCache: Scheduler Entry Points ----
 
@@ -2194,6 +2261,7 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def check_hicache_events(self) -> None:
         """Called per scheduler step to poll async HiCache events."""
+        self._drain_async_work()
         self.writing_check()
         self.loading_check()
         if self.enable_storage:

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_pp_sync.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_pp_sync.py
@@ -1,0 +1,148 @@
+"""Focused tests for UnifiedRadixCache HiCache PP completion sync."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.distributed.communication_tags import P2PTag
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _FakeWork:
+    def __init__(self):
+        self.waited = False
+
+    def wait(self):
+        self.waited = True
+
+
+class _Holder:
+    pass
+
+
+class TestUnifiedRadixCachePPSync(unittest.TestCase):
+    def test_completion_reduce_covers_attention_cp_and_tp_groups(self):
+        holder = _Holder()
+        holder.attn_cp_group = object()
+        holder.attn_tp_group = object()
+        holder.tp_group = object()
+        holder.tp_world_size = 4
+        data = torch.tensor(1, dtype=torch.int)
+
+        with mock.patch.object(
+            torch.distributed, "get_world_size", return_value=2
+        ), mock.patch.object(torch.distributed, "all_reduce") as all_reduce:
+            UnifiedRadixCache._all_reduce_attn_groups(
+                holder, data, torch.distributed.ReduceOp.MIN
+            )
+
+        self.assertEqual(all_reduce.call_count, 2)
+        self.assertEqual(
+            all_reduce.call_args_list[0].kwargs["group"], holder.attn_cp_group
+        )
+        self.assertEqual(
+            all_reduce.call_args_list[1].kwargs["group"], holder.attn_tp_group
+        )
+
+    def test_drain_waits_all_and_clears(self):
+        holder = _Holder()
+        works = [_FakeWork(), _FakeWork()]
+        holder.work_list = list(works)
+
+        UnifiedRadixCache._drain_async_work(holder)
+
+        self.assertTrue(all(work.waited for work in works))
+        self.assertEqual(holder.work_list, [])
+
+    def test_pp_sync_uses_dedicated_tag_and_tracks_send(self):
+        holder = _Holder()
+        holder.pp_rank = 1
+        holder.pp_size = 3
+        holder.pp_group = object()
+        holder.work_list = []
+        data = torch.tensor(0, dtype=torch.int)
+        send_work = _FakeWork()
+
+        with mock.patch.object(torch.distributed, "recv") as recv, mock.patch.object(
+            torch.distributed, "isend", return_value=send_work
+        ) as isend:
+            UnifiedRadixCache._pp_sync(holder, data)
+
+        recv.assert_called_once_with(
+            data,
+            group_src=0,
+            group=holder.pp_group,
+            tag=P2PTag.HIRADIX_PP_SYNC,
+        )
+        isend.assert_called_once()
+        self.assertEqual(isend.call_args.kwargs["group_dst"], 2)
+        self.assertEqual(isend.call_args.kwargs["tag"], P2PTag.HIRADIX_PP_SYNC)
+        self.assertEqual(holder.work_list, [send_work])
+
+    def test_loading_check_participates_with_empty_local_queue(self):
+        holder = _Holder()
+        holder.cache_controller = SimpleNamespace(ack_load_queue=[])
+        holder.ongoing_load_back = {}
+        holder.pp_rank = 1
+        holder._all_reduce = mock.Mock()
+
+        UnifiedRadixCache.loading_check(holder)
+
+        holder._all_reduce.assert_called_once()
+
+    def test_loading_check_releases_device_and_host_locks_after_completion(self):
+        holder = _Holder()
+        finish_event = mock.Mock()
+        finish_event.query.return_value = True
+        holder.cache_controller = SimpleNamespace(
+            ack_load_queue=[(None, finish_event, [7])]
+        )
+        node = object()
+        device_lock = object()
+        host_lock = object()
+        holder.ongoing_load_back = {7: (node, device_lock, host_lock)}
+        holder.pp_rank = 0
+        holder._all_reduce = mock.Mock()
+        holder.dec_lock_ref = mock.Mock()
+        holder.dec_host_lock_ref = mock.Mock()
+
+        UnifiedRadixCache.loading_check(holder)
+
+        finish_event.synchronize.assert_called_once()
+        holder.dec_lock_ref.assert_called_once_with(node, device_lock)
+        holder.dec_host_lock_ref.assert_called_once_with(node, host_lock)
+        self.assertEqual(holder.cache_controller.ack_load_queue, [])
+
+    def test_nonzero_pp_stage_consumes_propagated_write_count(self):
+        holder = _Holder()
+        finish_event = mock.Mock()
+        holder.cache_controller = SimpleNamespace(
+            ack_write_queue=[(None, finish_event, [11])]
+        )
+        node = object()
+        lock_params = object()
+        holder.ongoing_write_through = {11: (node, lock_params)}
+        holder.pp_rank = 1
+        holder.enable_storage = False
+        holder.dec_lock_ref = mock.Mock()
+
+        def propagate_one(count, _op):
+            count.fill_(1)
+
+        holder._all_reduce = mock.Mock(side_effect=propagate_one)
+
+        UnifiedRadixCache.writing_check(holder)
+
+        finish_event.query.assert_not_called()
+        finish_event.synchronize.assert_called_once()
+        holder.dec_lock_ref.assert_called_once_with(node, lock_params)
+        self.assertEqual(holder.cache_controller.ack_write_queue, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Logically backport the final PP-safe UnifiedRadixCache L2 completion semantics from:

- sgl-project/sglang#25395 (`63dc20ae`): synchronize completion counts across attention CP/TP groups
- sgl-project/sglang#27285 (`42fe0252`): propagate PP0's completion count through every PP stage
- sgl-project/sglang#27489 (`d03182cd`): keep empty local load queues in the collective sequence
- sgl-project/sglang#28916 (`349a6af6`): bound asynchronous PP send lifetime by draining the previous round

The target branch has the writing half of #27489, but it does not have `pp_cache_group`, `_pp_sync()`, the loading collective, or bounded PP send work.

## Changes

- Wire the PP CPU process group from Scheduler through CacheInitParams into UnifiedRadixCache.
- Reduce write/load completion counts across CP and attention-TP on PP0, then propagate the same count through the PP pipeline.
- Make every PP stage consume the same number of write/load acknowledgements.
- Remove the load-side early return on an empty local queue so PP message sequences cannot drift.
- Add a dedicated `P2PTag.HIRADIX_PP_SYNC` instead of reusing an unscoped numeric tag.
- Drain the previous round's asynchronous PP sends at the start of each HiCache event round.
- Add focused CPU regression tests for CP/TP reduction, PP send/tag behavior, empty-queue participation, bounded send work, downstream write consumption, and host-lock release.

## Fork compatibility

This is intentionally not a blind cherry-pick.

- Preserve fork #638's `(node, device_lock, host_lock)` load-back tuple.
- Release both locks only after `finish_event.synchronize()`.
- Preserve fork #639's PP-local DSV4 SWA allocation and layer mapping.
- Keep `load_back_threshold = 256`; do not import #27285's unrelated threshold change.
- Keep the fork's existing HybridCacheController `pp_rank` / `pp_size` plumbing.
- Scope the synchronization implementation to UnifiedRadixCache, which is the DSV4 HiCache path.

When HiCache is disabled, `cache_controller` remains `None`, so the new write/load collectives are not entered.

## Validation

Passed:

- `git diff --check`
- `python3 -m compileall -q` on all modified Python files
- AST parsing for all modified Python files
- pre-commit: symlink checks, whitespace, EOF, AST, large files, merge conflicts, private keys, debug statements, isort, ruff, Black, codespell
- focused test file is registered with `register_cpu_ci`

The repository-wide `check-registered-tests` hook still reports the target branch's pre-existing unregistered file:

```text
test/registered/unit/disaggregation/test_dsv4_decode_radix_cache.py
```

That file is unchanged by this PR. Local pytest execution was unavailable because the local Python environment does not include `torch` or `pytest`.

Recommended CI/runtime validation:

```bash
python3 -m pytest -q \
  test/registered/unit/mem_cache/test_unified_radix_cache_pp_sync.py
```

Then validate DeepSeek-V4 Flash with PP2/TP2 and the production PP/CP/TP topology, HiCache L2 `write_through`, forced L1 eviction, and cold-vs-L2-hit logits/KL comparison.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->