### PR TITLE
[HiCache][DSV4] Fix EIC SWA extend eviction: unlock, dedup, drop reserved page

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2684,7 +2684,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                             req.last_node, req.swa_uuid_for_lock
                         )
                         req.swa_prefix_lock_released = True
-                elif self.forward_mode.is_extend() and self.tree_cache.is_chunk_cache():
+                elif self.forward_mode.is_extend() and (
+                    self.tree_cache.is_chunk_cache()
+                    or getattr(  # EIC-only hook; other caches lack it.
+                        self.tree_cache, "eic_swa_extend_eviction", lambda: False
+                    )()
+                ):
                     pre_len = self.prefix_lens[idx]
                     if self.enable_overlap:
                         # In chunked prefill case, when the second extend batch is scheduling, the first extend batch is still running, so we cannot evict swa tokens

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -378,13 +378,13 @@ class EICHiRadixCache(RadixCache):
 
         self.token_to_kv_pool_allocator.free(kv_indices[key_len:])
 
-        # Backstop: reconcile any SWA slots left by per-step prefix eviction
-        # (page-align / load-back re-alloc). free_swa is idempotent.
+        # Backstop SWA slots not released by per-step eviction or FULL cleanup.
         if self.sliding_window_size is not None:
             if hasattr(self.token_to_kv_pool_allocator, "free_swa"):
                 self.token_to_kv_pool_allocator.free_swa(
                     self.req_to_token_pool.req_to_token[
-                        req.req_pool_idx, :kv_committed_len
+                        req.req_pool_idx,
+                        req.swa_evicted_seqlen : kv_committed_len,
                     ]
                 )
 
@@ -564,6 +564,10 @@ class EICHiRadixCache(RadixCache):
         # the SWA pool fills up and prefill OOMs. The full-attention radix tree is
         # unaffected: only per-request SWA tails are freed in maybe_evict_swa.
         return self.sliding_window_size is not None
+
+    def eic_swa_extend_eviction(self) -> bool:
+        # EIC radix owns only FULL indices, so free out-of-window SWA in extend.
+        return self.supports_swa()
 
     def sanity_check(self):
         # invariant_checker._check_tree_cache() calls this when

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -12,6 +12,7 @@ from sglang.srt.mem_cache.allocator import (
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import KVCache, MHATokenToKVPool
 from sglang.srt.mem_cache.utils import maybe_init_custom_mem_pool
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import is_npu
 from sglang.srt.utils.common import get_num_new_pages
 
@@ -629,7 +630,11 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             mapping_indices = self._expand_to_full_pages(free_index)
 
         swa_indices = self.full_to_swa_index_mapping[mapping_indices]
-        swa_indices = swa_indices[swa_indices > 0]
+        if get_global_server_args().enable_eic_cache:
+            # EIC aliases FULL spans onto reused SWA slots; skip reserved page + dedup.
+            swa_indices = torch.unique(swa_indices[swa_indices >= self.page_size])
+        else:
+            swa_indices = swa_indices[swa_indices > 0]
         self.swa_attn_allocator.free(swa_indices)
         self.full_to_swa_index_mapping[mapping_indices] = 0
 

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -164,6 +164,27 @@ class TestEICHiCacheRegression(unittest.TestCase):
             server_args=server_args,
         )
 
+    def test_free_swa_skips_reserved_page_and_dedups_aliases(self):
+        # free_swa must drop reserved-page sentinels + dedup aliases under EIC.
+        from sglang.srt.mem_cache.swa_memory_pool import SWATokenToKVPoolAllocator
+
+        alloc = object.__new__(SWATokenToKVPoolAllocator)
+        alloc.page_size = 256
+        alloc.swa_attn_allocator = mock.Mock()
+        alloc.full_to_swa_index_mapping = torch.tensor(
+            [6, 8, 10, 21, 512, 512, 512, 768], dtype=torch.int64
+        )
+        alloc._expand_to_full_pages = lambda idx: idx
+
+        with mock.patch(
+            "sglang.srt.mem_cache.swa_memory_pool.get_global_server_args",
+            return_value=SimpleNamespace(enable_eic_cache=True),
+        ):
+            SWATokenToKVPoolAllocator.free_swa(alloc, torch.arange(8))
+
+        freed = alloc.swa_attn_allocator.free.call_args[0][0]
+        self.assertEqual(sorted(freed.tolist()), [512, 768])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Under EIC hierarchical cache (`EICHiRadixCache`) with 32K chunked prefill at high concurrency, DeepSeek-V4 either:
- **Deadlocks**: SWA pool locks at 100%, `running-req: 0, queue-req: 255`, scheduler stalls, health times out; or
- **Crashes**: `assert swa_attn_allocator.available_size() <= size` (SWA double-free) at request finish, taking down all ranks near completion-heavy points.

## Root cause (three coupled EIC-only issues)

**1. Extend-time SWA eviction gated off for EIC**
`ScheduleBatch.maybe_evict_swa()`'s extend branch was `is_chunk_cache()`-only. `EICHiRadixCache` is a radix cache whose tree owns only FULL indices — `swa_evictable_size()` is `0`, so its own eviction can never reclaim SWA. Running requests never released out-of-window SWA during long prefills → pool fills → deadlock. Fixed with an **EIC-only** opt-in `eic_swa_extend_eviction()` read via `getattr` (every other cache lacks the method and is untouched).

**2. finish backstop double-frees the already-evicted prefix**
`cache_finished_req`'s SWA backstop rescanned `[0, kv_committed_len)`, re-freeing `[0, swa_evicted_seqlen)` already released during extend. Start the backstop at `swa_evicted_seqlen`.

**3. `free_swa` frees reserved-page sentinels and aliased slots**
`full_to_swa_index_mapping` aliases many FULL positions onto a few reused SWA slots and onto the reserved page (`< page_size`). The `> 0` filter passed reserved-page sentinels and duplicate slots to `swa_attn_allocator.free`, double-freeing and inflating `available_size`. Runtime diagnostic caught it:
```
SWA_DOUBLE_FREE dup=[6,8,10,21,...] n_dup=174  free_index_head=[102400,...]
```
(page_size=256 → real slots start at 256; `6/8/10/21` are reserved-page sentinels.) Under `enable_eic_cache`, skip the reserved page (`>= page_size`) and `torch.unique` the aliases. **The non-EIC path keeps the original `> 0` behavior byte-for-byte.**

## Isolation

Every branch is EIC-gated:
- `schedule_batch.py`: `getattr(..., "eic_swa_extend_eviction", lambda: False)` — non-EIC caches don't define it.
- `swa_memory_pool.py`: `if get_global_server_args().enable_eic_cache:` — non-EIC falls through to the original line unchanged.
- `eic_hiradix_cache.py`: EIC-only file.

## SWA reuse unaffected

Only **device** SWA slots are recycled; the sliding window never reads out-of-window KV, and EIC reloads the window from **host backup** on reuse. Verified live: reload rounds still hit EIC (`hit_rate total/gpu/eic = 0.98/0.00/0.98`).

## Verification

DeepSeek-V4-Flash-FP8, native EIC L2 (`--enable-eic-cache`), 32K `generated-shared-prefix` agent workload (64×8, 512 prompts) @ concurrency 256:
- No deadlock, no Prefill OOM, no AssertionError, no scheduler crash, health stays 200.
- SWA usage a healthy sawtooth (0.05–0.99) instead of locking at 1.00; `only evicted 0` gone.
- EIC KV read/write hits intact.

Before this fix: same workload deadlocks (running-req 0) or asserts near 512/512. Adds a focused `free_swa` regression under `stage-a-test-cpu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->