### PR TITLE
[HiCache][DSV4] Scheme B: SWA exits EIC L2, recompute window on reuse

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1044,6 +1044,14 @@ class Req(ReqDllmMixin):
 
         token_ids_to_match = self.fill_ids[: self._compute_max_prefix_len(input_len)]
 
+        # SWA KV isn't in L2; drop the last recompute_tail tokens from the match
+        # so they re-prefill and rebuild their SWA window locally.
+        recompute_tail = getattr(tree_cache, "swa_l2_recompute_tail", 0)
+        if recompute_tail:
+            token_ids_to_match = token_ids_to_match[
+                : max(0, len(token_ids_to_match) - recompute_tail)
+            ]
+
         # Disable prefix caching when embed overrides are present: same token IDs
         # with different override vectors must not share cached KV values.
         if self.positional_embed_overrides is not None:

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -44,6 +44,13 @@ def page_align_floor(length: int, page_size: int) -> int:
     return (length // page_size) * page_size
 
 
+def swa_retained_tail(sliding_window_size: int, page_size: int) -> int:
+    """Trailing tokens whose SWA must stay live: the window, but at least one
+    page so a page wider than the window (DSV4: 256 vs 128) never leaves an
+    all-tombstone leaf. Also EIC Scheme-B's recompute-tail."""
+    return max(sliding_window_size, page_size)
+
+
 def free_swa_out_of_window_slots(
     req: Req,
     pre_len: int,
@@ -83,7 +90,7 @@ def free_swa_out_of_window_slots(
     else:
         # Page-aligning below and retaining max(window, page) keeps the frontier
         # strictly below page_floor(seq_len) without an extra page margin.
-        evict_threshold = pre_len - max(sliding_window_size, page_size)
+        evict_threshold = pre_len - swa_retained_tail(sliding_window_size, page_size)
 
     new_swa_evicted_seqlen = max(req.swa_evicted_seqlen, evict_threshold)
     if page_size > 1:

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -37,6 +37,7 @@ from sglang.srt.mem_cache.memory_pool import (
     MLATokenToKVPool,
     NSATokenToKVPool,
 )
+from sglang.srt.mem_cache.common import swa_retained_tail
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 from sglang.srt.server_args import ServerArgs
 
@@ -234,6 +235,14 @@ class EICHiRadixCache(RadixCache):
         )
         self.load_back_threshold = 10
         super().__init__(params)
+
+        # Scheme B: SWA isn't persisted to L2; init_next_round_input drops this
+        # many trailing tokens from the match so they re-prefill locally.
+        self.swa_l2_recompute_tail = (
+            swa_retained_tail(self.sliding_window_size, self.page_size)
+            if self.sliding_window_size is not None
+            else 0
+        )
 
         self.save_decode_cache = True
         config_file = get_eic_config_file_path()

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -1675,11 +1675,9 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
         return "kernel"
 
     def _estimate_page_bytes(self, device_pool) -> int:
+        # Scheme B: L2 holds only FULL (KV-sourced) pools; SWA + compress-state
+        # rings are recomputed on reuse, so excluded here and in _build_page_specs.
         page_bytes = 0
-        if device_pool.swa_kv_pool.kv_buffer:
-            page_bytes += len(device_pool.swa_kv_pool.kv_buffer) * int(
-                device_pool.swa_kv_pool.bytes_per_page_padded
-            )
         if device_pool.c4_kv_pool.kv_buffer:
             page_bytes += len(device_pool.c4_kv_pool.kv_buffer) * int(
                 device_pool.c4_kv_pool.bytes_per_page_padded
@@ -1693,16 +1691,6 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
             page_bytes += len(device_pool.c128_kv_pool.kv_buffer) * int(
                 device_pool.c128_kv_pool.bytes_per_page_padded
             )
-
-        for pools in (
-            device_pool.compress_state_pools,
-            device_pool.indexer_compress_state_pools,
-        ):
-            for pool in pools:
-                if pool is None or pool.ratio == 128:
-                    continue
-                state_tensor = pool.kv_score_buffer.kv_score
-                page_bytes += int(pool.ring_size * state_tensor[0].nbytes)
         return page_bytes
 
     def get_size_per_token(self):
@@ -1713,92 +1701,62 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
         for name, entry in self.host_pool_group.entry_map.items():
             if name == PoolName.KV:
                 continue
+            # Scheme B: skip SWA-sourced pools; recomputed on reuse, not in L2.
+            if name in self._SWA_SOURCED_POOLS:
+                continue
+            if name not in self._KV_SOURCED_POOLS:
+                raise ValueError(f"Unsupported DeepSeek V4 EIC pool: {name}")
             host_pool = entry.host_pool
             dummy = host_pool.get_dummy_flat_data_page()
             if dummy.numel() == 0:
                 continue
-            if name in self._SWA_SOURCED_POOLS:
-                source = PoolName.SWA
-            elif name in self._KV_SOURCED_POOLS:
-                source = PoolName.KV
-            else:
-                raise ValueError(f"Unsupported DeepSeek V4 EIC pool: {name}")
             specs.append(
                 {
                     "name": name,
                     "host_pool": host_pool,
-                    "source": source,
                     "numel": dummy.numel(),
                 }
             )
         return specs
 
-    def _swa_indices(self, full_indices: torch.Tensor) -> torch.Tensor:
-        return self.device_pool.translate_loc_from_full_to_swa(full_indices).to(
-            torch.int64
-        )
-
     def alloc_device_indices(self, allocator, need_size: int):
+        # Scheme B: alloc only FULL KV; SWA is recomputed on reuse, so don't
+        # consume the scarce SWA pool. full->swa mapping stays 0 (never read).
         full_allocator = getattr(allocator, "full_attn_allocator", None)
-        swa_allocator = getattr(allocator, "swa_attn_allocator", None)
-        if full_allocator is None or swa_allocator is None:
+        if full_allocator is None:
             return allocator.alloc(need_size)
-
-        full_indices = full_allocator.alloc(need_size)
-        if full_indices is None:
-            return None
-        swa_indices = swa_allocator.alloc(need_size)
-        if swa_indices is None:
-            full_allocator.free(full_indices)
-            return None
-        allocator.set_full_to_swa_mapping(full_indices, swa_indices)
-        return full_indices
+        return full_allocator.alloc(need_size)
 
     def _build_pool_transfers(self, full_indices: torch.Tensor):
+        # Scheme B: all page_specs are FULL, so no full->swa translation.
         full_host_indices = full_indices.detach().cpu().to(torch.int64)
-        swa_device_indices = self._swa_indices(full_indices)
-        swa_host_indices = swa_device_indices.detach().cpu().to(torch.int64)
-
-        transfers = []
-        for spec in self.page_specs:
-            if spec["source"] == PoolName.SWA:
-                host_indices = swa_host_indices
-                device_indices = swa_device_indices
-            else:
-                host_indices = full_host_indices
-                device_indices = full_indices
-            transfers.append(
-                PoolTransfer(
-                    name=spec["name"],
-                    host_indices=host_indices,
-                    device_indices=device_indices,
-                )
+        transfers = [
+            PoolTransfer(
+                name=spec["name"],
+                host_indices=full_host_indices,
+                device_indices=full_indices,
             )
-        return full_host_indices, swa_host_indices, transfers
+            for spec in self.page_specs
+        ]
+        return full_host_indices, transfers
 
-    def _pack_page(self, full_page_start: int, swa_page_start: int) -> torch.Tensor:
+    def _pack_page(self, full_page_start: int) -> torch.Tensor:
         pieces = []
         for spec in self.page_specs:
-            page_start = (
-                swa_page_start if spec["source"] == PoolName.SWA else full_page_start
-            )
             pieces.append(
-                spec["host_pool"].get_data_page(page_start, flat=True).view(torch.uint8)
+                spec["host_pool"]
+                .get_data_page(full_page_start, flat=True)
+                .view(torch.uint8)
             )
         return torch.cat(pieces).contiguous()
 
-    def _unpack_page(
-        self, full_page_start: int, swa_page_start: int, page_data: torch.Tensor
-    ) -> None:
+    def _unpack_page(self, full_page_start: int, page_data: torch.Tensor) -> None:
         offset = 0
         page_data = page_data.view(torch.uint8)
         for spec in self.page_specs:
             next_offset = offset + spec["numel"]
-            page_start = (
-                swa_page_start if spec["source"] == PoolName.SWA else full_page_start
-            )
             spec["host_pool"].set_from_flat_data_page(
-                page_start, page_data[offset:next_offset]
+                full_page_start, page_data[offset:next_offset]
             )
             offset = next_offset
 
@@ -1847,9 +1805,7 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
         assert len(dst_tensors) == page_count * self.page_chunk_count, (
             "Length of dst_tensors must equal pages * DSv4 EIC chunks per page"
         )
-        full_host_indices, swa_host_indices, transfers = self._build_pool_transfers(
-            device_indices
-        )
+        full_host_indices, transfers = self._build_pool_transfers(device_indices)
         self.host_pool_group.backup_from_device_all_layer(
             self.device_pool,
             full_host_indices,
@@ -1861,10 +1817,7 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
 
         for page_id in range(page_count):
             token_offset = page_id * self.page_size
-            page = self._pack_page(
-                full_host_indices[token_offset].item(),
-                swa_host_indices[token_offset].item(),
-            )
+            page = self._pack_page(full_host_indices[token_offset].item())
             for chunk_id in range(self.page_chunk_count):
                 chunk_offset = chunk_id * self.eic_chunk_bytes
                 chunk_end = min(chunk_offset + self.eic_chunk_bytes, self.page_bytes)
@@ -1883,9 +1836,7 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
         if page_count == 0:
             return
         device_indices = device_indices[: page_count * self.page_size]
-        full_host_indices, swa_host_indices, transfers = self._build_pool_transfers(
-            device_indices
-        )
+        full_host_indices, transfers = self._build_pool_transfers(device_indices)
 
         for page_id in range(page_count):
             pieces = []
@@ -1900,11 +1851,7 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
                 )
             page_data = torch.cat(pieces)
             token_offset = page_id * self.page_size
-            self._unpack_page(
-                full_host_indices[token_offset].item(),
-                swa_host_indices[token_offset].item(),
-                page_data,
-            )
+            self._unpack_page(full_host_indices[token_offset].item(), page_data)
         torch.cuda.current_stream().synchronize()
 
         for layer_id in range(self.transfer_layer_num):


### PR DESCRIPTION
## Problem

EIC L2 packed SWA KV alongside FULL, but async `device_backup` read
`full_to_swa_index_mapping` *after* `maybe_evict_swa` had zeroed it — so
out-of-window SWA pages were persisted as slot-0 garbage. On reuse the restored
window was correct only at its newest edge and stale everywhere older, silently
corrupting attention on any prefix long enough to evict SWA.

## Fix (Scheme B)

Stop persisting SWA to L2. Pages pack only FULL/KV pools. On reuse, drop the last
`max(window, page)` tokens from the prefix match and re-prefill them, recomputing
their SWA window locally.

- Root-removes the async backup/free race and the slot-0 garbage.
- Page shrinks ~9x: `9158208 → 998208` B, 3 chunks → 1.
- Recompute cost trivial (window = 128).
- Net **−29 lines** of pool code (drops SWA/FULL page-spec branching, `_swa_indices`, full→swa backup translation).

## Verification

DSv4-Flash-FP8 TP4/EP4 + EIC, production-shape 8-turn agent chat (each turn
~3584 in / 512 out, context to **32K**): L2-reuse output is **bitwise-identical
to ideal device-reuse** at every turn boundary — the exact path where Scheme B's
tail recompute fires. Any residual divergence vs a cold run is model
non-determinism (FP8/MoE), reproduced by two cold runs alone.