### PR TITLE
[HiCache][DSV4] Release prompt-prefix SWA under EIC + fix paged host accounting

### DIFF
--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -567,10 +567,14 @@ class EICCacheController(HiCacheController):
     def evict_device(
         self, device_indices: torch.Tensor, host_indices: torch.Tensor
     ) -> int:
-        if self.disable_shared and not self.mem_pool_host.is_synced(host_indices):
-            raise ValueError(
-                f"Inconsistent states: {self.mem_pool_host.get_state(host_indices)}"
-            )
+        # Paged mode: host_indices are device-space ids, out of range for the
+        # swa-sized mem_state. mem_state is only used when disable_shared.
+        if self.disable_shared:
+            if not self.mem_pool_host.is_synced(host_indices):
+                raise ValueError(
+                    f"Inconsistent states: {self.mem_pool_host.get_state(host_indices)}"
+                )
         self.mem_pool_device_allocator.free(device_indices)
-        self.mem_pool_host.update_backup(host_indices)
+        if self.disable_shared:
+            self.mem_pool_host.update_backup(host_indices)
         return len(device_indices)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2692,7 +2692,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         assert (
             req.cache_protected_len % self.tree_cache.page_size == 0
         ), "cache_protected_len must be page aligned"
-        req.swa_evicted_seqlen = max(req.swa_evicted_seqlen, req.cache_protected_len)
+        if not getattr(self.tree_cache, "swa_evict_release_prefix", False):
+            req.swa_evicted_seqlen = max(
+                req.swa_evicted_seqlen, req.cache_protected_len
+            )
 
         # Subtract an extra page_size so the eviction frontier never reaches the
         # radix tree insert boundary (page_floor(seq_len)). This keeps at least one

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -378,6 +378,16 @@ class EICHiRadixCache(RadixCache):
 
         self.token_to_kv_pool_allocator.free(kv_indices[key_len:])
 
+        # Backstop: reconcile any SWA slots left by per-step prefix eviction
+        # (page-align / load-back re-alloc). free_swa is idempotent.
+        if self.sliding_window_size is not None:
+            if hasattr(self.token_to_kv_pool_allocator, "free_swa"):
+                self.token_to_kv_pool_allocator.free_swa(
+                    self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, :kv_committed_len
+                    ]
+                )
+
         if req.last_node is not None:
             self.dec_lock_ref(req.last_node)
 
@@ -518,13 +528,33 @@ class EICHiRadixCache(RadixCache):
         return self.evictable_size_
 
     def swa_evictable_size(self):
-        return self.evictable_size_
+        # EIC radix holds only FULL indices; SWA is allocator-managed. Report 0
+        # to avoid double-counting vs swa_available_size in the idle leak check.
+        return 0
 
     def full_protected_size(self):
         return self.protected_size_
 
     def swa_protected_size(self):
-        return self.protected_size_
+        # No SWA state in the EIC radix tree.
+        return 0
+
+    def supports_swa(self) -> bool:
+        # EIC replaces the SWA-capable UnifiedRadixCache; re-declare SWA support
+        # or maybe_evict_swa is gated off and the SWA pool fills (prefill OOM).
+        return self.sliding_window_size is not None
+
+    def sanity_check(self):
+        # EIC frees SWA outside the radix tree; no tree invariant to assert.
+        pass
+
+    @property
+    def swa_evict_release_prefix(self) -> bool:
+        # EIC lacks SWARadixCache.dec_swa_lock_only, so let maybe_evict_swa drop
+        # this request's out-of-window prefix SWA directly. Safe: SWA attention
+        # never reads past the window, full KV is in the separate full pool, and
+        # reuse reloads SWA from the EIC host backup.
+        return True
 
     def evict(self, params: EvictParams, retry_times: int = 3) -> EvictResult:
         start_time = time.perf_counter()

--- a/python/sglang/srt/mem_cache/storage/eic/eic_storage.py
+++ b/python/sglang/srt/mem_cache/storage/eic/eic_storage.py
@@ -326,7 +326,12 @@ class EICStorage(HiCacheStorage):
         self.connection.register_memory(vals, meminfo)
 
     def _pool_buffers(self, memory_pool_host: HostKVCache) -> List[torch.Tensor]:
-        buffer = memory_pool_host.kv_buffer
+        # NSA indexer host has no kv_buffer; use get_hybrid_pool_buffer() if present.
+        get_hybrid = getattr(memory_pool_host, "get_hybrid_pool_buffer", None)
+        if callable(get_hybrid):
+            buffer = get_hybrid()
+        else:
+            buffer = memory_pool_host.kv_buffer
         if buffer is None:
             return []
         if isinstance(buffer, list):


### PR DESCRIPTION
## Motivation

Follow-up to #650 (which merged the `supports_swa()` gate fix). On-pod validation (DSV4-Flash-FP8, native EIC) showed the gate alone is **necessary but not sufficient**, and separately surfaced two more EIC-on-DSv4 defects. This PR carries three related fixes, all validated on-pod.

## Fix 1 — Release prompt-prefix SWA under EIC (`cc20de8693`)

With `--enable-eic-cache`, SWA usage stayed pegged at **0.98** with a retract loop: a running request's prompt-prefix SWA `[0, cache_protected_len)` stays pinned (`_evict_swa` floors at `cache_protected_len`; EIC lacks `SWARadixCache.dec_swa_lock_only`). EIC cannot reuse `SWARadixCache` (single `lock_ref`, no `swa_lock_ref`/`swa_uuid`/`swa_tombstone`/`swa_lru` → per-node release would corrupt shared prefixes), so release per-request:

- `schedule_batch._evict_swa`: honor `tree_cache.swa_evict_release_prefix` so EIC drops its own out-of-window prefix SWA. Safe: SWA attention never reads past the window; full-attention prefix KV is in the separate full pool; reuse reloads SWA from the EIC host backup.
- `eic_hiradix_cache`: `swa_evict_release_prefix=True` + finish-time `free_swa` backstop (idempotent) over the committed range to reconcile slots left by page-alignment / load-back re-alloc.
- `eic_hiradix_cache`: `swa_evictable_size`/`swa_protected_size` return `0` (EIC radix holds only FULL indices; reporting `evictable_size_` double-counted vs allocator `swa_available_size` and tripped the idle SWA leak check).
- `eic_cache_controller.evict_device`: gate the base `mem_state` state-machine on `disable_shared`. In paged mode `host_indices` are device-index-space ids backed by `host_pool_group`; indexing the swa-sized `mem_state` overflowed (`IndexError: index 162048 vs size 94208`).

**Validated** (TP=4, native EIC, 3500/1500 random-ids, cc64): SWA usage **0.14–0.79** (was 0.98 pegged), **0** retract/crash/leak, **128/128** requests completed (was retract deadlock, never finished), EIC prefix reuse hit **0.93**.

## Fix 2 — EIC L3-backend startup crash on NSA indexer host pool (`5b4ffea58a`)

With `--hicache-storage-backend eic` on DSv4, the hybrid pool assembler registers every host sub-pool, including `NSAIndexerPoolHost`. `EICStorage._pool_buffers` read `memory_pool_host.kv_buffer` directly, but `NSAIndexerPoolHost` never sets `kv_buffer` (tensors live in `index_k_with_scale_buffer`) → `AttributeError` at startup.

Fix: prefer `get_hybrid_pool_buffer()` (every host pool exposes it; DSv4Paged/State return `kv_buffer`-as-list unchanged, NSAIndexer returns `[index_k_with_scale_buffer]`), fall back to `kv_buffer` for MHA/MLA.

**Validated** (TP=8, `--hicache-storage-backend eic`): server reaches READY (was crash-on-startup); gsp bench 64/64 OK; **0** `batch_exists_v2`/AttributeError; L3 prefix reuse working (`#cached-token` up to 30720). The reporter's secondary `batch_exists_v2` request-time error did not reproduce post-fix (it was a downstream effect of the failed host-pool registration).

## Commits
- `aabbc83` gate fix (also in merged #650)
- `cc20de8693` prefix-SWA release + paged host accounting
- `5b4ffea58a` L3-backend NSA indexer host-pool startup fix



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->