### PR TITLE
feat(dsv4): adapt runtime for decode context parallelism

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c128_online_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c128_online_v2.cuh
@@ -732,6 +732,7 @@ struct OnlinePrefillStage1Params {
   const int32_t* __restrict__ req_to_token;      // (num_reqs, max_tokens)
   int64_t stride_r2t;
   int32_t state_slot_offset;
+  uint32_t active_bs;
   uint32_t num_c;
   uint32_t num_w;
 };
@@ -746,6 +747,10 @@ __global__ void plan_c128_online_prefill_kernel(const OnlinePrefillStage1Params 
   auto plan = *plan_ptr;
   if (plan.is_invalid()) return;
   const auto batch_id = plan.read_page_0;
+  if (batch_id >= params.active_bs) {
+    *plan_ptr = CompressPlan::invalid();
+    return;
+  }
   const auto rid = params.req_pool_indices[batch_id];
   const int32_t main_slot = static_cast<int32_t>(rid);
   plan.read_page_0 = main_slot + params.state_slot_offset;
@@ -765,7 +770,8 @@ inline OnlinePrefillPlan plan_online_prefill(
     const tvm::ffi::TensorView plan_c_dev_,
     const tvm::ffi::TensorView plan_w_dev_,
     const int32_t state_slot_offset,
-    const bool use_cuda_graph) {
+    const bool use_cuda_graph,
+    const int32_t active_bs) {
   auto B = SymbolicSize{"batch_size"};
   auto N = SymbolicSize{"num_q_tokens"};
   auto cpu = SymbolicDevice{};
@@ -797,6 +803,8 @@ inline OnlinePrefillPlan plan_online_prefill(
       .verify(plan_c_dev_)
       .verify(plan_w_dev_);
   RuntimeCheck(state_slot_offset >= 0);
+  RuntimeCheck(active_bs >= 0);
+  RuntimeCheck(active_bs <= B.unwrap());
 
   const auto stage0_params = OnlinePrefillStage0Params{
       .plan_c = static_cast<CompressPlan*>(plan_c_pin.data_ptr()),
@@ -913,6 +921,7 @@ inline OnlinePrefillPlan plan_online_prefill(
         .req_to_token = static_cast<const int32_t*>(req_to_token.data_ptr()),
         .stride_r2t = req_to_token.stride(0),
         .state_slot_offset = state_slot_offset,
+        .active_bs = static_cast<uint32_t>(active_bs),
         .num_c = num_c_padded,
         .num_w = num_w_padded,
     };

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
@@ -42,6 +42,7 @@ struct Prefill0Params {
   const IDX_T* seq_lens_ptr;     // [batch_size]
   const IDX_T* extend_lens_ptr;  // [batch_size]
   uint32_t batch_size;
+  uint32_t active_bs;
   uint32_t num_q_tokens;
   int32_t compress_ratio;
   int32_t swa_page_size;
@@ -60,6 +61,7 @@ struct Prefill1Params {
   uint32_t num_c_padded;
   uint32_t num_w_padded;
   uint32_t num_work;
+  uint32_t active_bs;
   int32_t swa_page_size;
   int32_t ring_size;
   int32_t compress_ratio;
@@ -139,7 +141,7 @@ __global__ __launch_bounds__(1024, 1)  //
 
   // === Stage A: load per-batch fields, init shared scratch ===
   int32_t seq_len = 0, extend_len = 0, prefix_len = 0;
-  if (tx < params.batch_size) {
+  if (tx < params.active_bs) {
     seq_len = static_cast<int32_t>(params.seq_lens_ptr[tx]);
     extend_len = static_cast<int32_t>(params.extend_lens_ptr[tx]);
     prefix_len = seq_len - extend_len;
@@ -156,9 +158,10 @@ __global__ __launch_bounds__(1024, 1)  //
   }
 
   // === Stage B: min/max(extend_len) for MTP-uniform detection ===
-  // For min, treat threads outside `batch_size` as +inf so they don't pull the min down.
+  // For min, treat padded graph slots outside `active_bs` as +inf so they
+  // don't pull the min down or read uninitialized padded metadata.
   const uint32_t e_for_max = static_cast<uint32_t>(extend_len);
-  const uint32_t e_for_min = (tx < params.batch_size) ? e_for_max : 0xFFFFFFFFu;
+  const uint32_t e_for_min = (tx < params.active_bs) ? e_for_max : 0xFFFFFFFFu;
   warp_max[warp_id] = warp::reduce_max(e_for_max);
   warp_min[warp_id] = warp::reduce_min(e_for_min);
   __syncthreads();
@@ -183,6 +186,7 @@ __global__ __launch_bounds__(1024, 1)  //
     const uint32_t num_real_q = params.batch_size * E;
     for (uint32_t k = tx; k < num_real_q; k += block_size) {
       const uint32_t batch_id = k / E;
+      if (batch_id >= params.active_bs) continue;
       const uint32_t j = k % E;
       const int32_t pl = s_prefix_len[batch_id];
       const int32_t sl = s_seq_len[batch_id];
@@ -192,13 +196,15 @@ __global__ __launch_bounds__(1024, 1)  //
       if ((position + 1) % cr == 0) {
         const int32_t buffer_len = window_size - min(static_cast<int32_t>(j) + 1, window_size);
         const uint32_t out_idx = atomicAdd(&counter_c, 1u);
-        params.plan_c[out_idx] = {
-            .seq_len = static_cast<uint32_t>(position + 1),
-            .ragged_id = static_cast<uint16_t>(ragged_id),
-            .buffer_len = static_cast<uint16_t>(buffer_len),
-            .read_page_0 = -1,
-            .read_page_1 = static_cast<int32_t>(batch_id),
-        };
+        if (out_idx < num_q) {
+          params.plan_c[out_idx] = {
+              .seq_len = static_cast<uint32_t>(position + 1),
+              .ragged_id = static_cast<uint16_t>(ragged_id),
+              .buffer_len = static_cast<uint16_t>(buffer_len),
+              .read_page_0 = -1,
+              .read_page_1 = static_cast<int32_t>(batch_id),
+          };
+        }
       }
 
       const int32_t last_c_pos = (sl / cr) * cr;
@@ -207,14 +213,16 @@ __global__ __launch_bounds__(1024, 1)  //
       if (!do_write && is_overlap) do_write = (position % sps) >= (sps - cr);
       if (do_write) {
         const uint32_t out_idx = atomicAdd(&counter_w, 1u);
-        params.plan_w[out_idx] = pack_w(ragged_id, batch_id, position + 1);
+        if (out_idx < num_q) {
+          params.plan_w[out_idx] = pack_w(ragged_id, batch_id, position + 1);
+        }
       }
     }
   } else {
     // Path 2: general prefill (long extend_len). Iterate batches in an outer loop;
     // the whole block sweeps each batch's tokens in parallel.
     uint32_t base_e = 0;
-    for (uint32_t batch_id = 0; batch_id < params.batch_size; ++batch_id) {
+    for (uint32_t batch_id = 0; batch_id < params.active_bs; ++batch_id) {
       const int32_t pl = s_prefix_len[batch_id];
       const int32_t sl = s_seq_len[batch_id];
       const int32_t el = sl - pl;
@@ -227,20 +235,24 @@ __global__ __launch_bounds__(1024, 1)  //
         if ((position + 1) % cr == 0) {
           const int32_t buffer_len = window_size - min(j + 1, window_size);
           const uint32_t out_idx = atomicAdd(&counter_c, 1u);
-          params.plan_c[out_idx] = {
-              .seq_len = static_cast<uint32_t>(position + 1),
-              .ragged_id = static_cast<uint16_t>(ragged_id),
-              .buffer_len = static_cast<uint16_t>(buffer_len),
-              .read_page_0 = -1,
-              .read_page_1 = static_cast<int32_t>(batch_id),
-          };
+          if (out_idx < num_q) {
+            params.plan_c[out_idx] = {
+                .seq_len = static_cast<uint32_t>(position + 1),
+                .ragged_id = static_cast<uint16_t>(ragged_id),
+                .buffer_len = static_cast<uint16_t>(buffer_len),
+                .read_page_0 = -1,
+                .read_page_1 = static_cast<int32_t>(batch_id),
+            };
+          }
         }
 
         bool do_write = position >= first_w_pos;
         if (!do_write && is_overlap) do_write = (position % sps) >= (sps - cr);
         if (do_write) {
           const uint32_t out_idx = atomicAdd(&counter_w, 1u);
-          params.plan_w[out_idx] = pack_w(ragged_id, static_cast<uint32_t>(batch_id), position + 1);
+          if (out_idx < num_q) {
+            params.plan_w[out_idx] = pack_w(ragged_id, static_cast<uint32_t>(batch_id), position + 1);
+          }
         }
       }
       base_e += static_cast<uint32_t>(el);
@@ -249,8 +261,8 @@ __global__ __launch_bounds__(1024, 1)  //
   __syncthreads();
 
   // === Stage D: pad [counter_c, num_q) / [counter_w, num_q) with invalid ===
-  const auto total_c = counter_c;
-  const auto total_w = counter_w;
+  const auto total_c = min(counter_c, num_q);
+  const auto total_w = min(counter_w, num_q);
   for (uint32_t k = total_c + tx; k < num_q; k += block_size) {
     params.plan_c[k] = PlanC::invalid();
   }
@@ -276,8 +288,10 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
   };
 
   if (!plan_c.is_invalid()) {  // 1. in bound. 2. not masked
-    if (plan_c.buffer_len > 0) {
-      const auto batch_id = plan_c.read_page_1;
+    const auto batch_id = plan_c.read_page_1;
+    if (batch_id >= params.active_bs) {
+      params.plan_c[idx] = PlanC::invalid();
+    } else if (plan_c.buffer_len > 0) {
       const auto rid = params.rid_ptr[batch_id];
       const auto mapping = params.r2t_ptr + rid * params.stride_r2t;
       // `seq_len` should be ratio-aligned here
@@ -294,8 +308,8 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
         const auto state_loc_1 = params.f2s_ptr[raw_loc_1];
         plan_c.read_page_0 = compute_loc(state_loc_0) / params.compress_ratio;
         plan_c.read_page_1 = compute_loc(state_loc_1) / params.compress_ratio;
+        params.plan_c[idx] = plan_c;
       }
-      params.plan_c[idx] = plan_c;
     }
   } else if (idx < params.num_c_padded) {
     params.plan_c[idx] = PlanC::invalid();
@@ -462,7 +476,8 @@ inline PrefillPlan plan_compress_prefill(
     const int32_t compress_ratio,
     const int32_t swa_page_size,
     const int32_t ring_size,
-    const bool use_cuda_graph) {
+    const bool use_cuda_graph,
+    const int32_t active_bs) {
   auto B = SymbolicSize{"batch_size"};
   auto N = SymbolicSize{"num_q_tokens"};
   auto cpu_or_gpu = SymbolicDevice{};
@@ -504,7 +519,9 @@ inline PrefillPlan plan_compress_prefill(
   const auto batch_size = static_cast<uint32_t>(B.unwrap());
   constexpr auto kMaxTokens = static_cast<uint32_t>(std::numeric_limits<uint16_t>::max());
   RuntimeCheck(compress_ratio == 4 || compress_ratio == 128);
-  RuntimeCheck(batch_size <= num_q_tokens && num_q_tokens <= kMaxTokens);
+  RuntimeCheck(active_bs >= 0);
+  RuntimeCheck(static_cast<uint32_t>(active_bs) <= batch_size);
+  RuntimeCheck(static_cast<uint32_t>(active_bs) <= num_q_tokens && num_q_tokens <= kMaxTokens);
   // `swa_page_size` >= `ring_size` >= `compress_ratio`
   RuntimeCheck(swa_page_size % ring_size == 0 && ring_size % compress_ratio == 0);
 
@@ -528,6 +545,7 @@ inline PrefillPlan plan_compress_prefill(
         .seq_lens_ptr = seq_ptr,
         .extend_lens_ptr = ext_ptr,
         .batch_size = batch_size,
+        .active_bs = static_cast<uint32_t>(active_bs),
         .num_q_tokens = num_q_tokens,
         .compress_ratio = compress_ratio,
         .swa_page_size = swa_page_size,
@@ -547,6 +565,7 @@ inline PrefillPlan plan_compress_prefill(
         .num_c_padded = num_q_tokens,
         .num_w_padded = num_q_tokens,
         .num_work = num_q_tokens,
+        .active_bs = static_cast<uint32_t>(active_bs),
         .swa_page_size = swa_page_size,
         .ring_size = ring_size,
         .compress_ratio = compress_ratio,
@@ -568,7 +587,7 @@ inline PrefillPlan plan_compress_prefill(
   uint32_t counter_w = 0;
 
   const auto should_compress = [=](int32_t position) { return (position + 1) % compress_ratio == 0; };
-  for (const auto i : irange(batch_size)) {
+  for (const auto i : irange(static_cast<uint32_t>(active_bs))) {
     const int32_t seq_len = seq_ptr[i];
     const int32_t extend_len = ext_ptr[i];
     const int32_t prefix_len = seq_len - extend_len;
@@ -599,7 +618,7 @@ inline PrefillPlan plan_compress_prefill(
     }
     counter += extend_len;
   }
-  RuntimeCheck(counter == num_q_tokens);
+  RuntimeCheck(counter <= num_q_tokens);
 
   const auto copy_to_device = [stream](void* cuda_ptr, auto* host_ptr, size_t count) {
     const auto size_bytes = count * sizeof(*host_ptr);
@@ -623,6 +642,7 @@ inline PrefillPlan plan_compress_prefill(
       .num_c_padded = num_c_padded,
       .num_w_padded = num_w_padded,
       .num_work = std::max(num_c_padded, num_w_padded),
+      .active_bs = static_cast<uint32_t>(active_bs),
       .swa_page_size = swa_page_size,
       .ring_size = ring_size,
       .compress_ratio = compress_ratio,

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/fused_norm_rope_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/fused_norm_rope_v2.cuh
@@ -49,12 +49,25 @@ struct FusedNormRopeStoreParams {
   float eps;
   uint32_t compress_ratio;
   uint32_t num_tokens;
+  int32_t dcp_world_size;
+  int32_t dcp_rank;
 };
 
 enum class ForwardMode : bool {
   CompressExtend = 0,
   CompressDecode = 1,
 };
+
+SGL_DEVICE int32_t map_dcp_token_loc(
+    const int32_t loc,
+    const int32_t dcp_world_size,
+    const int32_t dcp_rank) {
+  if (loc < 0) return -1;
+  if (dcp_world_size <= 1) return loc;
+  if (loc == 0) return -1;
+  if (loc % dcp_world_size != dcp_rank) return -1;
+  return loc / dcp_world_size;
+}
 
 #define INDEXER_KERNEL __global__ __launch_bounds__(kBlockSize, 8)
 #define FLASHMLA_KERNEL __global__ __launch_bounds__(kBlockSize, 8)
@@ -98,12 +111,15 @@ INDEXER_KERNEL void fused_norm_rope_indexer(const __grid_constant__ FusedNormRop
     out_loc = params.out_loc[plan.ragged_id];
   } else if constexpr (kMode == CompressDecode) {
     const auto plan = static_cast<const PlanD*>(params.handle)[work_id];
+    if (plan.write_loc < 0 || plan.read_page_0 < 0) return;
     if (plan.seq_len % params.compress_ratio != 0) return;
     position = plan.seq_len - params.compress_ratio;
     out_loc = params.out_loc[work_id];
   } else {
     static_assert(host::dependent_false_v<DType>, "Unsupported Mode");
   }
+  out_loc = map_dcp_token_loc(out_loc, params.dcp_world_size, params.dcp_rank);
+  if (out_loc < 0) return;
   const auto freqs_cis = params.freqs_cis + position * kRopeDim;
 
   PDLWaitPrimary<kUsePDL>();
@@ -406,12 +422,15 @@ FLASHMLA_KERNEL void fused_norm_rope_flashmla(const __grid_constant__ FusedNormR
     out_loc = params.out_loc[plan.ragged_id];
   } else if constexpr (kMode == CompressDecode) {
     const auto plan = static_cast<const PlanD*>(params.handle)[work_id];
+    if (plan.write_loc < 0 || plan.read_page_0 < 0) return;
     if (plan.seq_len % params.compress_ratio != 0) return;
     position = plan.seq_len - params.compress_ratio;
     out_loc = params.out_loc[work_id];
   } else {
     static_assert(host::dependent_false_v<DType>, "Unsupported Mode");
   }
+  out_loc = map_dcp_token_loc(out_loc, params.dcp_world_size, params.dcp_rank);
+  if (out_loc < 0) return;
   const auto freqs_cis = params.freqs_cis + position * kRopeDim;
 
   PDLWaitPrimary<kUsePDL>();
@@ -537,7 +556,9 @@ struct FusedNormRopeKernel {
       const tvm::ffi::TensorView out_loc,
       const tvm::ffi::TensorView kvcache,
       const bool is_decode,
-      const uint32_t compress_ratio) {
+      const uint32_t compress_ratio,
+      const int32_t dcp_world_size,
+      const int32_t dcp_rank) {
     using namespace host;
     using enum ForwardMode;
 
@@ -579,6 +600,8 @@ struct FusedNormRopeKernel {
         RuntimeCheck(out_loc.size(0) == N.unwrap());
         break;
     }
+    RuntimeCheck(dcp_world_size >= 1);
+    RuntimeCheck(dcp_rank >= 0 && dcp_rank < dcp_world_size);
 
     const auto num_tokens = static_cast<uint32_t>(N.unwrap());
     if (num_tokens == 0) return;
@@ -592,6 +615,8 @@ struct FusedNormRopeKernel {
         .eps = eps,
         .compress_ratio = compress_ratio,
         .num_tokens = num_tokens,
+        .dcp_world_size = dcp_world_size,
+        .dcp_rank = dcp_rank,
     };
     // Indexer packs `kNumWarps` tokens per block (warp-major); FlashMLA uses
     // a whole block per token (cta-major sum-reduce over head_dim=512).

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/online_c128_mtp.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/online_c128_mtp.cuh
@@ -34,6 +34,7 @@ struct OnlineC128MTPWritePrefixParams {
   int64_t layer_bs;
   int64_t num_verify_tokens;
   int64_t state_slot_stride;
+  int64_t max_num_reqs;
 };
 
 template <typename TSeq, typename TReq>
@@ -87,6 +88,7 @@ online_c128_mtp_commit_pending_kernel(const OnlineC128MTPCommitPendingParams<TSe
   if (old_seq < 0) return;
 
   const int64_t cur_seq = static_cast<int64_t>(params.cur_seq_lens[bid]);
+  if (cur_seq < 0) return;
   const int64_t accept = clamp_accept_len(cur_seq - old_seq, params.num_verify_tokens);
   if (accept <= 0) return;
 
@@ -110,6 +112,7 @@ online_c128_mtp_write_prefix_kernel(const OnlineC128MTPWritePrefixParams<TSeq, T
 
   const int64_t seq_before = static_cast<int64_t>(params.seq_lens[bid]);
   const int64_t req_idx = static_cast<int64_t>(params.req_pool_indices[bid]);
+  if (seq_before < 0 || req_idx < 0 || req_idx >= params.max_num_reqs) return;
   const int64_t start_pos = seq_before & 127;
   const bool has_partial = seq_before > 0 && start_pos != 0;
 
@@ -207,6 +210,7 @@ struct OnlineC128MTPWritePrefixKernel {
       int64_t layer_bs,
       int64_t num_verify_tokens,
       int64_t state_slot_stride,
+      int64_t max_num_reqs,
       DLDevice device) {
     using namespace host;
 
@@ -224,6 +228,7 @@ struct OnlineC128MTPWritePrefixKernel {
         .layer_bs = layer_bs,
         .num_verify_tokens = num_verify_tokens,
         .state_slot_stride = state_slot_stride,
+        .max_num_reqs = max_num_reqs,
     };
 
     static_assert(kHeadDim == 512, "online c128 MTP write-prefix only supports head_dim=512");
@@ -241,7 +246,8 @@ struct OnlineC128MTPWritePrefixKernel {
       tvm::ffi::TensorView state,
       int64_t layer_bs,
       int64_t num_verify_tokens,
-      int64_t state_slot_stride) {
+      int64_t state_slot_stride,
+      int64_t max_num_reqs) {
     using namespace host;
 
     auto device = SymbolicDevice{};
@@ -260,6 +266,11 @@ struct OnlineC128MTPWritePrefixKernel {
     RuntimeCheck(layer_bs <= seq_lens.shape()[0], "layer_bs exceeds seq_lens rows");
     RuntimeCheck(layer_bs <= req_pool_indices.shape()[0], "layer_bs exceeds req_pool_indices rows");
     RuntimeCheck(layer_bs * num_verify_tokens <= kv_score_input.shape()[0], "kv_score_input is too small");
+    RuntimeCheck(max_num_reqs > 0, "max_num_reqs must be positive");
+    RuntimeCheck(max_num_reqs <= req_to_token.shape()[0], "max_num_reqs exceeds req_to_token rows");
+    RuntimeCheck(
+        state_slot_stride * (num_verify_tokens + 1) <= state.shape()[0],
+        "state buffer is too small for online MTP slots");
 
     launch(
         kv_score_input,
@@ -271,6 +282,7 @@ struct OnlineC128MTPWritePrefixKernel {
         layer_bs,
         num_verify_tokens,
         state_slot_stride,
+        max_num_reqs,
         device.unwrap());
   }
 };
@@ -387,6 +399,10 @@ struct OnlineC128MTPCommitPendingKernel {
     RuntimeCheck(cur_bs <= cur_seq_lens.shape()[0], "cur_bs exceeds seq_lens rows");
     RuntimeCheck(cur_bs <= cur_req_pool_indices.shape()[0], "cur_bs exceeds req rows");
     RuntimeCheck(max_num_reqs <= pending_seq_lens.shape()[0], "max_num_reqs exceeds pending rows");
+    RuntimeCheck(max_num_reqs <= req_to_token.shape()[0], "max_num_reqs exceeds req_to_token rows");
+    RuntimeCheck(
+        state_slot_stride * (num_verify_tokens + 1) <= state.shape()[0],
+        "state buffer is too small for online MTP slots");
 
     launch(
         cur_seq_lens,

--- a/python/sglang/jit_kernel/dsv4/compress.py
+++ b/python/sglang/jit_kernel/dsv4/compress.py
@@ -38,6 +38,18 @@ if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
 
+def _get_dcp_world_rank() -> tuple[int, int]:
+    try:
+        from sglang.srt.distributed.parallel_state import get_dcp_group_no_assert
+
+        group = get_dcp_group_no_assert()
+        if group is not None and group.world_size > 1:
+            return int(group.world_size), int(group.rank_in_group)
+    except Exception:
+        pass
+    return 1, 0
+
+
 @cache_once
 def _jit_compress_norm_rope_module(
     dtype: torch.dtype,
@@ -55,7 +67,7 @@ def _jit_compress_norm_rope_module(
             ("forward_fp4", f"FusedNormRopeKernel<{args}>::forward_fp4")
         )
     return load_jit(
-        make_name(f"fused_norm_rope_v2"),
+        make_name(f"fused_norm_rope_v2_dcp"),
         *args,
         cuda_files=[f"deepseek_v4/fused_norm_rope_v2.cuh"],
         cuda_wrappers=cuda_wrappers,
@@ -94,7 +106,7 @@ def _jit_compress_128_online_module(
     args = make_cpp_args(head_dim, dtype_buffer, is_arch_support_pdl())
     kernel_class = f"FlashCompress128OnlineKernel<{args}>"
     return load_jit(
-        make_name(f"compress_128_online_v2"),
+        make_name(f"compress_128_online_v2_activebs"),
         *args,
         cuda_files=["deepseek_v4/c128_online_v2.cuh"],
         cuda_wrappers=[
@@ -110,7 +122,7 @@ def _jit_compress_128_online_module(
 @cache_once
 def _jit_compress_plan_module() -> Module:
     return load_jit(
-        make_name(f"compress_plan"),
+        make_name(f"compress_plan_activebs_v4"),
         cuda_files=[f"deepseek_v4/c_plan.cuh"],
         cuda_wrappers=[
             ("plan_prefill", "plan_compress_prefill"),
@@ -222,6 +234,8 @@ class CompressorPrefillPlan(NamedTuple):
     def copy_(self, other) -> None:
         assert isinstance(other, CompressorPrefillPlan)
         assert self.compress_ratio == other.compress_ratio
+        if self.pin_buffer is not None and other.pin_buffer is not None:
+            self.pin_buffer.copy_(other.pin_buffer)
         self.plan_c.copy_(other.plan_c)
         self.plan_w.copy_(other.plan_w)
 
@@ -237,6 +251,7 @@ class CompressorPrefillPlan(NamedTuple):
         ring_size: int,
         num_q_tokens: int,
         use_cuda_graph: bool = False,
+        active_bs: Optional[int] = None,
     ) -> CompressorPrefillPlan:
         is_gpu_input = seq_lens.device.type in ["cuda", "xpu"]
         pin_buffer = torch.empty(
@@ -276,6 +291,7 @@ class CompressorPrefillPlan(NamedTuple):
             int(swa_page_size),
             int(ring_size),
             bool(use_cuda_graph),
+            int(seq_lens.shape[0] if active_bs is None else active_bs),
         )
         return CompressorPrefillPlan(
             compress_ratio,
@@ -330,6 +346,7 @@ class CompressorPrefillPlan(NamedTuple):
         num_q_tokens: int,
         use_cuda_graph: bool = False,
         state_slot_offset: int = 0,
+        active_bs: Optional[int] = None,
     ) -> CompressorPrefillPlan:
         seq_lens_cpu = seq_lens.detach().to(torch.int64).cpu()
         extend_lens_cpu = extend_lens.detach().to(torch.int64).cpu()
@@ -354,6 +371,7 @@ class CompressorPrefillPlan(NamedTuple):
             plan_w_dev,
             int(state_slot_offset),
             bool(use_cuda_graph),
+            int(seq_lens.shape[0] if active_bs is None else active_bs),
         )
         return CompressorPrefillPlan(
             128,
@@ -438,6 +456,7 @@ def compress_norm_rope_store(
             kv.dtype, kv.shape[-1], freq_cis.shape[-1], page_size, bf16_store
         )
         fn = module.forward_fp4 if use_fp4 else module.forward
+        dcp_world_size, dcp_rank = _get_dcp_world_rank()
         fn(
             kv,
             plan[1],
@@ -448,4 +467,6 @@ def compress_norm_rope_store(
             kvcache,
             plan.is_decode,
             plan.compress_ratio,
+            int(dcp_world_size),
+            int(dcp_rank),
         )

--- a/python/sglang/jit_kernel/dsv4/elementwise.py
+++ b/python/sglang/jit_kernel/dsv4/elementwise.py
@@ -66,10 +66,12 @@ def _jit_main_k_norm_rope_flashmla_module(
 
 @cache_once
 def _jit_main_q_indexer_rope_hadamard_quant_module(dtype: torch.dtype):
-    """C4 indexer Q kernel: RoPE + 128-pt Hadamard + fp8 act-quant"""
-    args = make_cpp_args(dtype, is_arch_support_pdl())
+    """C4 indexer Q kernel: RoPE + 128-pt Hadamard + fp8 act-quant."""
+    # This kernel runs in target-verify CUDA graph warmup for DSV4 MTP. PDL has
+    # shown illegal accesses there on H20, so keep this small Q path non-PDL.
+    args = make_cpp_args(dtype, False)
     return load_jit(
-        make_name("main_q_indexer_rope_hadamard_quant"),
+        make_name("main_q_indexer_rope_hadamard_quant_no_pdl"),
         *args,
         cuda_files=["deepseek_v4/main_norm_rope.cuh"],
         cuda_wrappers=[

--- a/python/sglang/jit_kernel/dsv4/online_c128_mtp.py
+++ b/python/sglang/jit_kernel/dsv4/online_c128_mtp.py
@@ -22,7 +22,7 @@ def _jit_online_c128_mtp_module(
 ) -> Module:
     args = make_cpp_args(head_dim, seq_dtype, req_dtype, dtype_buffer)
     return load_jit(
-        make_name(f"online_c128_mtp_{head_dim}"),
+        make_name(f"online_c128_mtp_bounds_{head_dim}"),
         *args,
         cuda_files=["deepseek_v4/online_c128_mtp.cuh"],
         cuda_wrappers=[
@@ -112,11 +112,12 @@ class OnlineC128MTPController:
             self.clear()
             return 0
 
+        if verify_bs is None and logical_forward_mode.is_target_verify():
+            verify_bs = req_pool_indices.shape[0]
+
         active_req_pool_indices = req_pool_indices
         active_seq_lens = seq_lens
-        if logical_forward_mode.is_target_verify():
-            if verify_bs is None:
-                verify_bs = req_pool_indices.shape[0]
+        if verify_bs is not None:
             active_req_pool_indices = req_pool_indices[:verify_bs]
             active_seq_lens = seq_lens[:verify_bs]
             if verify_bs == 0:
@@ -179,6 +180,7 @@ class OnlineC128MTPController:
             layer_bs,
             num_verify_tokens,
             state_pool.online_mtp_state_slot_offset,
+            token_to_kv_pool.get_online_c128_state_num_req_slots(),
         )
 
     def commit_pending(

--- a/python/sglang/kernels/ops/attention/dsa/index_buf_accessor.py
+++ b/python/sglang/kernels/ops/attention/dsa/index_buf_accessor.py
@@ -259,7 +259,7 @@ class SetKAndS:
         cls.triton(*args, **kwargs, buf=buf)
 
     @classmethod
-    def triton(cls, pool, buf, loc, index_k, index_k_scale):
+    def triton(cls, pool, buf, loc, index_k, index_k_scale, write_mask=None):
         loc = loc.to(torch.int64)
 
         _set_k_and_s_triton(
@@ -268,6 +268,7 @@ class SetKAndS:
             index_k=index_k,
             index_k_scale=index_k_scale,
             page_size=pool.page_size,
+            write_mask=write_mask,
         )
 
 
@@ -277,6 +278,7 @@ def _set_k_and_s_triton(
     index_k: torch.Tensor,
     index_k_scale: torch.Tensor,
     page_size: int,
+    write_mask: torch.Tensor | None = None,
 ):
     """
     :param buf: (num_pages, page_size 64 * (128B data + 4B scale)), uint8
@@ -323,6 +325,14 @@ def _set_k_and_s_triton(
     assert loc.is_contiguous()
     assert index_k.is_contiguous()
     assert index_k_scale.is_contiguous()
+    if write_mask is None:
+        write_mask = loc
+        has_write_mask = False
+    else:
+        assert write_mask.shape == loc.shape, f"{write_mask.shape=} {loc.shape=}"
+        assert write_mask.dtype == torch.bool, f"{write_mask.dtype=}"
+        assert write_mask.is_contiguous()
+        has_write_mask = True
 
     if _is_fp8_fnuz:
         buf_fp8 = buf.view(torch.float8_e4m3fnuz)
@@ -334,6 +344,7 @@ def _set_k_and_s_triton(
         buf_fp8,
         buf_fp32,
         loc,
+        write_mask,
         index_k,
         index_k_scale,
         index_k.stride(0),
@@ -341,6 +352,7 @@ def _set_k_and_s_triton(
         BUF_NUMEL_PER_PAGE=buf_numel_per_page,
         NUM_K_ELEMS_PER_TOKEN=index_head_dim,
         S_OFFSET_NBYTES_IN_PAGE=page_size * index_head_dim,
+        HAS_WRITE_MASK=has_write_mask,
     )
 
 
@@ -349,6 +361,7 @@ def _set_k_and_s_triton_kernel(
     buf_fp8_ptr,
     buf_fp32_ptr,
     loc_ptr,
+    write_mask_ptr,
     index_k_ptr,
     index_k_scale_ptr,
     index_k_ptr_stride_0,
@@ -356,8 +369,12 @@ def _set_k_and_s_triton_kernel(
     BUF_NUMEL_PER_PAGE: tl.constexpr,
     NUM_K_ELEMS_PER_TOKEN: tl.constexpr,
     S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
 ):
     token_id = tl.program_id(0)
+    if HAS_WRITE_MASK:
+        if not tl.load(write_mask_ptr + token_id):
+            return
 
     loc = tl.load(loc_ptr + token_id)
 

--- a/python/sglang/kernels/ops/attention/dsv4/index_buf_accessor.py
+++ b/python/sglang/kernels/ops/attention/dsv4/index_buf_accessor.py
@@ -33,16 +33,60 @@ class NopeFp8RopeBf16Pack:
 
 class SetKAndS:
     @classmethod
-    def execute(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
-        cls.triton(pool, buf, loc, nope_fp8_rope_bf16_pack)
+    def execute(
+        cls,
+        pool,
+        buf,
+        loc,
+        nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: torch.Tensor | None = None,
+    ):
+        cls.triton(
+            pool,
+            buf,
+            loc,
+            nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
 
     @classmethod
-    def torch(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
+    def torch(
+        cls,
+        pool,
+        buf,
+        loc,
+        nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        write_mask: torch.Tensor | None = None,
+    ):
+        if write_mask is not None:
+            nope_fp8_rope_bf16_pack = nope_fp8_rope_bf16_pack.slice_pack(write_mask)
+            loc = loc[write_mask]
         _set_k_and_s_torch(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
 
     @classmethod
-    def triton(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
-        _set_k_and_s_triton(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
+    def triton(
+        cls,
+        pool,
+        buf,
+        loc,
+        nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: torch.Tensor | None = None,
+    ):
+        _set_k_and_s_triton(
+            buf,
+            loc,
+            nope_fp8_rope_bf16_pack,
+            pool.page_size,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
 
 
 def _set_k_and_s_triton(
@@ -50,6 +94,9 @@ def _set_k_and_s_triton(
     loc: torch.Tensor,
     nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
     page_size: int,
+    dcp_world_size: int = 1,
+    dcp_rank: int = 0,
+    write_mask: torch.Tensor | None = None,
 ):
     num_pages, buf_numel_per_page = buf.shape
     (num_tokens_to_write,) = loc.shape
@@ -83,6 +130,14 @@ def _set_k_and_s_triton(
     assert k_nope.is_contiguous()
     assert k_rope.is_contiguous()
     assert scale_k_nope.is_contiguous()
+    if write_mask is None:
+        write_mask = loc
+        has_write_mask = False
+    else:
+        assert write_mask.shape == loc.shape, f"{write_mask.shape=} {loc.shape=}"
+        assert write_mask.dtype == torch.bool, f"{write_mask.dtype=}"
+        assert write_mask.is_contiguous()
+        has_write_mask = True
 
     buf_fp8 = buf.view(fp8_dtype)
     buf_bf16 = buf.view(torch.bfloat16)
@@ -96,6 +151,7 @@ def _set_k_and_s_triton(
         buf_bf16,
         buf_uint8,
         loc,
+        write_mask,
         k_nope,
         k_rope,
         scale_k_nope,
@@ -113,6 +169,9 @@ def _set_k_and_s_triton(
         BLOCK_NOPE=512,
         BLOCK_ROPE=64,
         BLOCK_SCALE=8,
+        DCP_WORLD_SIZE=dcp_world_size,
+        DCP_RANK=dcp_rank,
+        HAS_WRITE_MASK=has_write_mask,
     )
 
 
@@ -122,6 +181,7 @@ def _set_k_and_s_triton_kernel(
     buf_bf16_ptr,
     buf_uint8_ptr,
     loc_ptr,
+    write_mask_ptr,
     k_nope_ptr,
     k_rope_ptr,
     scale_k_nope_ptr,
@@ -139,9 +199,26 @@ def _set_k_and_s_triton_kernel(
     BLOCK_NOPE: tl.constexpr,
     BLOCK_ROPE: tl.constexpr,
     BLOCK_SCALE: tl.constexpr,
+    DCP_WORLD_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
 ):
     token_id = tl.program_id(0)
+    if HAS_WRITE_MASK:
+        if not tl.load(write_mask_ptr + token_id):
+            return
+
     loc = tl.load(loc_ptr + token_id)
+
+    # DCP: each rank only owns the slots whose global ``loc`` satisfies
+    # ``loc % world_size == rank``. Skip the ones that don't belong to us
+    # so this rank's local buffer keeps an interleaved (every-Nth-token)
+    # view of the full sequence. When DCP is disabled (world_size==1)
+    # the modulo is always zero and the divide is a no-op.
+    if DCP_WORLD_SIZE > 1:
+        if (loc % DCP_WORLD_SIZE) != DCP_RANK:
+            return
+        loc = loc // DCP_WORLD_SIZE
 
     nope_range = tl.arange(0, BLOCK_NOPE)
     nope_mask = nope_range < NUM_NOPE_ELEMS_PER_TOKEN

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -62,6 +62,51 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
                 server_args.speculative_eagle_topk == 1
             ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
 
+    validate_deepseek_v4_dcp(server_args)
+
+
+def validate_deepseek_v4_dcp(server_args: ServerArgs) -> None:
+    """Validate DeepSeek V4 DCP (decode context parallel) compatibility."""
+    if server_args.dcp_size <= 1:
+        return
+
+    if not envs.SGLANG_DSV4_ENABLE_DCP.get():
+        raise ValueError(
+            "DeepSeekV4 DCP (--dcp-size > 1) is gated behind "
+            "SGLANG_DSV4_ENABLE_DCP=1. Set the env var explicitly after "
+            "verifying numerical equivalence vs. dcp_size=1 on your cluster."
+        )
+
+    # DSV4 DCP reduce-scatters attention output across the attention-TP head
+    # dimension, so the DCP group must match the attention-TP group.
+    attn_tp = server_args.tp_size // max(server_args.dp_size, 1)
+    if attn_tp != server_args.dcp_size:
+        raise ValueError(
+            f"DeepSeekV4 DCP currently requires dcp_size ({server_args.dcp_size}) "
+            f"== attn_tp ({attn_tp}); configure tp/dp_size/dcp_size accordingly."
+        )
+
+    # Online c128 + DCP: untested combination; warn but allow.
+    if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+        logger.warning(
+            "DeepSeekV4 DCP + SGLANG_OPT_USE_ONLINE_COMPRESS combo is "
+            "experimental; numerical correctness has not been validated."
+        )
+
+    # HiSparse + DCP: HiSparse C4 device pool uses index translation that is
+    # not yet DCP-aware in the fused C++ kernels; only the Triton fallback
+    # write path supports DCP.
+    if server_args.enable_hisparse:
+        logger.warning(
+            "DeepSeekV4 DCP + enable_hisparse falls back to Triton write "
+            "path for KV writes; expect throughput regression vs. fused C++."
+        )
+
+    logger.info(
+        f"DeepSeekV4 DCP enabled: dcp_size={server_args.dcp_size}, "
+        f"attn_tp={attn_tp}"
+    )
+
 
 def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
     """Validate DeepSeek V4 context-parallel configuration."""

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1747,7 +1747,7 @@ def get_attn_tp_group() -> GroupCoordinator:
 def get_attn_cp_group() -> GroupCoordinator:
     assert (
         _ATTN_CP is not None
-    ), "attention context model parallel group is not initialized"
+    ), "attention context parallel group is not initialized"
     return _ATTN_CP
 
 
@@ -2397,7 +2397,6 @@ def initialize_model_parallel(
         max_world_size=max_world_size,
     )
 
-
 def create_custom_parallel_group(
     group_ranks: List[int], backend: str = "gloo"
 ) -> Optional[torch.distributed.ProcessGroup]:
@@ -2535,17 +2534,20 @@ def get_tensor_model_parallel_world_size():
     return get_tp_group().world_size
 
 
-def get_dcp_world_size():
-    return get_dcp_group().world_size
-
-
-def get_dcp_rank():
-    return get_dcp_group().rank_in_group
-
-
 def get_tensor_model_parallel_rank():
     """Return my rank for the tensor model parallel group."""
     return get_tp_group().rank_in_group
+
+
+# DCP helpers (return 1 / 0 when DCP is not enabled)
+def get_dcp_world_size() -> int:
+    """Return world size for the decode context parallel group, or 1 when off."""
+    return _DCP.world_size if _DCP is not None else 1
+
+
+def get_dcp_rank() -> int:
+    """Return my rank for the decode context parallel group, or 0 when off."""
+    return _DCP.rank_in_group if _DCP is not None else 0
 
 
 # ATTN_TP
@@ -2660,7 +2662,6 @@ def destroy_model_parallel():
     if _PDMUX_PREFILL_TP_GROUP:  # type: ignore[union-attr]
         _PDMUX_PREFILL_TP_GROUP.destroy()
     _PDMUX_PREFILL_TP_GROUP = None
-
 
 def destroy_distributed_environment():
     global _WORLD, _MODEL_PARALLEL_GROUP_TIMEOUT

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -907,6 +907,11 @@ class Envs:
     # Set False when using FP4-to-FP8 converted DeepSeek V4 checkpoint.
     SGLANG_DSV4_FP4_EXPERTS = EnvBool(True)
     SGLANG_DSV4_FP4_DEQUANT = EnvBool(False)
+    # Master gate for DeepSeek V4 Decode Context Parallel (DCP). When False
+    # (default), DSv4 hook rejects --dcp-size > 1 with a clear error so users
+    # cannot enable an unvalidated combination by accident. Flip to 1 once
+    # numerical-equivalence regression has been verified on the target cluster.
+    SGLANG_DSV4_ENABLE_DCP = EnvBool(False)
     # Default reasoning_effort for dsv4 chat encoder when request doesn't set it.
     # Accepts "", "max", "high" (empty string means unset); other values filtered to None.
     SGLANG_DSV4_REASONING_EFFORT = EnvStr("")

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -138,6 +138,10 @@ class AttentionBackend(ABC):
         """
         pass
 
+    def on_after_cuda_graph_capture(self):
+        """Hook immediately after a CUDA graph capture finishes."""
+        pass
+
     def get_verify_buffers_to_fill_after_draft(self):
         """
         Return buffers of verify attention kernels that needs to be filled after draft.

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -33,6 +33,11 @@ from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
     BuildPageTablePositions,
     ExpandPrefillCausally,
 )
+from sglang.srt.distributed.parallel_state import (
+    get_dcp_group,
+    get_dcp_rank,
+    get_dcp_world_size,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.dsv4.compressor_v2 import (
@@ -51,6 +56,7 @@ from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
     SparsePrefillChunkCache,
     SparsePrefillWorkspace,
 )
+from sglang.srt.layers.attention.utils import cp_lse_ag_out_rs
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_parallel
@@ -87,6 +93,17 @@ logger = logging.getLogger(__name__)
 SWA_WINDOW = 128
 C4_TOPK = 512
 PAGE_INDEX_ALIGNED_SIZE = 64
+
+
+def _expand_dcp_local_kv_mask(mask: torch.Tensor, target_len: int) -> torch.Tensor:
+    mask = mask.reshape(-1)
+    if mask.numel() == target_len:
+        return mask
+    if mask.numel() == 0:
+        return torch.zeros(target_len, device=mask.device, dtype=torch.bool)
+    if mask.numel() < target_len:
+        return F.pad(mask, (0, target_len - mask.numel()), value=False)
+    return mask[:target_len]
 
 
 def _get_logical_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
@@ -179,6 +196,9 @@ class DSV4AttnMetadata:
     c128_out_loc: Optional[torch.Tensor] = None
     c128_page_indices: Optional[torch.Tensor] = None
     c128_topk_lengths_clamp1: Optional[torch.Tensor] = None
+    dcp_swa_has_local_kv: Optional[torch.Tensor] = None
+    dcp_c128_has_local_kv: Optional[torch.Tensor] = None
+    dcp_has_local_kv: Optional[torch.Tensor] = None
 
     c1_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
     c4_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
@@ -223,6 +243,9 @@ class DSV4AttnMetadata:
                 "c4_sparse_topk_lengths",
                 "c4_sparse_page_indices",
                 "c4_sparse_raw_indices",
+                "dcp_swa_has_local_kv",
+                "dcp_c128_has_local_kv",
+                "dcp_has_local_kv",
             ],
             assign_fields=[
                 # Recomputed by the recorded init_forward_metadata_in_graph op
@@ -248,6 +271,9 @@ class DSV4AttnMetadata:
             "c4_topk_lengths_raw",
             "c4_topk_lengths_clamp1",
             "c4_sparse_topk_lengths",
+            "dcp_swa_has_local_kv",
+            "dcp_c128_has_local_kv",
+            "dcp_has_local_kv",
         ]
         reference_assign_fields = [
             "page_table",
@@ -300,8 +326,74 @@ class DSV4AttnMetadata:
             compute_page_indices=True,
         )
 
+        self.apply_dcp_local_kv_indices()
         self.c128_page_indices = _pad_last_dim(self.c128_page_indices)
         self.swa_page_indices = _pad_last_dim(self.swa_page_indices)
+
+    @staticmethod
+    def _compact_dcp_local_indices(
+        indices: torch.Tensor,
+        dcp_world_size: int,
+        dcp_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        valid_mask = indices >= 0
+        local_mask = valid_mask & ((indices % dcp_world_size) == dcp_rank)
+        physical_indices = torch.where(
+            local_mask, indices // dcp_world_size, torch.full_like(indices, -1)
+        )
+
+        col = torch.arange(indices.shape[-1], device=indices.device).view(
+            *([1] * (indices.dim() - 1)), -1
+        )
+        order_key = torch.where(local_mask, col, col + indices.shape[-1])
+        order = torch.argsort(order_key, dim=-1)
+        compacted = torch.gather(physical_indices, dim=-1, index=order)
+
+        local_lengths = local_mask.sum(dim=-1).to(torch.int32)
+        compact_mask = col < local_lengths.unsqueeze(-1)
+        compacted = torch.where(
+            compact_mask, compacted, torch.full_like(compacted, -1)
+        )
+        # Keep empty-row indices at -1 so FlashMLA masks them out, but avoid
+        # passing topk_length=0 to the graph-captured scheduler path. A dummy
+        # ``index=0`` would pollute rows where SWA is empty but an extra source
+        # is present; ``length=1,index=-1`` preserves the "no local KV" signal.
+        return compacted.to(torch.int32), local_lengths
+
+    def apply_dcp_local_kv_indices(self) -> None:
+        dcp_world_size = get_dcp_world_size()
+        if dcp_world_size == 1 or self.dcp_swa_has_local_kv is not None:
+            return
+
+        dcp_rank = get_dcp_rank()
+        self.swa_page_indices, swa_local_lengths = (
+            self._compact_dcp_local_indices(
+                self.swa_page_indices, dcp_world_size, dcp_rank,
+            )
+        )
+        self.dcp_swa_has_local_kv = swa_local_lengths > 0
+        self.swa_topk_lengths = torch.clamp(swa_local_lengths, min=1)
+        if self.c128_page_indices is not None:
+            self.c128_page_indices, c128_local_lengths = (
+                self._compact_dcp_local_indices(
+                    self.c128_page_indices, dcp_world_size, dcp_rank,
+                )
+            )
+            self.dcp_c128_has_local_kv = c128_local_lengths > 0
+            # Extra KV sources may be empty while SWA still has local KV for
+            # this row. Clamp only the length; empty rows retain index -1, so
+            # FlashMLA masks them instead of attending to a dummy KV.
+            self.c128_topk_lengths_clamp1 = torch.clamp(c128_local_lengths, min=1)
+        # Backward-compatible alias for existing metadata copy/replay paths.
+        # Forward must use the compress-ratio-specific mask below instead.
+        self.dcp_has_local_kv = self.dcp_swa_has_local_kv
+
+    def get_dcp_has_local_kv(self, compress_ratio: Literal[0, 4, 128]):
+        if self.dcp_swa_has_local_kv is None:
+            return self.dcp_has_local_kv
+        if compress_ratio == 128 and self.dcp_c128_has_local_kv is not None:
+            return self.dcp_swa_has_local_kv | self.dcp_c128_has_local_kv
+        return self.dcp_swa_has_local_kv
 
     _CP_REINDEX_FIELDS = [
         "seq_lens_casual",
@@ -313,6 +405,9 @@ class DSV4AttnMetadata:
         "c4_topk_lengths_clamp1",
         "c128_page_indices",
         "c128_topk_lengths_clamp1",
+        "dcp_swa_has_local_kv",
+        "dcp_c128_has_local_kv",
+        "dcp_has_local_kv",
     ]
     _CP_GLOBAL_FIELDS = [
         "raw_out_loc",
@@ -333,13 +428,17 @@ class DSV4AttnMetadata:
         expected_local_len = pre_global_len // cp_size
         for field_name in self._CP_REINDEX_FIELDS:
             val = getattr(self, field_name, None)
+            if val is None:
+                continue
             assert isinstance(
                 val, torch.Tensor
             ), f"CP reindex: {field_name} is {type(val)}, expected Tensor"
             setattr(self, field_name, val[idx].contiguous())
 
         for field_name in self._CP_REINDEX_FIELDS:
-            val = getattr(self, field_name)
+            val = getattr(self, field_name, None)
+            if val is None:
+                continue
             assert val.shape[0] == expected_local_len, (
                 f"apply_cp_reindex post-condition: {field_name}.shape[0]={val.shape[0]} "
                 f"!= expected_local_len={expected_local_len} (cp_size={cp_size})"
@@ -432,6 +531,7 @@ class DSV4RawVerifyMetadata:
 
     extend_seq_lens: Optional[torch.Tensor] = None
     seq_lens_cpu: Optional[List[int]] = None
+    active_bs: Optional[int] = None
     c128_compress_metadata: Optional[FusedCompressMetadata] = None
 
     extend_start_loc: Optional[torch.Tensor] = None
@@ -445,6 +545,7 @@ class DSV4RawVerifyMetadata:
 
         self.extend_seq_lens = other.extend_seq_lens
         self.seq_lens_cpu = other.seq_lens_cpu
+        self.active_bs = other.active_bs
         self.c128_compress_metadata = _copy_or_replace(
             self.c128_compress_metadata, other.c128_compress_metadata
         )
@@ -556,6 +657,13 @@ class DeepseekV4AttnBackend(
             DSV4RawVerifyMetadata,
             DSV4RawDecodeMetadata,
         ] = None
+        self._current_capture_raw: Optional[
+            Union[DSV4RawVerifyMetadata, DSV4RawDecodeMetadata]
+        ] = None
+        self._current_capture_bucket_bs: Optional[Tuple[_GraphBucket, int]] = None
+        self._cuda_graph_captured_full_metadata: Dict[
+            _GraphBucket, Dict[int, DSV4Metadata]
+        ] = {bucket: {} for bucket in _GraphBucket}
         self.online_c128_mtp = OnlineC128MTPController(self)
         self.sparse_prefill_workspace = SparsePrefillWorkspace(self.device)
         spec_alg = model_runner.spec_algorithm
@@ -618,6 +726,7 @@ class DeepseekV4AttnBackend(
         extend_seq_lens: torch.Tensor,
         use_prefill_cuda_graph: bool,
         online_c128_state_slot_offset: int,
+        online_c128_active_bs: Optional[int] = None,
     ) -> Optional[FusedCompressMetadata]:
         if not self.online_c128_mtp.enabled():
             return None
@@ -638,6 +747,7 @@ class DeepseekV4AttnBackend(
             extend_lens_cpu=extend_lens_cpu,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
             online_state_slot_offset=online_c128_state_slot_offset,
+            online_active_bs=online_c128_active_bs,
         )
 
     def init_forward_metadata_indexer(
@@ -801,6 +911,7 @@ class DeepseekV4AttnBackend(
         use_prefill_cuda_graph: bool = False,
         online_c128_state_slot_offset: int = 0,
         ragged_layout: Optional[RaggedVerifyLayout] = None,
+        online_c128_active_bs: Optional[int] = None,
     ) -> Union[DSV4Metadata, DSV4RawVerifyMetadata]:
         if envs.SGLANG_PREP_IN_CUDA_GRAPH.get():
             assert out_cache_loc is not None
@@ -832,6 +943,7 @@ class DeepseekV4AttnBackend(
                 out_cache_loc=out_cache_loc,
                 extend_seq_lens=extend_seq_lens,
                 seq_lens_cpu=seq_lens_cpu_list,
+                active_bs=online_c128_active_bs,
                 c128_compress_metadata=self._make_target_verify_c128_metadata(
                     req_pool_indices,
                     seq_lens,
@@ -839,6 +951,7 @@ class DeepseekV4AttnBackend(
                     extend_seq_lens,
                     use_prefill_cuda_graph,
                     online_c128_state_slot_offset,
+                    online_c128_active_bs,
                 ),
                 extend_start_loc=extend_start_loc,
                 verify_lens=verify_lens,
@@ -977,6 +1090,7 @@ class DeepseekV4AttnBackend(
                     qo_len=num_draft_tokens,
                     seq_lens=seq_lens,
                     req_pool_indices=req_pool_indices,
+                    padded_num_tokens=out_cache_loc.shape[0],
                 )
             )
         core_attn_metadata = self.make_core_attn_metadata(
@@ -1001,6 +1115,7 @@ class DeepseekV4AttnBackend(
             use_prefill_cuda_graph=True,
             num_q_tokens=num_q_tokens,
             online_state_slot_offset=online_c128_state_slot_offset,
+            online_active_bs=raw_metadata.active_bs,
         )
         c128_compress_metadata = raw_metadata.c128_compress_metadata
         if c128_compress_metadata is None:
@@ -1095,6 +1210,18 @@ class DeepseekV4AttnBackend(
             self.forward_metadata = self.make_forward_metadata_from_raw_decode(
                 raw_metadata=self.forward_metadata,
             )
+
+        # Keep the full metadata object whose tensor addresses are captured by
+        # the graph. Replay-side preparation updates this object in place; the
+        # raw metadata retained by the out-of-graph path is only an input to the
+        # conversion above and is not read by the captured kernels directly.
+        if (
+            torch.cuda.is_current_stream_capturing()
+            and self._current_capture_bucket_bs is not None
+            and isinstance(self.forward_metadata, DSV4Metadata)
+        ):
+            bucket, bs = self._current_capture_bucket_bs
+            self._cuda_graph_captured_full_metadata[bucket][bs] = self.forward_metadata
 
         # Compute the SWA KV-store write target once per forward and cache it on
         # the metadata for every layer's store. This is recorded inside the cuda
@@ -1217,10 +1344,15 @@ class DeepseekV4AttnBackend(
         if bucket == _GraphBucket.DECODE_OR_IDLE:
             assert out_cache_loc is not None
             assert len(out_cache_loc.shape) == 1, f"{out_cache_loc.shape=}"
+            assert len(out_cache_loc) <= bs, (
+                f"decode replay out_cache_loc is longer than graph batch: "
+                f"{len(out_cache_loc)=}, {bs=}"
+            )
             self.online_c128_mtp.prepare_forward(
                 actual_forward_mode,
                 req_pool_indices,
                 seq_lens,
+                verify_bs=_get_target_verify_bs(forward_batch),
             )
             out_cache_loc_padded = torch.nn.functional.pad(
                 out_cache_loc,
@@ -1297,12 +1429,14 @@ class DeepseekV4AttnBackend(
                 use_prefill_cuda_graph=True,
                 online_c128_state_slot_offset=online_c128_state_slot_offset,
                 ragged_layout=ragged_layout,
+                online_c128_active_bs=verify_bs,
             )
         elif bucket == _GraphBucket.DRAFT_EXTEND:
             self.online_c128_mtp.prepare_forward(
                 actual_forward_mode,
                 req_pool_indices,
                 seq_lens,
+                verify_bs=_get_target_verify_bs(forward_batch),
             )
             num_tokens_per_req = self.draft_extend_num_tokens_per_req
             if out_cache_loc is not None:
@@ -1331,6 +1465,7 @@ class DeepseekV4AttnBackend(
         if in_capture:
             # Preserve _current_capture_raw for on_after_cuda_graph_warmup
             metadata = self.forward_metadata
+            self._current_capture_bucket_bs = (bucket, bs)
             self._current_capture_raw = (
                 metadata
                 if isinstance(
@@ -1532,6 +1667,26 @@ class DeepseekV4AttnBackend(
             self.forward_metadata = temp_metadata
             return
         chosen_metadata.copy_(temp_metadata)
+        captured_full_metadata = self._cuda_graph_captured_full_metadata[bucket].get(
+            bs
+        )
+        if captured_full_metadata is not None:
+            if isinstance(temp_metadata, DSV4Metadata):
+                temp_full_metadata = temp_metadata
+            elif isinstance(temp_metadata, DSV4RawVerifyMetadata):
+                temp_full_metadata = self.make_forward_metadata_from_raw_verify(
+                    raw_metadata=temp_metadata,
+                    online_c128_state_slot_offset=(
+                        self.online_c128_mtp.state_slot_offset()
+                    ),
+                )
+            elif isinstance(temp_metadata, DSV4RawDecodeMetadata):
+                temp_full_metadata = self.make_forward_metadata_from_raw_decode(
+                    raw_metadata=temp_metadata,
+                )
+            else:
+                raise TypeError(f"unexpected {type(temp_metadata)=}")
+            captured_full_metadata.copy_(temp_full_metadata)
         self.forward_metadata = chosen_metadata
 
     def get_cuda_graph_seq_len_fill_value(self):
@@ -1588,6 +1743,8 @@ class DeepseekV4AttnBackend(
                 layer_id=layer_id,
                 swa_loc=swa_loc,
                 cache_k=swa_k,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
+                raw_loc=forward_batch.out_cache_loc,
             )
         else:
             swa_k_pack = quant_to_nope_fp8_rope_bf16_pack_triton(swa_k)
@@ -1595,6 +1752,8 @@ class DeepseekV4AttnBackend(
                 layer_id=layer_id,
                 swa_loc=swa_loc,
                 cache_nope_fp8_rope_bf16_pack=swa_k_pack,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
+                raw_loc=forward_batch.out_cache_loc,
             )
 
     def forward(
@@ -1666,10 +1825,32 @@ class DeepseekV4AttnBackend(
                     return x[: q.shape[0]]
                 return _pad_tensor_to_size(x, q.shape[0], value=value)
 
-            swa_page_indices = match_num_queries(swa_page_indices, value=0)
+            # If query rows outgrow the metadata rows (for example padded
+            # target-verify buckets), pad with FlashMLA's empty-row sentinel.
+            # SWA slot 0 is a valid local cache slot under DCP, so using 0 here
+            # would make synthetic rows attend to unrelated KV.
+            swa_page_indices = match_num_queries(swa_page_indices, value=-1)
             swa_topk_lengths = match_num_queries(swa_topk_lengths, value=1)
             extra_indices = match_num_queries(extra_indices, value=-1)
             extra_topk_lengths = match_num_queries(extra_topk_lengths, value=1)
+
+            c4_has_local_kv = None
+            if (
+                get_dcp_world_size() > 1
+                and compress_ratio == 4
+                and extra_indices is not None
+            ):
+                dcp_world_size = get_dcp_world_size()
+                dcp_rank = get_dcp_rank()
+                extra_indices, c4_local_lengths = (
+                    core_attn_metadata._compact_dcp_local_indices(
+                        extra_indices, dcp_world_size, dcp_rank
+                    )
+                )
+                # Same rule as C128: avoid topk_length=0 in FlashMLA while
+                # keeping empty-row indices at -1 so no dummy KV is attended.
+                extra_topk_lengths = torch.clamp(c4_local_lengths, min=1)
+                c4_has_local_kv = c4_local_lengths > 0
 
             if q.ndim == 3:
                 q = q.unsqueeze(1)
@@ -1679,7 +1860,6 @@ class DeepseekV4AttnBackend(
                 extra_indices = extra_indices.unsqueeze(1)
 
             assert attn_sink is not None
-
             flashmla_metadata = core_attn_metadata.get_flashmla_metadata(compress_ratio)
 
             assert (
@@ -1714,7 +1894,7 @@ class DeepseekV4AttnBackend(
                     flash_mla_with_kvcache_sm120,
                 )
 
-                o = flash_mla_with_kvcache_sm120(
+                flashmla_ret = flash_mla_with_kvcache_sm120(
                     q=q,
                     k_cache=swa_k_cache,
                     head_dim_v=self.head_dim_v,
@@ -1725,14 +1905,14 @@ class DeepseekV4AttnBackend(
                     extra_k_cache=extra_k_cache,
                     extra_indices_in_kvcache=extra_indices,
                     extra_topk_length=extra_topk_lengths,
-                )[0]
+                )
             else:
                 if _is_xpu:
                     from sgl_kernel import flash_mla_with_kvcache
                 else:
                     from sgl_kernel.flash_mla import flash_mla_with_kvcache
 
-                o = flash_mla_with_kvcache(
+                flashmla_ret = flash_mla_with_kvcache(
                     q=q,
                     k_cache=swa_k_cache,
                     head_dim_v=self.head_dim_v,
@@ -1747,9 +1927,63 @@ class DeepseekV4AttnBackend(
                     extra_k_cache=extra_k_cache,
                     extra_indices_in_kvcache=extra_indices,
                     extra_topk_length=extra_topk_lengths,
-                )[0]
+                )
 
-            o = o.squeeze(1)
+            o = flashmla_ret[0].squeeze(1)
+            dcp_has_local_kv = None
+            if get_dcp_world_size() > 1:
+                o_dtype = o.dtype
+                lse = flashmla_ret[1]
+                if lse.dim() == 3 and lse.shape[0] == 1:
+                    lse = lse.squeeze(0)
+                elif lse.dim() == 3 and lse.shape[1] == 1:
+                    lse = lse.squeeze(1)
+                elif lse.dim() == 3 and lse.shape[-1] == 1:
+                    lse = lse.squeeze(-1)
+                if lse.dim() > 2:
+                    token_dim = 0
+                    if lse.shape[0] != o.shape[0]:
+                        for dim, size in enumerate(lse.shape):
+                            if size == o.shape[0]:
+                                token_dim = dim
+                                break
+                    if token_dim != 0:
+                        lse = lse.movedim(token_dim, 0).contiguous()
+                    lse = lse.reshape(lse.shape[0], -1)
+                if (
+                    lse.dim() == 2
+                    and lse.shape[0] != o.shape[0]
+                    and lse.shape[1] == o.shape[0]
+                ):
+                    lse = lse.transpose(0, 1).contiguous()
+                if lse.dim() != 2 or lse.shape[:2] != o.shape[:2]:
+                    raise RuntimeError(
+                        "Unexpected FlashMLA output/LSE shapes for DCP merge: "
+                        f"output={tuple(o.shape)}, lse={tuple(lse.shape)}"
+                    )
+                dcp_has_local_kv = core_attn_metadata.get_dcp_has_local_kv(
+                    compress_ratio
+                )
+                if compress_ratio == 4 and c4_has_local_kv is not None:
+                    dcp_has_local_kv = dcp_has_local_kv | c4_has_local_kv
+                if get_dcp_rank() != 0 and dcp_has_local_kv is not None:
+                    token_len = o.shape[0]
+                    dcp_has_local_kv = _expand_dcp_local_kv_mask(
+                        dcp_has_local_kv, token_len
+                    )
+                    no_local_kv = ~dcp_has_local_kv
+                    lse = torch.where(
+                        no_local_kv[:, None],
+                        torch.full_like(lse, torch.finfo(lse.dtype).min),
+                        lse,
+                    )
+                    o = torch.where(
+                        no_local_kv[:, None, None],
+                        torch.zeros_like(o),
+                        o,
+                    )
+                o = cp_lse_ag_out_rs(o, lse, get_dcp_group()).to(o_dtype)
+
             return o
 
         raise NotImplementedError("ragged attention")
@@ -1913,6 +2147,7 @@ class DeepseekV4AttnBackend(
         qo_len: int,
         seq_lens: torch.Tensor,
         req_pool_indices: torch.Tensor,
+        padded_num_tokens: Optional[int] = None,
     ):
         seq_lens_casual = seq_lens[:, None] + torch.arange(
             -qo_len + 1, 1, **self.cuda_int32_kwargs
@@ -1922,6 +2157,19 @@ class DeepseekV4AttnBackend(
             bs, **self.cuda_int32_kwargs
         ).repeat_interleave(qo_len)
         req_pool_indices_repeated = req_pool_indices[idx_to_req_repeated]
+        num_tokens = seq_lens_casual.shape[0]
+        if padded_num_tokens is not None and padded_num_tokens > num_tokens:
+            pad_size = padded_num_tokens - num_tokens
+            seq_lens_casual = torch.nn.functional.pad(
+                seq_lens_casual,
+                (0, pad_size),
+                value=1,
+            )
+            req_pool_indices_repeated = torch.nn.functional.pad(
+                req_pool_indices_repeated,
+                (0, pad_size),
+                value=req_pool_indices_repeated[-1].item(),
+            )
         return seq_lens_casual, req_pool_indices_repeated
 
     def make_core_attn_metadata(
@@ -1993,6 +2241,7 @@ class DeepseekV4AttnBackend(
             core_attn_metadata.init_compression_metadata()
             core_attn_metadata.init_flashmla_related(is_prefill=is_prefill)
         else:
+            core_attn_metadata.apply_dcp_local_kv_indices()
             core_attn_metadata.c4_sparse_topk_lengths = None
             core_attn_metadata.c4_sparse_page_indices = None
             core_attn_metadata.c4_sparse_raw_indices = None
@@ -2087,14 +2336,16 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
         else:
             if self.speculative_num_steps == 1:
                 return
-            self.attn_backends[0].init_forward_metadata_out_graph(inner_fb)
-            temp_metadata = self.attn_backends[0].forward_metadata
-            for i in range(1, self.speculative_num_steps - 1):
-                self.attn_backends[i].replay_cuda_graph_metadata_from(
-                    bs=forward_batch.batch_size,
-                    temp_metadata=temp_metadata,
-                    bucket=_GraphBucket.DECODE_OR_IDLE,
-                )
+            per_step_out_cache_loc = per_step_draft_out_cache_loc(
+                inner_fb.out_cache_loc,
+                inner_fb.batch_size,
+                self.topk,
+                self.speculative_num_steps,
+            )
+            for i in range(self.speculative_num_steps - 1):
+                step_fb = SimpleNamespace(**vars(inner_fb))
+                step_fb.out_cache_loc = per_step_out_cache_loc[i]
+                self.attn_backends[i].init_forward_metadata_out_graph(step_fb)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         for i in range(self.speculative_num_steps - 1):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -1375,6 +1375,8 @@ class DeepseekV4HipRadixBackend(
                 layer_id=layer_id,
                 swa_loc=swa_loc,
                 cache_k=swa_k,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
+                raw_loc=forward_batch.out_cache_loc,
             )
         else:
             swa_k_pack = quant_to_nope_fp8_rope_bf16_pack_triton(swa_k)
@@ -1382,6 +1384,8 @@ class DeepseekV4HipRadixBackend(
                 layer_id=layer_id,
                 swa_loc=swa_loc,
                 cache_nope_fp8_rope_bf16_pack=swa_k_pack,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
+                raw_loc=forward_batch.out_cache_loc,
             )
 
     def forward(

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from sglang.srt.layers.rotary_embedding import RotaryEmbedding
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
-
 class FusedCompressMetadata(NamedTuple):
     write_loc: torch.Tensor
     extra_data: Optional[torch.Tensor]
@@ -183,10 +182,13 @@ class CompressorBackendMixin:
                 layer_id=layer_id,
                 loc=out_loc,
                 cache_k=new_compressed_kv,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
             )
         else:
             pack = quant_to_nope_fp8_rope_bf16_pack_triton(new_compressed_kv.bfloat16())
-            token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc, pack)
+            token_to_kv_pool.set_extra_key_buffer(
+                layer_id, out_loc, pack, dcp_kv_mask=forward_batch.dcp_kv_mask
+            )
 
     def forward_indexer_compressor(
         self,
@@ -215,6 +217,7 @@ class CompressorBackendMixin:
                 layer_id=layer_id,
                 loc=out_loc,
                 cache_k=new_compressed_kv,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
             )
         else:
             new_compressed_kv_fp8, new_compressed_kv_scale = act_quant(
@@ -225,6 +228,7 @@ class CompressorBackendMixin:
                 loc=out_loc,
                 index_k=new_compressed_kv_fp8,
                 index_k_scale=new_compressed_kv_scale,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
             )
 
 

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -20,13 +20,291 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
-
 CompressMetadata: TypeAlias = Union[CompressorDecodePlan, CompressorPrefillPlan]
 # NOTE: alias for backward compatibility
 FusedCompressMetadata: TypeAlias = CompressMetadata
 
 _is_hip = is_hip_runtime()
 
+def _dcp_write_enabled() -> bool:
+    from sglang.srt.distributed.parallel_state import get_dcp_group_no_assert
+
+    group = get_dcp_group_no_assert()
+    return group is not None and group.world_size > 1
+
+
+if _is_hip:
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _c128_compress_decode_kernel(
+        buf_ptr,
+        input_ptr,
+        ape_ptr,
+        out_ptr,
+        plan_ptr,
+        buf_stride_slot,
+        input_stride_b,
+        ape_stride_r,
+        out_stride_b,
+        bs,
+        HEAD_DIM: tl.constexpr,
+        BLOCK_D: tl.constexpr,
+        COMPRESS_RATIO: tl.constexpr,
+    ):
+        """Fused C128 decode: write to state buffer + online softmax-pool.
+
+        plan_ptr points to int32 view: [bs, 4] where each row is
+        {seq_len, write_loc, read_page_0, read_page_1}.
+        """
+        bid = tl.program_id(0)
+        if bid >= bs:
+            return
+
+        # Parse plan
+        plan_base = plan_ptr + bid * 4
+        seq_len = tl.load(plan_base).to(tl.int32)
+        write_loc = tl.load(plan_base + 1).to(tl.int32)
+        read_page_0 = tl.load(plan_base + 2).to(tl.int32)
+
+        d = tl.arange(0, BLOCK_D)
+        last_dim: tl.constexpr = HEAD_DIM * 2
+
+        # Step 1: Write kv_score_input to state buffer at write_loc
+        d_mask_full = d < last_dim
+        input_val = tl.load(
+            input_ptr + bid * input_stride_b + d, mask=d_mask_full, other=0.0
+        )
+        tl.store(buf_ptr + write_loc * buf_stride_slot + d, input_val, mask=d_mask_full)
+
+        # Step 2: Check boundary condition
+        d_mask_hd = d < HEAD_DIM
+        if seq_len % COMPRESS_RATIO != 0:
+            tl.store(
+                out_ptr + bid * out_stride_b + d,
+                tl.zeros([BLOCK_D], tl.float32),
+                mask=d_mask_hd,
+            )
+            return
+
+        # Step 3: Online softmax-pool over 128 slots in the page
+        page_base = read_page_0 * COMPRESS_RATIO * buf_stride_slot
+        m_prev = tl.full([BLOCK_D], float("-inf"), tl.float32)
+        kv_acc = tl.zeros([BLOCK_D], tl.float32)
+        w_acc = tl.zeros([BLOCK_D], tl.float32)
+
+        for k in tl.static_range(COMPRESS_RATIO):
+            slot_addr = page_base + k * buf_stride_slot
+            kv_val = tl.load(buf_ptr + slot_addr + d, mask=d_mask_hd, other=0.0).to(
+                tl.float32
+            )
+            sc_val = tl.load(
+                buf_ptr + slot_addr + HEAD_DIM + d, mask=d_mask_hd, other=0.0
+            ).to(tl.float32)
+            ape_val = tl.load(
+                ape_ptr + k * ape_stride_r + d, mask=d_mask_hd, other=0.0
+            ).to(tl.float32)
+            score_k = sc_val + ape_val
+
+            m_new = tl.maximum(m_prev, score_k)
+            exp_old = tl.where(m_prev == float("-inf"), 0.0, tl.exp(m_prev - m_new))
+            exp_cur = tl.where(score_k == float("-inf"), 0.0, tl.exp(score_k - m_new))
+            kv_acc = kv_acc * exp_old + exp_cur * kv_val
+            w_acc = w_acc * exp_old + exp_cur
+            m_prev = m_new
+
+        compressed = kv_acc / w_acc
+        tl.store(out_ptr + bid * out_stride_b + d, compressed, mask=d_mask_hd)
+
+    @triton.jit
+    def _c128_compress_prefill_write_kernel(
+        buf_ptr,
+        input_ptr,
+        plan_w_ptr,
+        buf_stride_slot,
+        input_stride_b,
+        num_w,
+        BLOCK_D: tl.constexpr,
+        LAST_DIM: tl.constexpr,
+    ):
+        """Prefill write phase: scatter kv_score_input tokens into state buffer."""
+        wid = tl.program_id(0)
+        if wid >= num_w:
+            return
+
+        # WritePlan: {ragged_id(u32), write_loc(i32)} = 8 bytes = 2 int32s
+        plan_base = plan_w_ptr + wid * 2
+        ragged_id = (tl.load(plan_base).to(tl.int32)) & 0xFFFF
+        write_loc = tl.load(plan_base + 1).to(tl.int32)
+
+        d = tl.arange(0, BLOCK_D)
+        d_mask = d < LAST_DIM
+
+        if write_loc >= 0:
+            input_val = tl.load(
+                input_ptr + ragged_id * input_stride_b + d, mask=d_mask, other=0.0
+            )
+            tl.store(buf_ptr + write_loc * buf_stride_slot + d, input_val, mask=d_mask)
+
+    @triton.jit
+    def _c128_compress_prefill_compress_kernel(
+        buf_ptr,
+        ape_ptr,
+        out_ptr,
+        plan_c_ptr,
+        buf_stride_slot,
+        ape_stride_r,
+        out_stride_b,
+        num_c,
+        HEAD_DIM: tl.constexpr,
+        BLOCK_D: tl.constexpr,
+        COMPRESS_RATIO: tl.constexpr,
+    ):
+        """Prefill compress phase: online softmax-pool for each compress plan entry."""
+        cid = tl.program_id(0)
+        if cid >= num_c:
+            return
+
+        # CompressPlan: {seq_len(u32), ragged_id(u16)|buffer_len(u16), read_page_0(i32), read_page_1(i32)}
+        plan_base = plan_c_ptr + cid * 4
+        read_page_0 = tl.load(plan_base + 2).to(tl.int32)
+
+        d = tl.arange(0, BLOCK_D)
+        d_mask_hd = d < HEAD_DIM
+
+        if read_page_0 < 0:
+            tl.store(
+                out_ptr + cid * out_stride_b + d,
+                tl.zeros([BLOCK_D], tl.float32),
+                mask=d_mask_hd,
+            )
+            return
+
+        page_base = read_page_0 * COMPRESS_RATIO * buf_stride_slot
+        m_prev = tl.full([BLOCK_D], float("-inf"), tl.float32)
+        kv_acc = tl.zeros([BLOCK_D], tl.float32)
+        w_acc = tl.zeros([BLOCK_D], tl.float32)
+
+        for k in tl.static_range(COMPRESS_RATIO):
+            slot_addr = page_base + k * buf_stride_slot
+            kv_val = tl.load(buf_ptr + slot_addr + d, mask=d_mask_hd, other=0.0).to(
+                tl.float32
+            )
+            sc_val = tl.load(
+                buf_ptr + slot_addr + HEAD_DIM + d, mask=d_mask_hd, other=0.0
+            ).to(tl.float32)
+            ape_val = tl.load(
+                ape_ptr + k * ape_stride_r + d, mask=d_mask_hd, other=0.0
+            ).to(tl.float32)
+            score_k = sc_val + ape_val
+
+            m_new = tl.maximum(m_prev, score_k)
+            exp_old = tl.where(m_prev == float("-inf"), 0.0, tl.exp(m_prev - m_new))
+            exp_cur = tl.where(score_k == float("-inf"), 0.0, tl.exp(score_k - m_new))
+            kv_acc = kv_acc * exp_old + exp_cur * kv_val
+            w_acc = w_acc * exp_old + exp_cur
+            m_prev = m_new
+
+        compressed = kv_acc / w_acc
+        tl.store(out_ptr + cid * out_stride_b + d, compressed, mask=d_mask_hd)
+
+
+def _compress_forward_c128_triton(
+    kv_score_buffer: torch.Tensor,
+    kv_score_input: torch.Tensor,
+    ape: torch.Tensor,
+    plan: Union[CompressorDecodePlan, CompressorPrefillPlan],
+    head_dim: int,
+) -> torch.Tensor:
+    """Triton C128 compress_forward for HIP (wave64).
+
+    Fuses write + online-softmax-pool into Triton kernels.
+    CUDA graph compatible.
+    """
+    num_total_slots = kv_score_buffer.shape[0] * kv_score_buffer.shape[1]
+    num_pages = kv_score_buffer.shape[0]
+    last_dim = kv_score_buffer.shape[-1]
+    compress_ratio = 128
+
+    buf_flat = kv_score_buffer.view(-1, last_dim)
+    buf_stride_slot = last_dim  # elements per slot
+
+    BLOCK_D = triton.next_power_of_2(last_dim)
+
+    if plan.is_decode:
+        # Decode path: single kernel does write + compress
+        plan_raw = plan[1].view(torch.int32)  # [bs, 4]
+        bs = plan_raw.shape[0]
+        out = torch.empty(
+            bs, head_dim, dtype=torch.float32, device=kv_score_input.device
+        )
+
+        if bs > 0 and num_total_slots > 0:
+            grid = (bs,)
+            _c128_compress_decode_kernel[grid](
+                buf_flat,
+                kv_score_input,
+                ape,
+                out,
+                plan_raw,
+                buf_stride_slot,
+                kv_score_input.stride(0),
+                ape.stride(0),
+                out.stride(0),
+                bs,
+                HEAD_DIM=head_dim,
+                BLOCK_D=triton.next_power_of_2(head_dim),
+                COMPRESS_RATIO=compress_ratio,
+                num_warps=8,
+            )
+        return out
+    else:
+        # Prefill path: separate write kernel + compress kernel
+        plan_c_raw = plan[1].view(torch.int32)  # [num_c, 4]
+        plan_w = plan[2]  # [num_w, 8] uint8
+        plan_w_raw = plan_w.view(torch.int32)  # [num_w, 2]
+        num_c = plan_c_raw.shape[0]
+        num_w = plan_w_raw.shape[0]
+
+        out = torch.empty(
+            num_c, head_dim, dtype=torch.float32, device=kv_score_input.device
+        )
+
+        # Phase 1: Write
+        if num_w > 0 and num_total_slots > 0:
+            grid_w = (num_w,)
+            _c128_compress_prefill_write_kernel[grid_w](
+                buf_flat,
+                kv_score_input,
+                plan_w_raw,
+                buf_stride_slot,
+                kv_score_input.stride(0),
+                num_w,
+                BLOCK_D=BLOCK_D,
+                LAST_DIM=last_dim,
+                num_warps=4,
+            )
+
+        # Phase 2: Compress
+        if num_c > 0 and num_pages > 0:
+            grid_c = (num_c,)
+            _c128_compress_prefill_compress_kernel[grid_c](
+                buf_flat,
+                ape,
+                out,
+                plan_c_raw,
+                buf_stride_slot,
+                ape.stride(0),
+                out.stride(0),
+                num_c,
+                HEAD_DIM=head_dim,
+                BLOCK_D=triton.next_power_of_2(head_dim),
+                COMPRESS_RATIO=compress_ratio,
+                num_warps=8,
+            )
+
+        return out
 
 def _use_online_compress(compress_ratio: int) -> bool:
     """Online state-pool path is c128-only."""
@@ -218,13 +496,17 @@ class CompressorBackendMixin:
             is_unified_kv_triton,
         )
 
-        if _is_hip and not envs.SGLANG_OPT_USE_JIT_NORM.get():
-            self._forward_unified_hip(
+        use_dcp_scatter_store = _dcp_write_enabled() and not is_unified_kv_triton()
+        if (
+            _is_hip and not envs.SGLANG_OPT_USE_JIT_NORM.get()
+        ) or use_dcp_scatter_store:
+            self._forward_unified_scatter_store(
                 token_to_kv_pool=token_to_kv_pool,
                 kv_score_input=kv_score_input,
                 state_pool=state_pool,
                 compressor=compressor,
                 layer_id=layer_id,
+                forward_batch=forward_batch,
             )
         else:
             out_loc = self._get_out_loc(compressor.ratio)
@@ -280,15 +562,16 @@ class CompressorBackendMixin:
                 or forward_batch.forward_mode,
             )
 
-    def _forward_unified_hip(
+    def _forward_unified_scatter_store(
         self,
         token_to_kv_pool: DeepSeekV4TokenToKVPool,
         kv_score_input: torch.Tensor,
         state_pool,
         compressor: Compressor,
         layer_id: int,
+        forward_batch: ForwardBatch,
     ) -> None:
-        """HIP-specific forward path using PyTorch/Triton fallbacks."""
+        """Fallback forward path that stores through DCP-aware KV-pool APIs."""
         from sglang.kernels.ops.attention.deepseek_v4_rope import (
             fused_norm_rope_inplace_triton,
         )
@@ -306,10 +589,14 @@ class CompressorBackendMixin:
         out_loc = self._get_out_loc(compress_ratio)
 
         # Step 1: compress_forward (always use JIT for both C4 and C128)
-        coff = 2 if is_overlap_compress(compress_ratio) else 1
-        last_dim = 2 * head_dim * coff
         kv_score_buffer = state_pool.kv_score_buffer.kv_score
-        kv_score_buffer = kv_score_buffer.view(-1, compress_ratio, last_dim)
+        is_online = _use_online_compress(compress_ratio)
+        if is_online:
+            kv_score_buffer = kv_score_buffer.view(-1, 1, head_dim * 3)
+        else:
+            coff = 2 if is_overlap_compress(compress_ratio) else 1
+            last_dim = 2 * head_dim * coff
+            kv_score_buffer = kv_score_buffer.view(-1, compress_ratio, last_dim)
 
         kv_compressed = compress_forward(
             kv_score_buffer=kv_score_buffer,
@@ -318,20 +605,17 @@ class CompressorBackendMixin:
             plan=plan,
             compress_ratio=compress_ratio,
             head_dim=head_dim,
-            is_online=False,
+            is_online=is_online,
         )
 
         if kv_compressed.shape[0] == 0:
             return
 
-        # For decode: zero out non-boundary tokens to prevent corrupting kvcache loc 0.
+        boundary_mask = None
         if plan.is_decode:
             plan_raw = plan[1].view(torch.int32)
             seq_lens_plan = plan_raw[:, 0].to(torch.int32)
-            is_boundary = (seq_lens_plan % compress_ratio == 0).unsqueeze(-1)
-            kv_compressed = torch.where(
-                is_boundary, kv_compressed, torch.zeros_like(kv_compressed)
-            )
+            boundary_mask = (seq_lens_plan % compress_ratio == 0).contiguous()
 
         # Step 2: norm + rope (Triton fallback for precision parity with V1)
         positions = _extract_positions_from_plan(plan, compress_ratio)
@@ -350,16 +634,23 @@ class CompressorBackendMixin:
             kv_compressed = rotate_activation(kv_compressed)
 
         # Step 4: store to kvcache
-        # For decode: store ALL tokens. Non-boundary tokens have out_loc=0 (safe).
+        # For decode: only store true compressed-boundary tokens. Slot 0 can be a
+        # real compressed cache slot, so non-boundary tokens must not write zeros
+        # there.
         # For prefill: plan_c already only contains valid entries.
+        write_mask = None
         if plan.is_decode:
             kv_to_store = kv_compressed
             out_loc_to_store = out_loc
+            write_mask = boundary_mask
         else:
             kv_to_store = kv_compressed
             plan_raw = plan[1].view(torch.int32)
+            valid_plan_mask = (plan_raw[:, 0].to(torch.int32) >= 0).contiguous()
             ragged_ids = plan_raw[:, 1].to(torch.int32) & 0xFFFF
-            out_loc_to_store = out_loc[ragged_ids.long()]
+            ragged_ids = ragged_ids.long().clamp(max=out_loc.shape[0] - 1)
+            out_loc_to_store = out_loc[ragged_ids]
+            write_mask = valid_plan_mask
 
         if kv_to_store.shape[0] == 0:
             return
@@ -371,12 +662,16 @@ class CompressorBackendMixin:
                     layer_id=layer_id,
                     loc=out_loc_to_store,
                     cache_k=kv_to_store,
+                    dcp_kv_mask=forward_batch.dcp_kv_mask,
+                    write_mask=write_mask,
                 )
             else:
                 token_to_kv_pool.set_extra_key_buffer_fused(
                     layer_id=layer_id,
                     loc=out_loc_to_store,
                     cache_k=kv_to_store,
+                    dcp_kv_mask=forward_batch.dcp_kv_mask,
+                    write_mask=write_mask,
                 )
         else:
             if is_indexer:
@@ -386,10 +681,18 @@ class CompressorBackendMixin:
                     loc=out_loc_to_store,
                     index_k=kv_fp8,
                     index_k_scale=kv_scale,
+                    dcp_kv_mask=forward_batch.dcp_kv_mask,
+                    write_mask=write_mask,
                 )
             else:
                 pack = quant_to_nope_fp8_rope_bf16_pack_triton(kv_to_store.bfloat16())
-                token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc_to_store, pack)
+                token_to_kv_pool.set_extra_key_buffer(
+                    layer_id,
+                    out_loc_to_store,
+                    pack,
+                    dcp_kv_mask=forward_batch.dcp_kv_mask,
+                    write_mask=write_mask,
+                )
 
     # NOTE: alias for backward compatibility
     forward_indexer_compressor = forward_unified
@@ -414,6 +717,7 @@ def create_paged_compressor_data(
     use_prefill_cuda_graph: bool = False,
     num_q_tokens: Optional[int] = None,
     online_state_slot_offset: int = 0,
+    online_active_bs: Optional[int] = None,
 ) -> CompressMetadata:
     """Build the paged compress metadata (= the plan).
 
@@ -433,6 +737,7 @@ def create_paged_compressor_data(
             use_prefill_cuda_graph=use_prefill_cuda_graph,
             num_q_tokens=num_q_tokens,
             online_state_slot_offset=online_state_slot_offset,
+            online_active_bs=online_active_bs,
         )
 
     swa_page_size = token_to_kv_pool.swa_page_size
@@ -465,6 +770,7 @@ def create_paged_compressor_data(
             ring_size=ring_size,
             num_q_tokens=num_q_tokens,
             use_cuda_graph=use_prefill_cuda_graph,
+            active_bs=online_active_bs,
         )
     else:
         return CompressorDecodePlan.generate(
@@ -491,6 +797,7 @@ def _create_online_paged_compressor_data(
     use_prefill_cuda_graph: bool,
     num_q_tokens: Optional[int],
     online_state_slot_offset: int = 0,
+    online_active_bs: Optional[int] = None,
 ) -> CompressMetadata:
     req_pool_indices = req_pool_indices.to(torch.int64)
 
@@ -517,6 +824,7 @@ def _create_online_paged_compressor_data(
             num_q_tokens=int(num_q_tokens_planner),
             use_cuda_graph=use_prefill_cuda_graph,
             state_slot_offset=online_state_slot_offset,
+            active_bs=online_active_bs,
         )
     else:
         return CompressorDecodePlan.generate_online(

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -42,9 +42,8 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
-
 FP8_DTYPE = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
-
+FP8_MAX = torch.finfo(FP8_DTYPE).max
 
 IndexerQuery: TypeAlias = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
 

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -12,6 +12,52 @@ from sglang.srt.utils import is_hip, is_xpu
 if TYPE_CHECKING:
     pass
 
+_TOPK_V2_MAX_SUPPORTED_LENGTH = 262144
+
+
+def _maybe_copy_flashmla_sched_meta(dst, src) -> bool:
+    if not (
+        hasattr(dst, "have_initialized")
+        and hasattr(src, "have_initialized")
+        and hasattr(dst, "tile_scheduler_metadata")
+        and hasattr(src, "tile_scheduler_metadata")
+        and hasattr(dst, "num_splits")
+        and hasattr(src, "num_splits")
+    ):
+        return False
+
+    if dst is None or src is None:
+        return False
+
+    # CUDA graphs capture the initialized FlashMLA metadata tensors by pointer.
+    # Replay preparation often builds a fresh, uninitialized metadata object;
+    # replacing the captured object would drop the tensors still referenced by
+    # the graph. Keep the captured object alive in that case.
+    if getattr(dst, "have_initialized", False) and not getattr(
+        src, "have_initialized", False
+    ):
+        return True
+
+    if not getattr(dst, "have_initialized", False) or not getattr(
+        src, "have_initialized", False
+    ):
+        return False
+
+    for field_name in ("tile_scheduler_metadata", "num_splits"):
+        src_val = getattr(src, field_name)
+        dst_val = getattr(dst, field_name)
+        if src_val is None and dst_val is None:
+            continue
+        if src_val is None or dst_val is None or not hasattr(dst_val, "copy_"):
+            return False
+        if tuple(src_val.shape) != tuple(dst_val.shape):
+            return False
+        dst_val.copy_(src_val)
+
+    dst.have_initialized = src.have_initialized
+    dst.config = src.config
+    return True
+
 
 """
 Some comments on the common terms used in DeepSeekV4Backend:
@@ -81,7 +127,10 @@ def copy_metadata(
             setattr(dst, field_name, src_val)
 
     for field_name in assign_fields:
-        setattr(dst, field_name, getattr(src, field_name))
+        src_val = getattr(src, field_name)
+        dst_val = getattr(dst, field_name)
+        if not _maybe_copy_flashmla_sched_meta(dst_val, src_val):
+            setattr(dst, field_name, src_val)
 
     provided_fields = check_eq_fields + copy_fields + assign_fields
     provided_fields_unique = set(provided_fields)
@@ -168,7 +217,23 @@ class PagedIndexerMetadata:
 
     @property
     def max_c4_seq_len(self) -> int:
-        return self.page_table.shape[1] * self.c4_page_size
+        if self.c4_seq_lens.numel() == 0:
+            return self.c4_page_size
+
+        # During CUDA graph capture, ``.item()`` forces a device->host sync,
+        # which is illegal on a capturing stream. The captured logits buffer
+        # must also be sized for the worst case so replay shapes stay valid.
+        # Fall back to the static max-capacity bound in that case.
+        if torch.cuda.is_current_stream_capturing():
+            return self.page_table.shape[1] * self.c4_page_size
+
+        # CUDA graph/raw metadata may keep a max-capacity page table. The indexer
+        # should only materialize logits up to the active compressed length.
+        max_c4_seq_len = int(self.c4_seq_lens.max().item())
+        max_c4_pages = max(
+            1, (max_c4_seq_len + self.c4_page_size - 1) // self.c4_page_size
+        )
+        return min(max_c4_pages, self.page_table.shape[1]) * self.c4_page_size
 
     def copy_(self, other: PagedIndexerMetadata):
         if is_hip():

--- a/python/sglang/srt/mem_cache/allocator/__init__.py
+++ b/python/sglang/srt/mem_cache/allocator/__init__.py
@@ -1,6 +1,7 @@
 """Token-to-KV-slot allocators. One file per allocation strategy."""
 
 from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.dcp import DcpTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.paged import (
     PagedTokenToKVPoolAllocator,
     alloc_extend_naive,
@@ -9,6 +10,7 @@ from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
 
 __all__ = [
     "BaseTokenToKVPoolAllocator",
+    "DcpTokenToKVPoolAllocator",
     "PagedTokenToKVPoolAllocator",
     "TokenToKVPoolAllocator",
     "alloc_extend_naive",

--- a/python/sglang/srt/mem_cache/allocator/dcp.py
+++ b/python/sglang/srt/mem_cache/allocator/dcp.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import KVCache
+
+
+class DcpTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
+    """Logical paged allocator for decode-context-parallel KV storage.
+
+    DCP keeps request metadata in a cluster-wide logical token-index space.
+    KV writers map logical token index ``i`` to rank ``i % dcp_world_size`` and
+    local physical offset ``i // dcp_world_size`` when writing the per-rank pool.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        device: str,
+        kvcache: "KVCache",
+        need_sort: bool,
+        dcp_rank: int,
+        dcp_world_size: int,
+    ):
+        assert dcp_world_size >= 1
+        assert size % dcp_world_size == 0, (
+            f"DCP logical size {size} must be divisible by dcp_world_size "
+            f"{dcp_world_size}"
+        )
+        self.size = size
+        self.page_size = page_size
+        self.dtype = dtype
+        self.device = device
+        self._kvcache = kvcache
+        self.need_sort = need_sort
+        self.dcp_rank = dcp_rank
+        self.dcp_world_size = dcp_world_size
+        self.real_allocator = PagedTokenToKVPoolAllocator(
+            size, page_size, dtype, device, kvcache, need_sort
+        )
+
+    @property
+    def free_pages(self):
+        return self.real_allocator.free_pages
+
+    @free_pages.setter
+    def free_pages(self, value):
+        self.real_allocator.free_pages = value
+
+    @property
+    def release_pages(self):
+        return self.real_allocator.release_pages
+
+    @release_pages.setter
+    def release_pages(self, value):
+        self.real_allocator.release_pages = value
+
+    @property
+    def is_not_in_free_group(self):
+        return self.real_allocator.is_not_in_free_group
+
+    @is_not_in_free_group.setter
+    def is_not_in_free_group(self, value):
+        self.real_allocator.is_not_in_free_group = value
+
+    @property
+    def free_group(self):
+        return self.real_allocator.free_group
+
+    @free_group.setter
+    def free_group(self, value):
+        self.real_allocator.free_group = value
+
+    @property
+    def num_pages(self):
+        return self.real_allocator.num_pages
+
+    @property
+    def size_full(self):
+        return self.size
+
+    def alloc(self, need_size: int):
+        return self.real_allocator.alloc(need_size)
+
+    def alloc_extend(self, *args, **kwargs):
+        return self.real_allocator.alloc_extend(*args, **kwargs)
+
+    def alloc_decode(self, *args, **kwargs):
+        return self.real_allocator.alloc_decode(*args, **kwargs)
+
+    def free(self, free_index: torch.Tensor):
+        return self.real_allocator.free(free_index)
+
+    def clear(self):
+        return self.real_allocator.clear()
+
+    def available_size(self):
+        return self.real_allocator.available_size()
+
+    def debug_print(self) -> str:
+        return self.real_allocator.debug_print()
+
+    def free_group_begin(self):
+        self.real_allocator.free_group_begin()
+
+    def free_group_end(self):
+        self.real_allocator.free_group_end()
+
+    def merge_and_sort_free(self):
+        self.real_allocator.merge_and_sort_free()
+
+    def backup_state(self):
+        return self.real_allocator.backup_state()
+
+    def restore_state(self, state):
+        self.real_allocator.restore_state(state)
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        return self.real_allocator.get_cpu_copy(indices, mamba_indices=mamba_indices)
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        return self.real_allocator.load_cpu_copy(
+            kv_cache_cpu, indices, mamba_indices=mamba_indices
+        )
+
+    def filter_local_indices(self, indices: torch.Tensor) -> torch.Tensor:
+        local_mask = indices % self.dcp_world_size == self.dcp_rank
+        return indices[local_mask] // self.dcp_world_size

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -1,6 +1,7 @@
 import torch
 
 from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.dcp import DcpTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
@@ -29,6 +30,8 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         device: str,
         kvcache: BaseSWAKVPool,
         need_sort: bool,
+        dcp_rank: int = 0,
+        dcp_world_size: int = 1,
     ):
         assert isinstance(kvcache, BaseSWAKVPool)
         self._size_full = size
@@ -56,26 +59,44 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 need_sort,
             )
         else:
-            if _is_npu:
-                PagedTokenToKVPoolAllocatorClass = NPUPagedTokenToKVPoolAllocator
+            if dcp_world_size > 1:
+                # DCP keeps allocator bookkeeping in logical token-index space.
+                # KV writers map logical locs to rank-local storage.
+                def _make_dcp_allocator(pool_size, kv_pool):
+                    return DcpTokenToKVPoolAllocator(
+                        pool_size,
+                        page_size,
+                        dtype,
+                        device,
+                        kv_pool,
+                        need_sort,
+                        dcp_rank=dcp_rank,
+                        dcp_world_size=dcp_world_size,
+                    )
+
+                self.full_attn_allocator = _make_dcp_allocator(size, full_kv_pool)
+                self.swa_attn_allocator = _make_dcp_allocator(size_swa, swa_kv_pool)
             else:
-                PagedTokenToKVPoolAllocatorClass = PagedTokenToKVPoolAllocator
-            self.full_attn_allocator = PagedTokenToKVPoolAllocatorClass(
-                size,
-                page_size,
-                dtype,
-                device,
-                full_kv_pool,
-                need_sort,
-            )
-            self.swa_attn_allocator = PagedTokenToKVPoolAllocatorClass(
-                size_swa,
-                page_size,
-                dtype,
-                device,
-                swa_kv_pool,
-                need_sort,
-            )
+                if _is_npu:
+                    PagedTokenToKVPoolAllocatorClass = NPUPagedTokenToKVPoolAllocator
+                else:
+                    PagedTokenToKVPoolAllocatorClass = PagedTokenToKVPoolAllocator
+                self.full_attn_allocator = PagedTokenToKVPoolAllocatorClass(
+                    size,
+                    page_size,
+                    dtype,
+                    device,
+                    full_kv_pool,
+                    need_sort,
+                )
+                self.swa_attn_allocator = PagedTokenToKVPoolAllocatorClass(
+                    size_swa,
+                    page_size,
+                    dtype,
+                    device,
+                    swa_kv_pool,
+                    need_sort,
+                )
         # Note: append one more item of value -1 in the end so -1 maps to -1.
         # It is needed for the last_loc in alloc_extend, where the first full_last_loc
         # is -1, and we need to map it to swa_last_loc -1 as well.
@@ -345,6 +366,12 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_swa_index_mapping[full_indices] = swa_indices
 
     def free_swa(self, free_index: torch.Tensor):
+        if free_index.numel() == 0:
+            return
+
+        free_index = free_index[
+            (free_index >= 0) & (free_index < self.full_to_swa_index_mapping.shape[0])
+        ]
         if free_index.numel() == 0:
             return
 

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.runtime_context import get_server_args
+from sglang.srt.platforms import current_platform
 from sglang.srt.utils import ceil_div, is_hip
 
 logger = logging.getLogger(__name__)
@@ -128,12 +129,18 @@ class DeepSeekV4SingleKVPool(KVCache):
         layer_id: int,
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
     ):
         dsv4_index_buf_accessor.SetKAndS.execute(
             pool=self,
             buf=self.kv_buffer[layer_id],
             loc=loc,
             nope_fp8_rope_bf16_pack=cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
         )
 
     def set_key_buffer_fused(
@@ -150,6 +157,34 @@ class DeepSeekV4SingleKVPool(KVCache):
             type="flashmla",
         )
 
+    def set_key_buffer_fused_fallback_triton(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
+    ) -> None:
+        """DCP fallback path: quantize the bf16 ``cache_k`` to a NopeFp8RopeBf16
+        pack on-device, then write through the Triton kernel which honors
+        ``dcp_world_size``/``dcp_rank``. Used when ``dcp_size > 1`` because the
+        fused C++ flashmla store kernel is not yet DCP-aware.
+        """
+        from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
+            quant_to_nope_fp8_rope_bf16_pack_triton,
+        )
+
+        pack = quant_to_nope_fp8_rope_bf16_pack_triton(cache_k.bfloat16())
+        self.set_key_buffer(
+            layer_id,
+            loc,
+            pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
+
     def get_key_buffer(self, layer_id: int):
         if self.store_dtype != self.dtype:
             return self.kv_buffer[layer_id - self.start_layer].view(self.dtype)
@@ -164,6 +199,124 @@ class DeepSeekV4SingleKVPool(KVCache):
 
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError("Use get_key_buffer instead.")
+
+    def _value_bytes_per_token(self) -> int:
+        return (
+            self.qk_nope_head_dim
+            + self.qk_rope_head_dim * self.rope_storage_dtype.itemsize
+        )
+
+    def _scale_bytes_per_token(self) -> int:
+        return self.qk_nope_head_dim // self.quantize_block_size + self.scale_pad
+
+    def _copy_token_rows_to_cpu(self, buf: torch.Tensor, indices: torch.Tensor):
+        value_bytes = self._value_bytes_per_token()
+        scale_bytes = self._scale_bytes_per_token()
+        pages = (indices // self.page_size).to(torch.long)
+        offsets = (indices % self.page_size).to(torch.long)
+
+        value_byte_offsets = torch.arange(value_bytes, device=buf.device)
+        value_offsets = offsets[:, None] * value_bytes + value_byte_offsets[None, :]
+        values_cpu = buf[pages[:, None], value_offsets].to("cpu", non_blocking=True)
+
+        scale_byte_offsets = torch.arange(scale_bytes, device=buf.device)
+        scale_base = self.page_size * value_bytes
+        scale_offsets = (
+            scale_base
+            + offsets[:, None] * scale_bytes
+            + scale_byte_offsets[None, :]
+        )
+        scales_cpu = buf[pages[:, None], scale_offsets].to("cpu", non_blocking=True)
+        return values_cpu, scales_cpu
+
+    def _load_token_rows_from_cpu(
+        self,
+        buf: torch.Tensor,
+        indices: torch.Tensor,
+        values_cpu: torch.Tensor,
+        scales_cpu: torch.Tensor,
+    ) -> None:
+        value_bytes = self._value_bytes_per_token()
+        scale_bytes = self._scale_bytes_per_token()
+        pages = (indices // self.page_size).to(torch.long)
+        offsets = (indices % self.page_size).to(torch.long)
+
+        value_byte_offsets = torch.arange(value_bytes, device=buf.device)
+        value_offsets = offsets[:, None] * value_bytes + value_byte_offsets[None, :]
+        values = values_cpu.to(buf.device, non_blocking=True)
+        buf[pages[:, None], value_offsets] = values
+
+        scale_byte_offsets = torch.arange(scale_bytes, device=buf.device)
+        scale_base = self.page_size * value_bytes
+        scale_offsets = (
+            scale_base
+            + offsets[:, None] * scale_bytes
+            + scale_byte_offsets[None, :]
+        )
+        scales = scales_cpu.to(buf.device, non_blocking=True)
+        buf[pages[:, None], scale_offsets] = scales
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        """Move packed DSV4 token rows between cache slots."""
+        if self.layer_num == 0 or tgt_loc.numel() == 0:
+            return
+
+        tgt_loc = tgt_loc.view(-1).long()
+        src_loc = src_loc.view(-1).long()
+
+        value_bytes = self._value_bytes_per_token()
+        scale_bytes = self._scale_bytes_per_token()
+        value_byte_offsets = torch.arange(value_bytes, device=self.device)
+        scale_byte_offsets = torch.arange(scale_bytes, device=self.device)
+        scale_base = self.page_size * value_bytes
+
+        pages_t = tgt_loc // self.page_size
+        offsets_t = tgt_loc % self.page_size
+        pages_s = src_loc // self.page_size
+        offsets_s = src_loc % self.page_size
+
+        value_offsets_t = offsets_t[:, None] * value_bytes + value_byte_offsets[None, :]
+        value_offsets_s = offsets_s[:, None] * value_bytes + value_byte_offsets[None, :]
+        scale_offsets_t = (
+            scale_base + offsets_t[:, None] * scale_bytes + scale_byte_offsets[None, :]
+        )
+        scale_offsets_s = (
+            scale_base + offsets_s[:, None] * scale_bytes + scale_byte_offsets[None, :]
+        )
+
+        for buf in self.kv_buffer:
+            values = buf[pages_s[:, None], value_offsets_s].clone()
+            scales = buf[pages_s[:, None], scale_offsets_s].clone()
+            buf[pages_t[:, None], value_offsets_t] = values
+            buf[pages_t[:, None], scale_offsets_t] = scales
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        kv_cache_cpu = []
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            layer_chunks = []
+            buf = self.kv_buffer[layer_id]
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                layer_chunks.append(self._copy_token_rows_to_cpu(buf, chunk_indices))
+            kv_cache_cpu.append(layer_chunks)
+        current_platform.synchronize()
+        return kv_cache_cpu
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            buf = self.kv_buffer[layer_id]
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                values_cpu, scales_cpu = kv_cache_cpu[layer_id][i // chunk_size]
+                assert values_cpu.shape[0] == scales_cpu.shape[0] == len(chunk_indices)
+                self._load_token_rows_from_cpu(
+                    buf, chunk_indices, values_cpu, scales_cpu
+                )
+        current_platform.synchronize()
 
 
 class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
@@ -229,9 +382,19 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         layer_id: int,
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
     ):
         loc = self.translate_loc_to_hisparse_device(loc)
-        super().set_key_buffer(layer_id, loc, cache_nope_fp8_rope_bf16_pack)
+        super().set_key_buffer(
+            layer_id,
+            loc,
+            cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
 
     def set_key_buffer_fused(
         self,
@@ -241,6 +404,25 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
     ) -> None:
         loc = self.translate_loc_to_hisparse_device(loc)
         return super().set_key_buffer_fused(layer_id, loc, cache_k)
+
+    def set_key_buffer_fused_fallback_triton(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
+    ) -> None:
+        loc = self.translate_loc_to_hisparse_device(loc)
+        return super().set_key_buffer_fused_fallback_triton(
+            layer_id,
+            loc,
+            cache_k,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         raise NotImplementedError("HiSparseC4DevicePool does not support get_cpu_copy")
@@ -303,6 +485,42 @@ class DeepSeekV4IndexerPool(KVCache):
                     for _ in range(self.layer_num)
                 ]
 
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        """Move C4 indexer key+scale rows between cache slots."""
+        if self.layer_num == 0 or tgt_loc.numel() == 0:
+            return
+
+        tgt_loc = tgt_loc.view(-1).long()
+        src_loc = src_loc.view(-1).long()
+
+        k_bytes = (
+            self.index_head_dim // 2 if self.use_fp4_indexer else self.index_head_dim
+        )
+        scale_bytes = 4
+        k_offsets = torch.arange(k_bytes, device=self.device)
+        scale_offsets = torch.arange(scale_bytes, device=self.device)
+        scale_base = self.page_size * k_bytes
+
+        pages_t = tgt_loc // self.page_size
+        offsets_t = tgt_loc % self.page_size
+        pages_s = src_loc // self.page_size
+        offsets_s = src_loc % self.page_size
+
+        k_offsets_t = offsets_t[:, None] * k_bytes + k_offsets[None, :]
+        k_offsets_s = offsets_s[:, None] * k_bytes + k_offsets[None, :]
+        scale_offsets_t = (
+            scale_base + offsets_t[:, None] * scale_bytes + scale_offsets[None, :]
+        )
+        scale_offsets_s = (
+            scale_base + offsets_s[:, None] * scale_bytes + scale_offsets[None, :]
+        )
+
+        for buf in self.index_k_with_scale_buffer:
+            keys = buf[pages_s[:, None], k_offsets_s].clone()
+            scales = buf[pages_s[:, None], scale_offsets_s].clone()
+            buf[pages_t[:, None], k_offsets_t] = keys
+            buf[pages_t[:, None], scale_offsets_t] = scales
+
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError()
 
@@ -342,10 +560,18 @@ class DeepSeekV4IndexerPool(KVCache):
         loc: torch.Tensor,
         index_k: torch.Tensor,
         index_k_scale: torch.Tensor,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
         index_buf_accessor.SetKAndS.execute(
-            pool=self, buf=buf, loc=loc, index_k=index_k, index_k_scale=index_k_scale
+            pool=self,
+            buf=buf,
+            loc=loc,
+            index_k=index_k,
+            index_k_scale=index_k_scale,
+            write_mask=write_mask,
         )
 
     def set_index_fused(
@@ -378,6 +604,84 @@ class DeepSeekV4IndexerPool(KVCache):
             loc=loc,
             page_size=self.page_size,
         )
+
+    def _scale_bytes_per_token(self) -> int:
+        return (self.index_head_dim // self.quant_block_size) * 4
+
+    def _copy_token_rows_to_cpu(self, buf: torch.Tensor, indices: torch.Tensor):
+        value_bytes = self.index_head_dim
+        scale_bytes = self._scale_bytes_per_token()
+        pages = (indices // self.page_size).to(torch.long)
+        offsets = (indices % self.page_size).to(torch.long)
+
+        value_byte_offsets = torch.arange(value_bytes, device=buf.device)
+        value_offsets = offsets[:, None] * value_bytes + value_byte_offsets[None, :]
+        values_cpu = buf[pages[:, None], value_offsets].to("cpu", non_blocking=True)
+
+        scale_byte_offsets = torch.arange(scale_bytes, device=buf.device)
+        scale_base = self.page_size * value_bytes
+        scale_offsets = (
+            scale_base
+            + offsets[:, None] * scale_bytes
+            + scale_byte_offsets[None, :]
+        )
+        scales_cpu = buf[pages[:, None], scale_offsets].to("cpu", non_blocking=True)
+        return values_cpu, scales_cpu
+
+    def _load_token_rows_from_cpu(
+        self,
+        buf: torch.Tensor,
+        indices: torch.Tensor,
+        values_cpu: torch.Tensor,
+        scales_cpu: torch.Tensor,
+    ) -> None:
+        value_bytes = self.index_head_dim
+        scale_bytes = self._scale_bytes_per_token()
+        pages = (indices // self.page_size).to(torch.long)
+        offsets = (indices % self.page_size).to(torch.long)
+
+        value_byte_offsets = torch.arange(value_bytes, device=buf.device)
+        value_offsets = offsets[:, None] * value_bytes + value_byte_offsets[None, :]
+        values = values_cpu.to(buf.device, non_blocking=True)
+        buf[pages[:, None], value_offsets] = values
+
+        scale_byte_offsets = torch.arange(scale_bytes, device=buf.device)
+        scale_base = self.page_size * value_bytes
+        scale_offsets = (
+            scale_base
+            + offsets[:, None] * scale_bytes
+            + scale_byte_offsets[None, :]
+        )
+        scales = scales_cpu.to(buf.device, non_blocking=True)
+        buf[pages[:, None], scale_offsets] = scales
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        kv_cache_cpu = []
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            layer_chunks = []
+            buf = self.index_k_with_scale_buffer[layer_id]
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                layer_chunks.append(self._copy_token_rows_to_cpu(buf, chunk_indices))
+            kv_cache_cpu.append(layer_chunks)
+        current_platform.synchronize()
+        return kv_cache_cpu
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            buf = self.index_k_with_scale_buffer[layer_id]
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                values_cpu, scales_cpu = kv_cache_cpu[layer_id][i // chunk_size]
+                assert values_cpu.shape[0] == scales_cpu.shape[0] == len(chunk_indices)
+                self._load_token_rows_from_cpu(
+                    buf, chunk_indices, values_cpu, scales_cpu
+                )
+        current_platform.synchronize()
 
 
 class DeepSeekV4LayerItem(NamedTuple):
@@ -479,6 +783,8 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         end_layer: Optional[int] = None,
         enable_hisparse: bool = False,
         online_mtp_max_draft_tokens: int = 0,
+        c4_indexer_size: Optional[int] = None,
+        c4_indexer_state_pool_size: Optional[int] = None,
         num_req_slots: Optional[int] = None,
     ):
         super().__init__(
@@ -491,13 +797,17 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             start_layer,
             end_layer,
         )
-        c4_logical_size = c128_size * 32
+        c4_logical_size = (
+            c4_indexer_size if c4_indexer_size is not None else c128_size * 32
+        )
 
         logger.info(
             "Initialize DeepSeekV4TokenToKVPool with "
             f"{max_num_reqs=} {swa_size=} {c4_size=} "
             f"{c4_logical_size=} {c128_size=} "
-            f"{c4_state_pool_size=} {c128_state_pool_size=}"
+            f"{c4_state_pool_size=} "
+            f"{c4_indexer_state_pool_size=} "
+            f"{c128_state_pool_size=}"
         )
 
         self.max_num_reqs = max_num_reqs
@@ -511,6 +821,11 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.c4_logical_size = c4_logical_size
         self.c128_size = c128_size
         self.c4_state_pool_size = c4_state_pool_size
+        self.c4_indexer_state_pool_size = (
+            c4_indexer_state_pool_size
+            if c4_indexer_state_pool_size is not None
+            else c4_state_pool_size
+        )
         c128_ring_size = self.get_ring_size(128)
         if ONLINE_C128:
             # Request-scoped online C128 state is indexed by req_pool_idx.
@@ -533,6 +848,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             self.online_c128_mtp_pending_seq_lens = torch.empty(
                 self.online_c128_state_num_req_slots, dtype=torch.int64, device=device
             )
+            self.online_c128_mtp_pending_seq_lens.fill_(-1)
 
         # Determine this PP stage's absolute layer range
         if (
@@ -668,6 +984,130 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):
         assert self.full_to_swa_index_mapping is not None
         return self.full_to_swa_index_mapping[kv_indices]
+
+    def _localize_dcp_move_locs(
+        self, tgt_loc: torch.Tensor, src_loc: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        dcp_world_size, dcp_rank = self._dcp_world_rank()
+        if dcp_world_size == 1 or tgt_loc.numel() == 0:
+            return tgt_loc, src_loc
+
+        local_mask = (tgt_loc % dcp_world_size == dcp_rank) & (
+            src_loc % dcp_world_size == dcp_rank
+        )
+        if not torch.any(local_mask):
+            return tgt_loc.new_empty((0,)), src_loc.new_empty((0,))
+        return (
+            tgt_loc[local_mask] // dcp_world_size,
+            src_loc[local_mask] // dcp_world_size,
+        )
+
+    @staticmethod
+    def _compressed_move_locs_from_full(
+        tgt_loc: torch.Tensor, src_loc: torch.Tensor, compress_ratio: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if tgt_loc.numel() == 0:
+            return tgt_loc, src_loc
+        mask = ((tgt_loc + 1) % compress_ratio == 0) & (
+            (src_loc + 1) % compress_ratio == 0
+        )
+        return (
+            (tgt_loc[mask] // compress_ratio).to(tgt_loc.dtype),
+            (src_loc[mask] // compress_ratio).to(src_loc.dtype),
+        )
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        """Move accepted speculative DSV4 KV rows into their committed slots."""
+        if tgt_loc.numel() == 0:
+            return
+
+        tgt_loc = tgt_loc.view(-1).long()
+        src_loc = src_loc.view(-1).long()
+
+        if self._unified_kv:
+            raise NotImplementedError("DSV4 unified KV move is not supported yet.")
+
+        tgt_swa = self.translate_loc_from_full_to_swa(tgt_loc)
+        src_swa = self.translate_loc_from_full_to_swa(src_loc)
+        tgt_swa_local, src_swa_local = self._localize_dcp_move_locs(tgt_swa, src_swa)
+        self.swa_kv_pool.move_kv_cache(tgt_swa_local, src_swa_local)
+
+        tgt_c4, src_c4 = self._compressed_move_locs_from_full(tgt_loc, src_loc, 4)
+        if tgt_c4.numel() and src_c4.numel():
+            # C4 indexer cache is replicated in global c4-index space.
+            self.c4_indexer_kv_pool.move_kv_cache(tgt_c4, src_c4)
+            tgt_c4_local, src_c4_local = self._localize_dcp_move_locs(tgt_c4, src_c4)
+            self.c4_kv_pool.move_kv_cache(tgt_c4_local, src_c4_local)
+
+        tgt_c128, src_c128 = self._compressed_move_locs_from_full(tgt_loc, src_loc, 128)
+        if tgt_c128.numel() and src_c128.numel():
+            tgt_c128_local, src_c128_local = self._localize_dcp_move_locs(
+                tgt_c128, src_c128
+            )
+            self.c128_kv_pool.move_kv_cache(tgt_c128_local, src_c128_local)
+
+    def move_accepted_kv_cache(
+        self,
+        tgt_loc: torch.Tensor,
+        src_loc: torch.Tensor,
+        accepted_seq_lens: torch.Tensor,
+    ):
+        """Move speculative accepted rows using logical seq-len boundaries.
+
+        DSV4 compressed KV is written when the logical sequence length hits a
+        compression boundary. The physical full-cache slot number is allocator
+        state and must not be used to infer C4/C128 boundaries.
+        """
+        if tgt_loc.numel() == 0:
+            return
+
+        tgt_loc = tgt_loc.view(-1).long()
+        src_loc = src_loc.view(-1).long()
+        accepted_seq_lens = accepted_seq_lens.view(-1).to(device=tgt_loc.device)
+
+        if self._unified_kv:
+            raise NotImplementedError("DSV4 unified KV move is not supported yet.")
+
+        tgt_swa = self.translate_loc_from_full_to_swa(tgt_loc)
+        src_swa = self.translate_loc_from_full_to_swa(src_loc)
+        tgt_swa_local, src_swa_local = self._localize_dcp_move_locs(tgt_swa, src_swa)
+        self.swa_kv_pool.move_kv_cache(tgt_swa_local, src_swa_local)
+
+        tgt_c4, src_c4 = self._compressed_move_locs_from_boundary_mask(
+            tgt_loc, src_loc, accepted_seq_lens, 4
+        )
+        if tgt_c4.numel() and src_c4.numel():
+            self.c4_indexer_kv_pool.move_kv_cache(tgt_c4, src_c4)
+            tgt_c4_local, src_c4_local = self._localize_dcp_move_locs(tgt_c4, src_c4)
+            self.c4_kv_pool.move_kv_cache(tgt_c4_local, src_c4_local)
+
+        tgt_c128, src_c128 = self._compressed_move_locs_from_boundary_mask(
+            tgt_loc, src_loc, accepted_seq_lens, 128
+        )
+        if tgt_c128.numel() and src_c128.numel():
+            tgt_c128_local, src_c128_local = self._localize_dcp_move_locs(
+                tgt_c128, src_c128
+            )
+            self.c128_kv_pool.move_kv_cache(tgt_c128_local, src_c128_local)
+
+    @staticmethod
+    def _compressed_move_locs_from_boundary_mask(
+        tgt_loc: torch.Tensor,
+        src_loc: torch.Tensor,
+        accepted_seq_lens: torch.Tensor,
+        compress_ratio: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if tgt_loc.numel() == 0:
+            return tgt_loc, src_loc
+        token_len = min(tgt_loc.numel(), src_loc.numel(), accepted_seq_lens.numel())
+        tgt_loc = tgt_loc[:token_len]
+        src_loc = src_loc[:token_len]
+        accepted_seq_lens = accepted_seq_lens[:token_len]
+        mask = accepted_seq_lens % compress_ratio == 0
+        return (
+            (tgt_loc[mask] // compress_ratio).to(tgt_loc.dtype),
+            (src_loc[mask] // compress_ratio).to(src_loc.dtype),
+        )
 
     def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs: List[int] = []
@@ -919,6 +1359,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
     def _init_paged_compress_states(self, enable_memory_saver: bool):
         c4_state_pool_size = self.c4_state_pool_size
+        c4_indexer_state_pool_size = self.c4_indexer_state_pool_size
         c128_state_pool_size = self.c128_state_pool_size
         total_L = len(self.compression_ratios)
         self.compress_state_pools: List[Optional[CompressStatePool]] = [None] * total_L
@@ -1009,16 +1450,25 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
             state = pool.kv_score_buffer.kv_score
             if ONLINE_C128:
-                row = state[req_pool_idx]
-                head_dim = row.shape[-1] // 3
-                row[:head_dim].fill_(float("-inf"))
-                row[head_dim:].zero_()
+                rows = [req_pool_idx]
+                if pool.online_mtp_max_draft_tokens > 0:
+                    rows = [
+                        req_pool_idx + i * pool.online_mtp_state_slot_offset
+                        for i in range(pool.online_mtp_max_draft_tokens + 1)
+                    ]
+                rows = torch.as_tensor(rows, dtype=torch.long, device=state.device)
+                head_dim = state.shape[-1] // 3
+                state[rows, :head_dim] = float("-inf")
+                state[rows, head_dim:] = 0
             else:
                 start = req_pool_idx * pool.ring_size
                 rows = state[start : start + pool.ring_size]
                 half = rows.shape[-1] // 2
                 rows[:, :half].zero_()
                 rows[:, half:].fill_(float("-inf"))
+
+        if self.online_c128_mtp_pending_seq_lens is not None:
+            self.online_c128_mtp_pending_seq_lens[req_pool_idx] = -1
 
     def clear_unaccepted_c128_draft_states(
         self,
@@ -1064,14 +1514,52 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.wait_layer_transfer(layer_id)
         return self.swa_kv_pool.get_key_buffer(self._swa_local_layer_id(layer_id))
 
+    def _dcp_world_rank(self) -> Tuple[int, int]:
+        """Resolve current DCP (decode context parallel) world size and rank.
+
+        Imported lazily so non-DCP setups don't pay an import cost. Returns
+        ``(world_size, rank)``; when DCP is disabled the group is ``None``
+        and we fall back to ``(1, 0)`` which makes the Triton kernel a no-op
+        on the dcp dimension.
+        """
+        from sglang.srt.distributed.parallel_state import get_dcp_group_no_assert
+
+        group = get_dcp_group_no_assert()
+        if group is None or group.world_size == 1:
+            return 1, 0
+        return group.world_size, group.rank_in_group
+
+    def _dcp_write_context(self) -> Tuple[int, int, bool]:
+        dcp_world_size, dcp_rank = self._dcp_world_rank()
+        return dcp_world_size, dcp_rank, dcp_world_size > 1
+
+    @staticmethod
+    def _dcp_loc_write_mask(loc: torch.Tensor) -> torch.Tensor:
+        # Keep only the validity part here: full-cache loc 0 is the allocator's
+        # dummy/padding slot and must not be persisted as KV. Callers that write
+        # translated locations (for example SWA ring slots) must pass the raw
+        # full-cache loc instead, because translated slot 0 can be valid.
+        return (loc > 0).contiguous()
+
     def set_swa_key_buffer(
         self,
         layer_id: int,
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+        if dcp_enabled or dcp_kv_mask is not None:
+            write_mask = self._dcp_loc_write_mask(loc)
+        else:
+            write_mask = None
         self.swa_kv_pool.set_key_buffer(
-            self._swa_local_layer_id(layer_id), loc, cache_nope_fp8_rope_bf16_pack
+            self._swa_local_layer_id(layer_id),
+            loc,
+            cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
         )
 
     def get_extra_key_page_size(self, layer_id: int) -> int:
@@ -1090,11 +1578,19 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, _ = self._dcp_write_context()
         _, compress_layer_id, compress_kv_pool = self.layer_mapping[layer_id]
         assert compress_kv_pool is not None
         compress_kv_pool.set_key_buffer(
-            compress_layer_id, loc, cache_nope_fp8_rope_bf16_pack
+            compress_layer_id,
+            loc,
+            cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=(write_mask.contiguous() if write_mask is not None else None),
         )
 
     def get_index_k_page_size(self) -> int:
@@ -1131,11 +1627,20 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         loc: torch.Tensor,
         index_k: torch.Tensor,
         index_k_scale: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
         assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
+        # The c4 indexer is a scoring cache used by paged_mqa_logits with the
+        # global c4 page_table, and its topk result is later localized for DCP
+        # attention. Keep this cache replicated in global c4-index space.
         self.c4_indexer_kv_pool.set_index_k_scale_buffer(
-            compress_layer_id, loc, index_k, index_k_scale
+            compress_layer_id,
+            loc,
+            index_k,
+            index_k_scale,
+            write_mask=write_mask.contiguous() if write_mask is not None else None,
         )
 
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:
@@ -1155,9 +1660,23 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         swa_loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        raw_loc: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+        if dcp_enabled or dcp_kv_mask is not None:
+            write_mask = self._dcp_loc_write_mask(
+                raw_loc if raw_loc is not None else swa_loc
+            )
+        else:
+            write_mask = None
         self.swa_kv_pool.set_key_buffer(
-            self._swa_local_layer_id(layer_id), swa_loc, cache_nope_fp8_rope_bf16_pack
+            self._swa_local_layer_id(layer_id),
+            swa_loc,
+            cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
         )
 
     def get_swa_key_buffer_radix(self, layer_id: int) -> torch.Tensor:
@@ -1169,7 +1688,21 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         swa_loc: torch.Tensor,
         cache_k: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        raw_loc: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+        if dcp_enabled or dcp_kv_mask is not None:
+            return self.swa_kv_pool.set_key_buffer_fused_fallback_triton(
+                self._swa_local_layer_id(layer_id),
+                swa_loc,
+                cache_k,
+                dcp_world_size=dcp_world_size,
+                dcp_rank=dcp_rank,
+                write_mask=self._dcp_loc_write_mask(
+                    raw_loc if raw_loc is not None else swa_loc
+                ),
+            )
         return self.swa_kv_pool.set_key_buffer_fused(
             self._swa_local_layer_id(layer_id), swa_loc, cache_k
         )
@@ -1183,7 +1716,25 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         eps: float,
         freqs_cis: torch.Tensor,
         positions: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        raw_loc: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+        if dcp_enabled or dcp_kv_mask is not None:
+            from sglang.jit_kernel.dsv4 import fused_norm_rope_inplace
+
+            kv = kv.contiguous()
+            fused_norm_rope_inplace(kv, kv_weight, eps, freqs_cis, positions)
+            return self.swa_kv_pool.set_key_buffer_fused_fallback_triton(
+                self._swa_local_layer_id(layer_id),
+                swa_loc,
+                kv,
+                dcp_world_size=dcp_world_size,
+                dcp_rank=dcp_rank,
+                write_mask=self._dcp_loc_write_mask(
+                    raw_loc if raw_loc is not None else swa_loc
+                ),
+            )
         fused_k_norm_rope_flashmla(
             kv=kv,
             kv_weight=kv_weight,
@@ -1200,9 +1751,24 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         loc: torch.Tensor,
         cache_k: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
-        _, compress_layer_id, compress_kv_pool = self.layer_mapping[layer_id]
+        compress_ratio, compress_layer_id, compress_kv_pool = self.layer_mapping[
+            layer_id
+        ]
         assert compress_kv_pool is not None
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+
+        if dcp_enabled or dcp_kv_mask is not None or write_mask is not None:
+            return compress_kv_pool.set_key_buffer_fused_fallback_triton(
+                compress_layer_id,
+                loc,
+                cache_k,
+                dcp_world_size=dcp_world_size,
+                dcp_rank=dcp_rank,
+                write_mask=write_mask.contiguous() if write_mask is not None else None,
+            )
         return compress_kv_pool.set_key_buffer_fused(compress_layer_id, loc, cache_k)
 
     def set_index_k_fused(
@@ -1210,9 +1776,24 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         loc: torch.Tensor,
         cache_k: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
         assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
+        if write_mask is not None:
+            from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
+
+            index_k, index_k_scale = act_quant(cache_k)
+            return self.c4_indexer_kv_pool.set_index_k_scale_buffer(
+                compress_layer_id,
+                loc,
+                index_k,
+                index_k_scale,
+                write_mask=write_mask.contiguous(),
+            )
+        # See set_index_k_scale_buffer: the indexer KV must stay global because
+        # the logits path reads it through the global c4 page_table.
         return self.c4_indexer_kv_pool.set_index_fused(compress_layer_id, loc, cache_k)
 
     def set_index_k_fp4(
@@ -1224,3 +1805,190 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
         assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
         return self.c4_indexer_kv_pool.set_index_fp4(compress_layer_id, loc, cache_k)
+
+    def _compressed_indices_from_full_indices(
+        self, indices: torch.Tensor, compress_ratio: int
+    ) -> torch.Tensor:
+        if len(indices) == 0:
+            return indices
+        positions = torch.arange(
+            1, len(indices) + 1, dtype=torch.long, device=indices.device
+        )
+        mask = (positions % compress_ratio) == 0
+        return (indices[mask] // compress_ratio).to(indices.dtype)
+
+    def _copy_state_pool_to_cpu(
+        self, pool: Optional[CompressStatePool], indices: torch.Tensor
+    ):
+        if (
+            pool is None
+            or self.full_to_swa_index_mapping is None
+            or len(indices) == 0
+        ):
+            return None
+        swa_indices = self.full_to_swa_index_mapping[indices]
+        mask = swa_indices >= 0
+        if not torch.any(mask):
+            return None
+        state_locs = pool.translate_from_swa_loc_to_state_loc(swa_indices[mask])
+        bank_offsets = [0]
+        if pool.online_mtp_max_draft_tokens > 0:
+            bank_offsets = [
+                i * pool.online_mtp_state_slot_offset
+                for i in range(pool.online_mtp_max_draft_tokens + 1)
+            ]
+        cpu_banks = [
+            pool.kv_score_buffer.kv_score[state_locs + offset].to(
+                "cpu", non_blocking=True
+            )
+            for offset in bank_offsets
+        ]
+        return {
+            "mask": mask.cpu(),
+            "bank_offsets": bank_offsets,
+            "kv_score": cpu_banks,
+        }
+
+    def _load_state_pool_from_cpu(
+        self,
+        pool: Optional[CompressStatePool],
+        state_cpu,
+        indices: torch.Tensor,
+    ) -> None:
+        if (
+            pool is None
+            or state_cpu is None
+            or self.full_to_swa_index_mapping is None
+            or len(indices) == 0
+        ):
+            return
+        old_mask = state_cpu["mask"].to(indices.device)
+        if not torch.any(old_mask):
+            return
+        swa_indices = self.full_to_swa_index_mapping[indices]
+        new_mask = swa_indices >= 0
+        row_mask = new_mask[old_mask]
+        if not torch.any(row_mask):
+            return
+        state_locs = pool.translate_from_swa_loc_to_state_loc(
+            swa_indices[old_mask][row_mask]
+        )
+        for bank_cpu, offset in zip(
+            state_cpu["kv_score"], state_cpu["bank_offsets"]
+        ):
+            pool.kv_score_buffer.kv_score[state_locs + offset] = bank_cpu[
+                row_mask.cpu()
+            ].to(pool.kv_score_buffer.kv_score.device, non_blocking=True)
+        pool.kv_score_buffer[-1].clear()
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        swa_cpu = None
+        swa_mask = None
+        if self.full_to_swa_index_mapping is not None and len(indices) > 0:
+            swa_indices = self.full_to_swa_index_mapping[indices]
+            swa_mask = swa_indices >= 0
+            if torch.any(swa_mask):
+                swa_cpu = self.swa_kv_pool.get_cpu_copy(swa_indices[swa_mask])
+                swa_mask = swa_mask.cpu()
+
+        c4_indices = self._compressed_indices_from_full_indices(indices, 4)
+        c128_indices = self._compressed_indices_from_full_indices(indices, 128)
+        c4_cpu = (
+            self.c4_kv_pool.get_cpu_copy(c4_indices)
+            if len(c4_indices) > 0
+            else None
+        )
+        c128_cpu = (
+            self.c128_kv_pool.get_cpu_copy(c128_indices)
+            if len(c128_indices) > 0
+            else None
+        )
+        c4_indexer_cpu = (
+            self.c4_indexer_kv_pool.get_cpu_copy(c4_indices)
+            if len(c4_indices) > 0
+            else None
+        )
+        state_cpu = [
+            self._copy_state_pool_to_cpu(pool, indices)
+            for pool in self.compress_state_pools
+        ]
+        indexer_state_cpu = [
+            self._copy_state_pool_to_cpu(pool, indices)
+            for pool in self.indexer_compress_state_pools
+        ]
+        current_platform.synchronize()
+        return {
+            "swa": swa_cpu,
+            "swa_mask": swa_mask,
+            "c4": c4_cpu,
+            "c4_indices_len": len(c4_indices),
+            "c128": c128_cpu,
+            "c128_indices_len": len(c128_indices),
+            "c4_indexer": c4_indexer_cpu,
+            "state": state_cpu,
+            "indexer_state": indexer_state_cpu,
+        }
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        swa_cpu = kv_cache_cpu["swa"]
+        if swa_cpu is not None and self.full_to_swa_index_mapping is not None:
+            swa_indices = self.full_to_swa_index_mapping[indices]
+            new_swa_mask = swa_indices >= 0
+            old_swa_mask = kv_cache_cpu.get("swa_mask")
+            if old_swa_mask is not None:
+                old_swa_mask = old_swa_mask.to(indices.device)
+                row_mask = new_swa_mask[old_swa_mask].cpu()
+                swa_indices = swa_indices[old_swa_mask][row_mask.to(indices.device)]
+            else:
+                row_mask = new_swa_mask.cpu()
+                swa_indices = swa_indices[new_swa_mask]
+            if swa_indices.numel() > 0:
+                swa_cpu = self._filter_layer_chunks(swa_cpu, row_mask)
+                self.swa_kv_pool.load_cpu_copy(swa_cpu, swa_indices)
+
+        c4_indices = self._compressed_indices_from_full_indices(indices, 4)
+        c128_indices = self._compressed_indices_from_full_indices(indices, 128)
+        if kv_cache_cpu["c4"] is not None and len(c4_indices) > 0:
+            c4_indices = c4_indices[: kv_cache_cpu["c4_indices_len"]]
+            self.c4_kv_pool.load_cpu_copy(kv_cache_cpu["c4"], c4_indices)
+        if kv_cache_cpu["c4_indexer"] is not None and len(c4_indices) > 0:
+            c4_indices = c4_indices[: kv_cache_cpu["c4_indices_len"]]
+            self.c4_indexer_kv_pool.load_cpu_copy(
+                kv_cache_cpu["c4_indexer"], c4_indices
+            )
+        if kv_cache_cpu["c128"] is not None and len(c128_indices) > 0:
+            c128_indices = c128_indices[: kv_cache_cpu["c128_indices_len"]]
+            self.c128_kv_pool.load_cpu_copy(kv_cache_cpu["c128"], c128_indices)
+
+        for pool, state_cpu in zip(self.compress_state_pools, kv_cache_cpu["state"]):
+            self._load_state_pool_from_cpu(pool, state_cpu, indices)
+        for pool, state_cpu in zip(
+            self.indexer_compress_state_pools, kv_cache_cpu["indexer_state"]
+        ):
+            self._load_state_pool_from_cpu(pool, state_cpu, indices)
+        current_platform.synchronize()
+
+    def _filter_layer_chunks(self, kv_cpu, row_mask: torch.Tensor):
+        if kv_cpu is None:
+            return None
+        if row_mask is None or bool(torch.all(row_mask).item()):
+            return kv_cpu
+        chunk_size = self.cpu_offloading_chunk_size
+        filtered = []
+        for layer_chunks in kv_cpu:
+            if len(layer_chunks) == 0:
+                filtered.append([])
+                continue
+            values_cpu = torch.cat([chunk[0] for chunk in layer_chunks], dim=0)
+            scales_cpu = torch.cat([chunk[1] for chunk in layer_chunks], dim=0)
+            values_cpu = values_cpu[row_mask]
+            scales_cpu = scales_cpu[row_mask]
+            filtered_layer = []
+            for i in range(0, len(values_cpu), chunk_size):
+                filtered_layer.append(
+                    (values_cpu[i : i + chunk_size], scales_cpu[i : i + chunk_size])
+                )
+            filtered.append(filtered_layer)
+        return filtered

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -643,6 +643,17 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if skip_attn_backend_init:
             self.mark_forward_metadata_ready()
 
+    # For Decode Context Parallel (DCP).
+    # Bool tensor of shape [num_tokens]; True at position i means the slot
+    # ``out_cache_loc[i]`` belongs to the current dcp rank and the writer
+    # kernel should actually persist this token's KV. Filled in ``init_new``
+    # only when ``model_runner.dcp_size > 1``; ``None`` otherwise.
+    dcp_kv_mask: Optional[torch.Tensor] = None
+
+    # Debug-only escape hatch for isolating CUDA graph issues on a specific
+    # forward without changing its semantic forward mode.
+    disable_cuda_graph_for_debug: bool = False
+
     @classmethod
     def init_new(
         cls,
@@ -898,11 +909,33 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if (
             getattr(model_runner, "dcp_size", 1) > 1
             and ret.out_cache_loc is not None
-            and is_hip()
         ):
-            ret.dcp_kv_mask = (
-                ret.positions % model_runner.dcp_size == model_runner.dcp_rank
-            )
+            dcp_positions = ret.positions
+            if (
+                dcp_positions is not None
+                and dcp_positions.numel() != ret.out_cache_loc.numel()
+                and ret.forward_mode.is_target_verify()
+            ):
+                bs = len(batch.seq_lens)
+                num_verify_tokens = ret.out_cache_loc.numel() // bs
+                if num_verify_tokens * bs == ret.out_cache_loc.numel():
+                    offsets = torch.arange(
+                        num_verify_tokens,
+                        dtype=batch.seq_lens.dtype,
+                        device=device,
+                    )
+                    dcp_positions = (
+                        batch.seq_lens[:, None] + offsets[None, :]
+                    ).reshape(-1)
+            if (
+                dcp_positions is not None
+                and dcp_positions.numel() == ret.out_cache_loc.numel()
+            ):
+                ret.dcp_kv_mask = (
+                    dcp_positions % model_runner.dcp_size == model_runner.dcp_rank
+                )
+            else:
+                ret.dcp_kv_mask = None
 
         return ret
 
@@ -1395,6 +1428,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if self.encoder_lens is not None:
             self.encoder_lens = self._pad_tensor_to_size(self.encoder_lens, bs)
         self.positions = self._pad_tensor_to_size(self.positions, num_tokens)
+        if self.dcp_kv_mask is not None:
+            self.dcp_kv_mask = self._pad_tensor_to_size(self.dcp_kv_mask, num_tokens)
         if self.mamba_track_indices is not None:
             self.mamba_track_indices = self._pad_tensor_to_size(
                 self.mamba_track_indices, bs
@@ -1494,6 +1529,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 logits_output.hidden_states = logits_output.hidden_states[:num_tokens]
             elif self.forward_mode.is_target_verify():  # verify
                 num_tokens = bs * self.spec_info.draft_token_num
+                if self.dcp_kv_mask is not None:
+                    self.dcp_kv_mask = self.dcp_kv_mask[:num_tokens]
                 if logits_output.next_token_logits is not None:
                     logits_output.next_token_logits = logits_output.next_token_logits[
                         :num_tokens

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -55,6 +55,7 @@ class MemoryPoolConfig:
     c4_max_total_num_tokens: int = 0
     c128_max_total_num_tokens: int = 0
     c4_state_pool_size: int = 0
+    c4_indexer_state_pool_size: int = 0
     c128_state_pool_size: int = 0
 
     mem_fraction_static: Optional[float] = None
@@ -518,6 +519,7 @@ class _DSV4PoolSizes:
     c4_max_total_num_tokens: int
     c128_max_total_num_tokens: int
     c4_state_pool_size: int
+    c4_indexer_state_pool_size: int
     c128_state_pool_size: int
 
 
@@ -664,12 +666,14 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
     def _compute_dsv4_sizes(self, full_token: int, page_size: int) -> _DSV4PoolSizes:
         full_token = full_token // page_size * page_size
         swa_tokens = int(full_token * self.swa_ratio) // page_size * page_size
+        c4_state_pool_size = swa_tokens // self.swa_page_size * self.c4_ring_size
         return _DSV4PoolSizes(
             full_max_total_num_tokens=full_token,
             swa_max_total_num_tokens=swa_tokens,
             c4_max_total_num_tokens=full_token // (4 * self.c4_shrink_factor),
             c128_max_total_num_tokens=full_token // 128,
-            c4_state_pool_size=swa_tokens // self.swa_page_size * self.c4_ring_size,
+            c4_state_pool_size=c4_state_pool_size,
+            c4_indexer_state_pool_size=c4_state_pool_size,
             c128_state_pool_size=0,
         )
 
@@ -721,6 +725,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             f"c4={sizes.c4_max_total_num_tokens}, "
             f"c128={sizes.c128_max_total_num_tokens}, "
             f"c4_state={sizes.c4_state_pool_size}, "
+            f"c4_indexer_state={sizes.c4_indexer_state_pool_size}, "
             f"c128_state={sizes.c128_state_pool_size}"
         )
         return MemoryPoolConfig(
@@ -730,6 +735,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             c4_max_total_num_tokens=sizes.c4_max_total_num_tokens,
             c128_max_total_num_tokens=sizes.c128_max_total_num_tokens,
             c4_state_pool_size=sizes.c4_state_pool_size,
+            c4_indexer_state_pool_size=sizes.c4_indexer_state_pool_size,
             c128_state_pool_size=sizes.c128_state_pool_size,
         )
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -38,6 +38,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
 from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.distributed import (
+    get_dcp_group_no_assert,
     get_pp_group,
     get_tp_group,
 )
@@ -64,7 +65,6 @@ from sglang.srt.layers.dp_attention import (
     _tbo_event,
     attn_tp_all_gather,
     attn_tp_all_reduce,
-    dp_gather_partial,
     dp_gather_replicate,
     dp_reduce_scatter_tensor,
     dp_reduce_scatterv_async,
@@ -192,6 +192,7 @@ def _get_mhc_ops() -> MhcOps:
 
 
 logger = logging.getLogger(__name__)
+
 
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 _MHC_POST_MULT_VALUE = 2.0
@@ -343,7 +344,10 @@ def deepseek_v4_attention_with_output(
     key_value = key_value[:real_num_tokens]
 
     original_out_cache_loc = forward_batch.out_cache_loc
+    original_dcp_kv_mask = forward_batch.dcp_kv_mask
     forward_batch.out_cache_loc = original_out_cache_loc[:real_num_tokens]
+    if original_dcp_kv_mask is not None:
+        forward_batch.dcp_kv_mask = original_dcp_kv_mask[:real_num_tokens]
 
     attn_backend = get_attn_backend()
     try:
@@ -359,6 +363,7 @@ def deepseek_v4_attention_with_output(
         )
     finally:
         forward_batch.out_cache_loc = original_out_cache_loc
+        forward_batch.dcp_kv_mask = original_dcp_kv_mask
 
     assert (
         output[:real_num_tokens].numel() == ret.numel()
@@ -695,6 +700,8 @@ class MQALayer(MqaAttentionBase):
             eps=self.eps,
             freqs_cis=self.freqs_cis,
             positions=positions,
+            dcp_kv_mask=forward_batch.dcp_kv_mask,
+            raw_loc=forward_batch.out_cache_loc,
         )
 
     def _compute_kv_bf16(
@@ -1165,6 +1172,29 @@ class MQALayer(MqaAttentionBase):
                 x_quant=x_quant,
             )
 
+        attn_q_base = q_out if q_out is not None else q
+        dcp_group = get_dcp_group_no_assert()
+        use_dcp = dcp_group is not None and dcp_group.world_size > 1
+        if use_dcp:
+            # DCP shards KV tokens across ranks, but every rank must evaluate
+            # attention for the same full set of query heads before the backend
+            # LSE-merge/reduce-scatter step. ``q_padded`` only has this rank's
+            # TP slice initialized, so gather local heads from the DCP group.
+            q_for_attn = dcp_group.all_gather(attn_q_base.contiguous(), dim=1)
+            attn_sink_for_attn = dcp_group.all_gather(
+                self._attn_sink_local[: self.n_local_heads].contiguous(), dim=0
+            )
+            if dcp_group.rank_in_group != 0:
+                # The sink is a global virtual KV item. Folding it into every
+                # DCP shard would count it multiple times during LSE merge.
+                attn_sink_for_attn = torch.full_like(
+                    attn_sink_for_attn,
+                    torch.finfo(attn_sink_for_attn.dtype).min,
+                )
+        else:
+            q_for_attn = q_padded if q_padded is not None else attn_q_base
+            attn_sink_for_attn = self._attn_sink_local
+
         # The cache write is always fused / already done by _forward_prepare* --
         # tell the backend to skip its own store_cache. When `kv is None`
         # (no DSA-CP), pass `q` as a sentinel for the `k is v` assert; the
@@ -1176,17 +1206,17 @@ class MQALayer(MqaAttentionBase):
 
         if is_unified_kv_triton():
             o = attn_backend.forward(
-                q=q_out if q_out is not None else q,
+                q=q_for_attn,
                 k=attn_k,
                 v=attn_k,
                 layer=self.attn_mqa,
                 forward_batch=forward_batch,
                 compress_ratio=self.compress_ratio,
-                attn_sink=self.attn_sink,
+                attn_sink=attn_sink_for_attn,
                 save_kv_cache=kv is not None,
             )
         else:
-            attn_q = q_padded if q_padded is not None else q
+            attn_q = q_for_attn
             save_kv_cache = False
             if forward_batch.forward_mode.is_extend() and is_in_breakable_cuda_graph():
                 o = attn_q.new_empty(
@@ -1198,7 +1228,7 @@ class MQALayer(MqaAttentionBase):
                     o,
                     self.attn_mqa.layer_id,
                     self.compress_ratio,
-                    self._attn_sink_local,
+                    attn_sink_for_attn,
                     save_kv_cache,
                 )
             else:
@@ -1209,10 +1239,17 @@ class MQALayer(MqaAttentionBase):
                     layer=self.attn_mqa,
                     forward_batch=forward_batch,
                     compress_ratio=self.compress_ratio,
-                    attn_sink=self._attn_sink_local,
+                    attn_sink=attn_sink_for_attn,
                     save_kv_cache=save_kv_cache,
                 )
             o = o[:, tp_slice, :]
+        if positions.shape[0] != o.shape[0]:
+            if o.shape[0] < positions.shape[0]:
+                raise RuntimeError(
+                    "DSV4 attention returned fewer tokens than requested: "
+                    f"output={o.shape[0]}, positions={positions.shape[0]}"
+                )
+            o = o[: positions.shape[0]]
         if _is_npu:
             v4_rope_inplace_npu(
                 o[..., -self.qk_rope_head_dim :],

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3095,9 +3095,9 @@ class ServerArgs:
         handle_pd_disaggregation(self)
 
     def _handle_dcp_validation(self):
-        # Decode context parallel (DCP) is currently implemented and validated
-        # only on AMD HIP/ROCm. Reject invalid or unverified configurations
-        # early instead of letting them fail deeper in model initialization.
+        # Decode context parallel (DCP) is implemented on AMD HIP/ROCm and
+        # CUDA. Reject invalid sizes or unsupported platforms early instead of
+        # letting them fail deeper in model initialization.
         if self.dcp_size < 1:
             raise ValueError(
                 "Decode context parallel size (--dcp-size / "
@@ -3106,24 +3106,14 @@ class ServerArgs:
             )
         if not self.dcp_size > 1:
             return
-        if is_hip():
+        if is_hip() or is_cuda():
             return
-        elif is_cuda():
-            if self.speculative_algorithm is not None:
-                raise ValueError(
-                    "Decode context parallel (--dcp-size / "
-                    "--decode-context-parallel-size > 1) on CUDA platform "
-                    "does not support any speculative algorithm, but got "
-                    f"dcp_size={self.dcp_size} on a CUDA platform with "
-                    "speculative decoding enabled."
-                )
-        else:
-            raise ValueError(
-                "Decode context parallel (--dcp-size / "
-                "--decode-context-parallel-size > 1) is currently only "
-                f"supported on the AMD HIP platform, but got dcp_size="
-                f"{self.dcp_size} on a non-HIP platform."
-            )
+        raise ValueError(
+            "Decode context parallel (--dcp-size / "
+            "--decode-context-parallel-size > 1) is currently only "
+            "supported on AMD HIP or CUDA platforms, but got dcp_size="
+            f"{self.dcp_size} on a non-HIP/CUDA platform."
+        )
 
     def _handle_load_balance_method(self):
         if self.disaggregation_mode not in ("null", "prefill", "decode"):
@@ -7376,6 +7366,30 @@ class ServerArgs:
             assert (
                 self.disable_overlap_schedule and self.speculative_algorithm is None
             ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+
+        if self.dcp_size > 1:
+            assert (
+                self.tp_size % self.dcp_size == 0
+            ), f"tp_size ({self.tp_size}) must be divisible by dcp_size ({self.dcp_size})"
+            assert (
+                self.pp_size == 1
+            ), "Decode context parallelism is not compatible with pipeline parallelism"
+            # DCP + PD disaggregation: only the mooncake transfer backend
+            # has been adapted to the per-rank physical offset remap
+            # (token-level RDMA path). Other backends still address GPU
+            # buffers using the cluster-wide global loc and would silently
+            # corrupt the transferred KV cache. Backends without DCP
+            # support also bail out at runtime via
+            # ``CommonKVManager._check_dcp_compat``; this assertion is the
+            # earlier, friendlier failure.
+            if self.disaggregation_mode != "null":
+                assert self.disaggregation_transfer_backend == "mooncake", (
+                    "Decode context parallelism (--dcp-size > 1) with PD "
+                    "disaggregation only supports "
+                    "--disaggregation-transfer-backend=mooncake right now "
+                    f"(got {self.disaggregation_transfer_backend!r}). Use "
+                    "--dcp-size 1 or switch to mooncake."
+                )
 
         assert not (
             self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -71,6 +71,7 @@ class EagleDraftInputBuffers(ForwardInputBuffers):
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
     dsa_seed_topk: Optional[torch.Tensor] = None
+    dcp_kv_mask: Optional[torch.Tensor] = None
 
 
 class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
@@ -189,6 +190,11 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
             topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
             topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
+            dcp_kv_mask = (
+                torch.zeros((self.max_num_token,), dtype=torch.bool)
+                if getattr(self.model_runner, "dcp_size", 1) > 1
+                else None
+            )
             draft_probs = (
                 torch.zeros(
                     (self.max_bs, self.model_runner.model_config.vocab_size),
@@ -261,6 +267,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
             dsa_seed_topk=dsa_seed_topk,
+            dcp_kv_mask=dcp_kv_mask,
         )
         self.buffers.share_buffers()
 
@@ -359,6 +366,11 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
         draft_probs = (
             buffers.draft_probs[:num_seqs] if buffers.draft_probs is not None else None
         )
+        dcp_kv_mask = (
+            buffers.dcp_kv_mask[:num_tokens]
+            if buffers.dcp_kv_mask is not None
+            else None
+        )
 
         if self.require_mlp_tp_gather:
             global_num_tokens_cpu = [num_tokens] * self.attn_dp_size
@@ -434,6 +446,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             sampling_info=sampling_info,
             rids_int=rids_int,
             bootstrap_room_ids_int=bootstrap_room_ids_int,
+            dcp_kv_mask=dcp_kv_mask,
             capture_hidden_mode=(
                 spec_info.capture_hidden_mode if spec_info else CaptureHiddenMode.NULL
             ),
@@ -504,6 +517,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
 
         raw_bs = forward_batch.batch_size
         raw_num_token = raw_bs * self.captured_req_width
+        raw_out_cache_loc = forward_batch.out_cache_loc
 
         # Pad to nearest captured shape
         if self.require_mlp_tp_gather:
@@ -535,6 +549,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             if buffers.dsa_seed_topk is not None:
                 buffers.dsa_seed_topk.zero_()
             buffers.req_pool_indices.zero_()
+            if buffers.dcp_kv_mask is not None:
+                buffers.dcp_kv_mask.zero_()
 
         num_tokens = bs * self.captured_req_width
 
@@ -599,6 +615,11 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
                 buffers.dsa_seed_topk[:raw_bs].copy_(seed)
             else:
                 buffers.dsa_seed_topk[:raw_bs].zero_()
+        if buffers.dcp_kv_mask is not None:
+            if forward_batch.dcp_kv_mask is not None:
+                buffers.dcp_kv_mask[:raw_num_token].copy_(forward_batch.dcp_kv_mask)
+            else:
+                buffers.dcp_kv_mask[:raw_num_token].zero_()
         # Only rejection sampling reads temperatures (renorm_draft_probs); skip
         # the copy otherwise to keep the non-RS path free of extra work.
         if (
@@ -626,6 +647,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             forward_batch.seq_lens = buffers.seq_lens[:bs]
             forward_batch.req_pool_indices = buffers.req_pool_indices[:bs]
             forward_batch.positions = buffers.positions[:num_tokens]
+            if buffers.dcp_kv_mask is not None:
+                forward_batch.dcp_kv_mask = buffers.dcp_kv_mask[:num_tokens]
             if raw_seq_lens_sum is not None:
                 forward_batch.seq_lens_sum = (
                     raw_seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value
@@ -646,20 +669,31 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             buffers.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
             forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:bs]
 
-        # forward_batch.batch_size was overwritten to bs above when padding.
-        self.draft_attn_backend.init_forward_metadata_out_graph(forward_batch)
-        self.raw_bs = raw_bs
-        self.bs = bs
+        # Metadata and the captured graph must read the padded static buffer.
+        # Padding the batch dimension expands the all-step flat buffer to
+        # bs * topk * num_steps entries.
+        forward_batch.out_cache_loc = buffers.out_cache_loc[
+            : num_tokens * self.speculative_num_steps
+        ]
+        try:
+            # forward_batch.batch_size was overwritten to bs above when padding.
+            self.draft_attn_backend.init_forward_metadata_out_graph(forward_batch)
+            self.raw_bs = raw_bs
+            self.bs = bs
 
-        # Replay via backend
-        shape_key = self._make_graph_key(bs)
-        timer_ctx = (
-            self.model_runner.device_timer.wrap(metadata={"category": "eagle_draft"})
-            if self.model_runner.device_timer
-            else contextlib.nullcontext()
-        )
-        with timer_ctx:
-            out = self._replay_graph(shape_key, forward_batch)
+            # Replay via backend
+            shape_key = self._make_graph_key(bs)
+            timer_ctx = (
+                self.model_runner.device_timer.wrap(
+                    metadata={"category": "eagle_draft"}
+                )
+                if self.model_runner.device_timer
+                else contextlib.nullcontext()
+            )
+            with timer_ctx:
+                out = self._replay_graph(shape_key, forward_batch)
+        finally:
+            forward_batch.out_cache_loc = raw_out_cache_loc
         if self.buffers.dsa_seed_topk is not None:
             forward_batch.spec_info.dsa_topk_indices = None
 
@@ -669,6 +703,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             forward_batch.positions = buffers.positions[:raw_num_token]
             forward_batch.seq_lens = buffers.seq_lens[:raw_bs]
             forward_batch.req_pool_indices = buffers.req_pool_indices[:raw_bs]
+            if buffers.dcp_kv_mask is not None:
+                forward_batch.dcp_kv_mask = buffers.dcp_kv_mask[:raw_num_token]
             if buffers.rids_int is not None and forward_batch.rids_int is not None:
                 forward_batch.rids_int = buffers.rids_int[:raw_bs]
             if (

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -73,6 +73,7 @@ class EagleDraftExtendInputBuffers(ForwardInputBuffers):
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
     dsa_seed_topk_capture: Optional[torch.Tensor] = None
+    dcp_kv_mask: Optional[torch.Tensor] = None
 
 
 class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
@@ -194,6 +195,11 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             num_accept_tokens = torch.full(
                 (self.max_bs,), self.captured_req_width, dtype=torch.int32
             )
+            dcp_kv_mask = (
+                torch.zeros((self.max_num_token,), dtype=torch.bool)
+                if getattr(self.model_runner, "dcp_size", 1) > 1
+                else None
+            )
 
             if self.require_gathered_buffer:
                 if self.require_mlp_tp_gather:
@@ -266,6 +272,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
             dsa_seed_topk_capture=dsa_seed_topk_capture,
+            dcp_kv_mask=dcp_kv_mask,
         )
         self.buffers.share_buffers()
 
@@ -346,6 +353,11 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         num_correct_drafts = buffers.num_correct_drafts[:bs]
         num_accept_tokens = buffers.num_accept_tokens[:bs]
         next_token_logits_buffer = buffers.next_token_logits_buffer[:num_tokens]
+        dcp_kv_mask = (
+            buffers.dcp_kv_mask[:num_tokens]
+            if buffers.dcp_kv_mask is not None
+            else None
+        )
 
         # pruned_states = num_tokens (all tokens)
         num_tokens_for_logprob = num_tokens
@@ -406,6 +418,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
             capture_hidden_mode=CaptureHiddenMode.LAST,
+            dcp_kv_mask=dcp_kv_mask,
         )
 
         if self.buffers.dsa_seed_topk_capture is not None:
@@ -510,6 +523,8 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             buffers.num_correct_drafts.fill_(self.captured_req_width)
             buffers.num_accept_tokens.fill_(self.captured_req_width)
             buffers.extend_seq_lens.fill_(self.captured_req_width)
+            if buffers.dcp_kv_mask is not None:
+                buffers.dcp_kv_mask.zero_()
 
         # Batch the small per-field device copies into a grouped foreach copy
         # (one foreach call per dtype pair) to cut launch overhead. hidden_states
@@ -543,6 +558,13 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
 
         # hidden_states is large + contiguous: copy_() uses the cudaMemcpyAsync
         # DMA engine; foreach would force the ~3x slower compute-kernel copy.
+        if (
+            buffers.dcp_kv_mask is not None
+            and forward_batch.dcp_kv_mask is not None
+        ):
+            buffers.dcp_kv_mask[:num_tokens].copy_(forward_batch.dcp_kv_mask)
+        elif buffers.dcp_kv_mask is not None:
+            buffers.dcp_kv_mask[:num_tokens].zero_()
         if (
             buffers.hidden_states is not None
             and forward_batch.spec_info.hidden_states is not None
@@ -603,6 +625,11 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             out_cache_loc=buffers.out_cache_loc[:num_tokens],
             out_cache_loc_dsv4=getattr(forward_batch, "out_cache_loc_dsv4", None),
             spec_info=forward_batch.spec_info,
+            dcp_kv_mask=(
+                buffers.dcp_kv_mask[:num_tokens]
+                if buffers.dcp_kv_mask is not None
+                else None
+            ),
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -106,6 +106,7 @@ class MultiLayerEagleDraftExtendInputBuffers(ForwardInputBuffers):
     next_token_logits_buffer: torch.Tensor
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
+    dcp_kv_mask: Optional[torch.Tensor]
 
 
 class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
@@ -246,6 +247,11 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         mrope_positions = buffers.mrope_positions[:, :num_tokens]
         hidden_states = buffers.hidden_states[:num_tokens]
         next_token_logits_buffer = buffers.next_token_logits_buffer[:num_tokens]
+        dcp_kv_mask = (
+            buffers.dcp_kv_mask[:num_tokens]
+            if buffers.dcp_kv_mask is not None
+            else None
+        )
 
         if self.require_mlp_tp_gather:
             global_num_tokens_cpu = [num_tokens] * self.dp_size
@@ -318,6 +324,7 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             extend_num_tokens=self.captured_req_width * bs,
             num_token_non_padded_cpu=self.captured_req_width * bs,
             return_hidden_states_before_norm=True,
+            dcp_kv_mask=dcp_kv_mask,
         )
         return forward_batch
 
@@ -434,6 +441,11 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             # per-step write target; out_cache_loc is frozen at prepare() time.
             out_cache_loc=buffers.out_cache_loc[:num_tokens],
             spec_info=spec_info,
+            dcp_kv_mask=(
+                buffers.dcp_kv_mask[:num_tokens]
+                if buffers.dcp_kv_mask is not None
+                else None
+            ),
         )
         self.eagle_worker.draft_extend_attn_backend_list[
             self.step
@@ -584,6 +596,11 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
             next_token_logits_buffer = torch.zeros(
                 (max_num_token, vocab_size), dtype=torch.float
             )
+            dcp_kv_mask = (
+                torch.zeros((max_num_token,), dtype=torch.bool)
+                if getattr(model_runner, "dcp_size", 1) > 1
+                else None
+            )
 
             if self.require_gathered_buffer:
                 if self.require_mlp_tp_gather:
@@ -618,6 +635,7 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
             next_token_logits_buffer=next_token_logits_buffer,
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
+            dcp_kv_mask=dcp_kv_mask,
         )
 
     def _prepare_extra(self, forward_batch: ForwardBatch) -> None:
@@ -663,6 +681,12 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
         buffers.num_accept_tokens[:raw_bs].copy_(
             forward_batch.spec_info.num_accept_tokens
         )
+
+        if buffers.dcp_kv_mask is not None:
+            if forward_batch.dcp_kv_mask is not None:
+                buffers.dcp_kv_mask[:num_tokens].copy_(forward_batch.dcp_kv_mask)
+            else:
+                buffers.dcp_kv_mask[:num_tokens].zero_()
 
         # Refresh the host mirror only when published; hand replay None
         # otherwise so no consumer reads a stale buffer.

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -650,9 +650,17 @@ def move_accept_tokens_to_target_kvcache(
         accept_out_cache_loc,
         size,
     )
-    token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
-        tgt_cache_loc, accept_out_cache_loc
-    )
+    kvcache = token_to_kv_pool_allocator.get_kvcache()
+    move_accepted_kv_cache = getattr(kvcache, "move_accepted_kv_cache", None)
+    if move_accepted_kv_cache is not None:
+        accept_offsets = torch.arange(
+            accept_index.shape[1], dtype=batch.seq_lens.dtype, device=device
+        )
+        accepted_seq_lens = batch.seq_lens[:, None] + accept_offsets[None, :] + 1
+        accepted_seq_lens = accepted_seq_lens[accept_index != -1]
+        move_accepted_kv_cache(tgt_cache_loc, accept_out_cache_loc, accepted_seq_lens)
+    else:
+        kvcache.move_kv_cache(tgt_cache_loc, accept_out_cache_loc)
 
 
 def prepare_mamba_track_for_verify(batch: ScheduleBatch) -> None:


### PR DESCRIPTION
## Summary

- Adapt DeepSeek V4 attention, compression, KV cache allocation, metadata, and CUDA graph paths to the existing DCP infrastructure.
- Correct DCP-aware memory-pool sizing and token-index handling.

This is PR 1/5 in the DSV4 DCP series.

## Validation

Focused DCP unit tests and an H20 Kubernetes smoke test.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->