### PR TITLE
[DSA] Handle partial-DP padding in Decode page-table transform

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -49,6 +49,7 @@ def transform_index_page_table_decode_kernel(
     result_ptr: torch.Tensor,
     page_size: tl.constexpr,
     page_table_row_stride: tl.constexpr,
+    page_table_num_rows,
 ):
     TOPK: tl.constexpr = 2048
     req_id = tl.program_id(0)
@@ -58,7 +59,9 @@ def transform_index_page_table_decode_kernel(
 
     offset = tl.arange(0, TOPK)  # topk should be 2048
     loaded_topk_indices = tl.load(topk_indices_ptr + offset)
-    mask = loaded_topk_indices >= 0
+    # Partial DP attention pads top-k rows to the local query shape, while the
+    # page table retains only rows for real local queries.
+    mask = (req_id < page_table_num_rows) & (loaded_topk_indices >= 0)
     loaded_kv_indices = tl.load(page_table_ptr + loaded_topk_indices, mask=mask)
     tl.store(result_ptr + offset, loaded_kv_indices, mask=mask)
     tl.store(result_ptr + offset, -1, mask=~mask)
@@ -128,14 +131,18 @@ def transform_index_page_table_decode_fast(
     """
     Transform the page table according to topk indices for sparse topk attention.
     Args:
-        page_table: [qo_len, max_seqlen_k], the original page table
-        topk_indices: [qo_len, topk], the topk indices for each query position
+        page_table: [real_qo_len, max_seqlen_k], the original page table
+        topk_indices: [padded_qo_len, topk], the topk indices for each query
+            position. Partial DP padding rows may extend beyond real_qo_len.
     Returns:
-        transformed_page_table: [qo_len, topk], the transformed page table
-        For out-of-bound indices in topk_indices, this should be filled with -1.
+        transformed_page_table: [padded_qo_len, topk], the transformed page table.
+        Padding rows and negative sentinel indices are filled with -1.
     """
     assert page_size == 1
-    assert page_table.shape[0] == topk_indices.shape[0]
+    assert page_table.shape[0] <= topk_indices.shape[0], (
+        f"page_table rows ({page_table.shape[0]}) exceed topk_indices rows "
+        f"({topk_indices.shape[0]})"
+    )
     assert topk_indices.shape[1] == 2048
     qo_len = topk_indices.shape[0]
     if result is None:
@@ -148,6 +155,7 @@ def transform_index_page_table_decode_fast(
         result,
         page_size,
         page_table_row_stride=page_table.stride(0),
+        page_table_num_rows=page_table.shape[0],
     )
     return result
 
@@ -209,17 +217,25 @@ def transform_index_page_table_decode_ref(
     page_size: int = 1,
 ) -> torch.Tensor:
     assert page_size == 1
-    assert page_table.shape[0] == topk_indices.shape[0]
+    assert page_table.shape[0] <= topk_indices.shape[0], (
+        f"page_table rows ({page_table.shape[0]}) exceed topk_indices rows "
+        f"({topk_indices.shape[0]})"
+    )
     if result is None:
         result = torch.empty_like(topk_indices, dtype=torch.int32)
     assert result.shape == topk_indices.shape
-    torch.gather(
-        page_table.to(result.dtype),
-        dim=1,
-        index=topk_indices.clamp(min=0),
-        out=result,
-    )
-    result[topk_indices < 0] = -1
+    result.fill_(-1)
+    real_rows = page_table.shape[0]
+    if real_rows > 0:
+        real_topk = topk_indices[:real_rows]
+        real_result = result[:real_rows]
+        torch.gather(
+            page_table.to(result.dtype),
+            dim=1,
+            index=real_topk.clamp(min=0),
+            out=real_result,
+        )
+        real_result.masked_fill_(real_topk < 0, -1)
     return result
 
 

--- a/test/registered/kernels/test_dsa_transform_index.py
+++ b/test/registered/kernels/test_dsa_transform_index.py
@@ -231,6 +231,58 @@ class TestDSATransformIndex(CustomTestCase):
         self._check_decode_case(17, 8192, provide_result=True)
         self._check_decode_case(17, 8192, zero_row_stride=True)
 
+    def test_decode_fast_partial_dp_padding(self):
+        real_rows = 3
+        padded_rows = 4
+        context_length = 8192
+        page_table = self._make_page_table(real_rows, context_length)
+        topk_indices = torch.cat(
+            [
+                self._make_topk(real_rows, context_length),
+                torch.full(
+                    (padded_rows - real_rows, TOPK),
+                    -1,
+                    dtype=torch.int64,
+                    device=self.device,
+                ),
+            ]
+        )
+        expected = torch.full(
+            (padded_rows, TOPK), -1, dtype=torch.int32, device=self.device
+        )
+        real_topk = topk_indices[:real_rows]
+        torch.gather(
+            page_table,
+            dim=1,
+            index=real_topk.clamp(min=0),
+            out=expected[:real_rows],
+        )
+        expected[:real_rows].masked_fill_(real_topk < 0, -1)
+        result = torch.full_like(expected, 12345)
+
+        actual = transform_index_page_table_decode_fast(
+            page_table=page_table,
+            topk_indices=topk_indices,
+            result=result,
+        )
+        torch.cuda.synchronize()
+
+        self.assertIs(actual, result)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_decode_fast_rejects_extra_page_table_rows(self):
+        page_table = self._make_page_table(4, 8192)
+        topk_indices = self._make_topk(3, 8192)
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"page_table rows \(4\) exceed topk_indices rows \(3\)",
+        ):
+            transform_index_page_table_decode_fast(
+                page_table=page_table,
+                topk_indices=topk_indices,
+            )
+
     def test_decode_fast_extreme_shapes(self):
         self._check_decode_case(8192, 4096)
         self._check_decode_case(2, 1_000_000)


### PR DESCRIPTION
## Motivation

Partial-DP attention can pad the local query layout while keeping the request page table unpadded. In the GLM-5.2 DSA + MTP decode path, `_pad_topk_indices()` therefore produces trailing `-1` rows to match the padded query shape, but `metadata.page_table_1` still has one row per real local query.

The unfused DSA decode transform currently requires both tensors to have exactly the same number of rows:

```python
assert page_table.shape[0] == topk_indices.shape[0]
```

With TP16 / DP8, the attention TP size is 2. An otherwise valid partial-DP batch can consequently reach the transform as, for example, a 3-row page table and a 4-row top-k tensor whose last row is all `-1`. The current assertion terminates the scheduler before the Triton kernel runs.

This was first observed while capturing the MTP draft-decode CUDA graph. Disabling CUDA graphs reproduced the same assertion on the eager MTP decode path, so the issue is the partial-DP metadata contract rather than graph capture itself.

## Minimal reproduction on `main`

Run this from an SGLang CUDA environment:

```bash
python3 - <<'PY'
import torch

from sglang.kernels.ops.attention.dsa.transform_index import (
    transform_index_page_table_decode_fast,
)

real_rows = 3
padded_rows = 4
context_length = 8192
topk = 2048

page_table = torch.arange(
    real_rows * context_length,
    dtype=torch.int32,
    device="cuda",
).view(real_rows, context_length)
topk_indices = torch.full(
    (padded_rows, topk),
    -1,
    dtype=torch.int64,
    device="cuda",
)
topk_indices[:real_rows] = torch.arange(topk, device="cuda")

result = transform_index_page_table_decode_fast(page_table, topk_indices)
torch.cuda.synchronize()
assert torch.all(result[-1] == -1)
print("partial-DP padding passed")
PY
```

On the base commit this fails at the equal-row assertion. With this change, the three real rows are transformed and the padded row is filled with `-1`.

## Full topology that triggered the issue

The failure was reproduced by the GLM-5.2 decode role below. Run once per node with `NODE_RANK=0/1`; CUDA Graph capture reaches the failing Draft Decode path during startup.

```bash
python3 -m sglang.launch_server \
  --model-path <GLM-5.2-FP8> \
  --served-model-name glm-5.2 \
  --host 0.0.0.0 \
  --port 30220 \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-ib-device "mlx5_1,mlx5_2,mlx5_3,mlx5_4" \
  --trust-remote-code \
  --nnodes 2 \
  --node-rank "${NODE_RANK}" \
  --dist-init-addr "${MASTER_ADDR}:21220" \
  --tp-size 16 \
  --dp-size 8 \
  --ep-size 16 \
  --enable-dp-attention \
  --num-reserved-decode-tokens 2000 \
  --mem-fraction-static 0.9 \
  --max-running-requests 80 \
  --max-total-tokens 205000 \
  --context-length 395000 \
  --page-size 64 \
  --moe-dense-tp-size 1 \
  --enable-dp-lm-head \
  --quantization fp8 \
  --moe-a2a-backend deepep \
  --deepep-mode low_latency \
  --cuda-graph-bs 1 4 10 16 \
  --dsa-topk-backend torch \
  --mooncake-ib-device "mlx5_1,mlx5_2,mlx5_3,mlx5_4" \
  --moe-runner-backend deep_gemm \
  --speculative-moe-runner-backend deep_gemm \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 2 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 3 \
  --kv-cache-dtype fp8_e4m3
```

Adding `--disable-cuda-graph` avoids the startup capture but the same assertion occurs when the first affected eager MTP Decode batch is executed.

## Root cause

The page table and top-k tensor intentionally describe different row domains in this case:

- `page_table.shape[0]`: real local queries/requests;
- `topk_indices.shape[0]`: padded local query layout consumed by the attention backend.

The existing transform assumes both domains are always equal. Merely relaxing the Python assertion would be unsafe because the Triton grid is sized from `topk_indices`, and padded programs would then form page-table pointers for rows that do not exist.

## Changes

- Allow `page_table.shape[0] <= topk_indices.shape[0]`, while continuing to reject the reverse mismatch with a clear error.
- Pass the real page-table row count as a runtime Triton argument and include `req_id < page_table_num_rows` in the load mask.
- Fill padded output rows with the existing `-1` sentinel in the same kernel; no concatenation, allocation, or additional clearing kernel is added to the fast path.
- Keep the row count as a runtime argument rather than a `tl.constexpr`, avoiding a full-value specialization for every real batch size.
- Align the reference implementation with the same row contract.
- Add coverage for partial-DP padding with a dirty preallocated output buffer and for the invalid reverse mismatch.

The existing equal-row correctness, stride, large-batch, and 1M-context test cases remain unchanged and cover the previous behavior.

## Validation

Completed locally:

- `git diff --check`
- `python -m compileall -q python/sglang/kernels/ops/attention/dsa/transform_index.py test/registered/kernels/test_dsa_transform_index.py`
- `ruff format --check` on both changed files
- `ruff check --ignore E741` on both changed files (`E741` is pre-existing in this file)

Pending before marking the PR ready:

- Run `python -m pytest -q test/registered/kernels/test_dsa_transform_index.py` on a CUDA runner.
- Capture the test-only RED result on the base commit and the GREEN result on this commit.
- Re-run the GLM-5.2 TP16 / DP8 / EP16 MTP topology in both eager and Full CUDA Graph modes.
- Compare equal-row transform latency before/after for representative Decode batch sizes.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29724969152](https://github.com/bytedance-iaas/sglang/actions/runs/29724969152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29724969058](https://github.com/bytedance-iaas/sglang/actions/runs/29724969058)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->