### PR TITLE
[HiCache][DSV4] Pin SWA host pages during L2 load-back

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -374,7 +374,9 @@ class SWAComponent(TreeComponent):
         root = self.cache.root_node
         sliding_window_size = self.sliding_window_size
         swa_lock_size = 0
-        swa_uuid_for_lock = None
+        swa_uuid = None
+        uuid_key = "host_uuid" if lock_host else "uuid"
+        lru = self.cache.host_lru_lists[ct] if lock_host else self.cache.lru_lists[ct]
 
         # Tombstoned nodes (cd.value is None) have no SWA chunk to protect
         # skip them and keep walking up. This path is hit when HiCache
@@ -382,23 +384,36 @@ class SWAComponent(TreeComponent):
         cur = node
         while cur != root and swa_lock_size < sliding_window_size:
             comp = cur.component_data[ct]
-            if comp.value is None:
+            value = comp.host_value if lock_host else comp.value
+            if value is None:
                 result.skip_lock_node_ids.setdefault(ct, set()).add(cur.id)
                 cur = cur.parent
                 continue
-            if comp.lock_ref == 0:
-                key_len = len(cur.key)
-                self.cache.component_evictable_size_[ct] -= key_len
-                self.cache.component_protected_size_[ct] += key_len
-            comp.lock_ref += 1
-            swa_lock_size += len(cur.key)
+
+            ref = comp.host_lock_ref if lock_host else comp.lock_ref
+            if ref == 0:
+                if lock_host:
+                    if lru.in_list(cur):
+                        lru.remove_node(cur)
+                else:
+                    key_len = len(cur.key)
+                    self.cache.component_evictable_size_[ct] -= key_len
+                    self.cache.component_protected_size_[ct] += key_len
+            if lock_host:
+                comp.host_lock_ref = ref + 1
+            else:
+                comp.lock_ref = ref + 1
+            swa_lock_size += len(value)
             if swa_lock_size >= sliding_window_size:
-                if comp.metadata.get("uuid") is None:
-                    comp.metadata["uuid"] = next_component_uuid()
-                swa_uuid_for_lock = comp.metadata["uuid"]
+                if comp.metadata.get(uuid_key) is None:
+                    comp.metadata[uuid_key] = next_component_uuid()
+                swa_uuid = comp.metadata[uuid_key]
             cur = cur.parent
 
-        result.swa_uuid_for_lock = swa_uuid_for_lock
+        if lock_host:
+            result.swa_uuid_for_host_lock = swa_uuid
+        else:
+            result.swa_uuid_for_lock = swa_uuid
         return result
 
     def release_component_lock(
@@ -409,9 +424,14 @@ class SWAComponent(TreeComponent):
     ) -> None:
         ct = self.component_type
         root = self.cache.root_node
-        swa_uuid_for_lock = params.swa_uuid_for_lock if params else None
+        swa_uuid_for_lock = (
+            (params.swa_uuid_for_host_lock if lock_host else params.swa_uuid_for_lock)
+            if params
+            else None
+        )
         skip_lock_node_ids = params.skip_lock_node_ids.get(ct, ()) if params else ()
         dec_swa = True
+        uuid_key = "host_uuid" if lock_host else "uuid"
 
         # A node in skip_lock_node_ids was a tombstone when this lock was acquired.
         cur = node
@@ -420,15 +440,25 @@ class SWAComponent(TreeComponent):
             if cur.id in skip_lock_node_ids:
                 cur = cur.parent
                 continue
-            if comp.lock_ref == 0:
+            ref = comp.host_lock_ref if lock_host else comp.lock_ref
+            if ref == 0:
                 cur = cur.parent
                 continue
-            if comp.lock_ref == 1:
-                key_len = len(cur.key)
-                self.cache.component_evictable_size_[ct] += key_len
-                self.cache.component_protected_size_[ct] -= key_len
-            comp.lock_ref -= 1
-            if swa_uuid_for_lock and comp.metadata.get("uuid") == swa_uuid_for_lock:
+            if ref == 1:
+                if lock_host:
+                    if comp.value is None and comp.host_value is not None:
+                        host_lru = self.cache.host_lru_lists[ct]
+                        if not host_lru.in_list(cur):
+                            host_lru.insert_mru(cur)
+                else:
+                    key_len = len(comp.value)
+                    self.cache.component_evictable_size_[ct] += key_len
+                    self.cache.component_protected_size_[ct] -= key_len
+            if lock_host:
+                comp.host_lock_ref = ref - 1
+            else:
+                comp.lock_ref = ref - 1
+            if swa_uuid_for_lock and comp.metadata.get(uuid_key) == swa_uuid_for_lock:
                 dec_swa = False
             cur = cur.parent
 

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2405,6 +2405,82 @@ class UnifiedRadixCacheSuite:
         tree.dec_lock_ref(leaf, request_lock.to_dec_params())
         self.assertEqual(cd.lock_ref, 0)
 
+    def test_hicache_swa_host_lock_pins_host_only_window_until_release(self):
+        """Async H2D source pages stay out of the host LRU until all loads finish."""
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA")
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only path keeps host lock assertions focused")
+
+        tree, allocator, req_to_token_pool = self._build_hicache_fixture()
+        ps = self.cfg.page_size
+        window_pages = (self.cfg.sliding_window_size + ps - 1) // ps
+        seq = self._make_seq(1, window_pages)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        leaf = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(seq))
+        ).last_device_node
+
+        self._set_aux_host_tombstone(tree, leaf, ComponentType.SWA)
+        cd = leaf.component_data[ComponentType.SWA]
+        host_lru = tree.host_lru_lists[ComponentType.SWA]
+        self.assertIsNone(cd.value)
+        self.assertIsNotNone(cd.host_value)
+        self.assertTrue(host_lru.in_list(leaf))
+
+        first_lock = tree.inc_host_lock_ref(leaf)
+        second_lock = tree.inc_host_lock_ref(leaf)
+
+        self.assertIsNotNone(first_lock.swa_uuid_for_host_lock)
+        self.assertEqual(
+            first_lock.swa_uuid_for_host_lock,
+            second_lock.swa_uuid_for_host_lock,
+        )
+        self.assertEqual(cd.host_lock_ref, 2)
+        self.assertFalse(host_lru.in_list(leaf))
+
+        tree.dec_host_lock_ref(leaf, first_lock.to_dec_params())
+        self.assertEqual(cd.host_lock_ref, 1)
+        self.assertFalse(host_lru.in_list(leaf))
+
+        tree.dec_host_lock_ref(leaf, second_lock.to_dec_params())
+        self.assertEqual(cd.host_lock_ref, 0)
+        self.assertTrue(host_lru.in_list(leaf))
+
+    def test_hicache_swa_load_back_holds_host_lock_until_ack(self):
+        """The real load-back path releases SWA host locks only after H2D ack."""
+        if not self.cfg.has_swa:
+            self.skipTest("requires SWA")
+        if self.cfg.has_mamba:
+            self.skipTest("SWA-only path keeps host lock assertions focused")
+
+        tree, allocator, req_to_token_pool = self._build_hicache_fixture()
+        ps = self.cfg.page_size
+        window_pages = (self.cfg.sliding_window_size + ps - 1) // ps
+        seq = self._make_seq(1, window_pages)
+        self._insert(tree, allocator, req_to_token_pool, seq)
+        leaf = tree.match_prefix(
+            MatchPrefixParams(key=RadixKey(seq))
+        ).last_device_node
+
+        self._backup_node(tree, leaf)
+        result = tree.evict(EvictParams(num_tokens=len(seq)))
+        self.assertGreaterEqual(result.num_tokens_evicted, len(seq))
+
+        cd = leaf.component_data[ComponentType.SWA]
+        host_lru = tree.host_lru_lists[ComponentType.SWA]
+        self.assertIsNone(cd.value)
+        self.assertIsNotNone(cd.host_value)
+        self.assertTrue(host_lru.in_list(leaf))
+
+        self.assertTrue(tree.load_back(leaf))
+        self.assertEqual(cd.host_lock_ref, 1)
+        self.assertFalse(host_lru.in_list(leaf))
+
+        self._finish_pending_loads(tree)
+        self.assertEqual(cd.host_lock_ref, 0)
+        self.assertFalse(host_lru.in_list(leaf))
+
     def test_hicache_swa_load_back_uses_full_pool_capacity(self):
         """load_back should gate Full KV load on Full pool capacity only."""
         if not self.cfg.has_swa:


### PR DESCRIPTION
## Summary

Complete the SWA side of async HiCache L2 host-page pinning on `bytedance/deepseek_v4`.

The branch already carries the upper-level host lock lifecycle from #638: `UnifiedRadixCache.load_back()` acquires a host lock before scheduling H2D and releases it after the load completion event. However, the fork's `SWAComponent` still ignored `lock_host=True`, so host-only SWA pages (`value is None`, `host_value is not None`) remained eligible for host LRU eviction while H2D was in flight.

This PR:

- makes SWA acquire/release select `host_value` and `host_lock_ref` for host locks;
- removes SWA host pages from the host LRU on the first lock;
- tracks an independent `host_uuid` window boundary;
- reinserts a page into the host LRU only after its last host lock is released and it is still host-only;
- preserves nested host-lock reference counting for concurrent loads.

The two modified lock methods are AST-equivalent to the current `sgl-project/sglang:main` implementation, originally introduced by upstream #26881 and relied on by the async load-back pinning in upstream #27444.

## Tests

Added regressions covering:

1. nested host locks keep a host-only SWA window out of the host LRU until the final release;
2. the real `load_back -> H2D ack -> loading_check` path holds and releases the SWA host lock at the expected points.

Local checks:

- `git diff --check`
- `python3 -m compileall -q` on the changed source and test files
- AST comparison of both modified SWA lock methods against current upstream `main`

The local Python environment does not include PyTorch, so the registered unit test could not be executed locally. GPU runtime acceptance should rerun the existing cold-vs-L2 tensor trace and require layer-1 attention inputs/outputs to match.

## Scope

This is intentionally P0-only. The proposed P1 tombstone/mapping changes from upstream PRs #25834 and #27586 are excluded because those PRs were closed without being merged into upstream `main`.



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->