### PR TITLE
[HiCache][DSV4] Enable SWA eviction on EIC radix cache

### DIFF
--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -526,6 +526,22 @@ class EICHiRadixCache(RadixCache):
     def swa_protected_size(self):
         return self.protected_size_
 
+    def supports_swa(self) -> bool:
+        # EIC replaces the SWA-capable UnifiedRadixCache in kv_cache_builder, so
+        # it must re-declare SWA support. Without this, supports_swa() falls back
+        # to the RadixCache default (False), ScheduleBatch.maybe_evict_swa() is
+        # gated off, and running sequences never release out-of-window SWA KV ->
+        # the SWA pool fills up and prefill OOMs. The full-attention radix tree is
+        # unaffected: only per-request SWA tails are freed in maybe_evict_swa.
+        return self.sliding_window_size is not None
+
+    def sanity_check(self):
+        # invariant_checker._check_tree_cache() calls this when
+        # is_hybrid_swa and supports_swa(). EIC manages SWA freeing outside the
+        # radix tree (per-request in maybe_evict_swa), so there is no tree
+        # invariant to assert here.
+        pass
+
     def evict(self, params: EvictParams, retry_times: int = 3) -> EvictResult:
         start_time = time.perf_counter()
         num_tokens = max(params.num_tokens, params.swa_num_tokens)


### PR DESCRIPTION
## Motivation

With EIC enabled, DSV4 sliding-window models OOM at prefill (`Prefill out of memory`), while the exact same config with EIC **off** runs fine even at high concurrency. Root cause is a missing SWA capability declaration, not tree eviction (which #637 already fixed via `max(swa_num_tokens)`).

`kv_cache_builder` builds the SWA-capable `UnifiedRadixCache`, then **replaces** it with `EICPagedHiRadixCache` when `enable_eic_cache` is set (`kv_cache_builder.py:316-321`). But `EICPagedHiRadixCache(EICHiRadixCache(RadixCache))` inherits `RadixCache` → `BasePrefixCache.supports_swa() == False`.

`ScheduleBatch.maybe_evict_swa()` is gated directly on `supports_swa()`:

```python
# schedule_batch.py:2629
def maybe_evict_swa(self):
    if self.tree_cache.supports_swa():   # False for EIC -> whole method skipped
```

So with EIC on, active decode sequences never release out-of-window SWA KV: each keeps its full length (~4096) in the SWA pool instead of just the window (128). Per rank, 8 × 4096 = 32768 tokens saturate the SWA pool → prefill OOM. EIC-off uses `SWARadixCache` (`supports_swa() == True`), so `maybe_evict_swa` trims each sequence to the 128 window and the pool stays flat — matching the observed "EIC on crashes / EIC off fine".

## Modifications

`python/sglang/srt/mem_cache/eic_hiradix_cache.py` (on `EICHiRadixCache`, inherited by `EICPagedHiRadixCache`):

- **`supports_swa()`** → `True` when `sliding_window_size is not None`, re-declaring the SWA support lost when EIC replaces `UnifiedRadixCache`. Only per-request SWA tails are freed in `maybe_evict_swa`; the full-attention radix tree is unaffected, so full-prefix reuse stays valid.
- **`sanity_check()`** no-op. `invariant_checker._check_tree_cache()` calls `tree_cache.sanity_check()` under `is_hybrid_swa and supports_swa()`; without this, flipping `supports_swa()` would raise `AttributeError` (neither EIC radix nor `RadixCache`/`BasePrefixCache` defines it). EIC frees SWA per-request outside the radix tree, so there is no tree invariant to assert.

The decode-time SWA free is safe: the DSV4 SWA allocator's `free_swa` (`hisparse_memory_pool.py:595`) is idempotent (zeroes `full_to_swa_index_mapping`), and SWA layers never read beyond-window KV.

## Verification

Local unit tests can't run on this macOS host (torch/inductor collection error, unrelated). Please validate on the pod: run the DSV4 SWA + EIC config at the concurrency that previously OOM'd and confirm the SWA pool stays flat.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->