### PR TITLE
feat(disagg): add Mooncake transfer diagnostics

### DIFF
--- a/docs_new/docs/advanced_features/pd_disaggregation.mdx
+++ b/docs_new/docs/advanced_features/pd_disaggregation.mdx
@@ -226,11 +226,15 @@ Please be aware that this setting will cause prefill instances to take a longer 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Timeout (seconds) for receiving KV Cache after request initialization</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`300`</td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>**`SGLANG_DISAGGREGATION_KV_TRANSFER_CHUNK_SIZE`**</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum KV indices in one Mooncake transfer work item. Set this for long cached prefixes to avoid one oversized synchronous transfer; <code>0</code> disables splitting.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`0`</td>
+    </tr>
   </tbody>
 </table>
 
 If a greater mean TTFT is acceptable, you can `export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600` (10 minutes) to relax the timeout condition.
-
 
 ## Heterogeneous TP with GPU Staging Buffer
 

--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -1409,6 +1409,11 @@ SGLang supports various environment variables that can be used to configure its 
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>4</code></td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DISAGGREGATION_KV_TRANSFER_CHUNK_SIZE</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum number of KV indices in one Mooncake transfer work item. <code>0</code> disables splitting.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>0</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Timeout (seconds) for the disaggregation bootstrap handshake.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>300</code></td>

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c128_online_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c128_online_v2.cuh
@@ -732,6 +732,7 @@ struct OnlinePrefillStage1Params {
   const int32_t* __restrict__ req_to_token;      // (num_reqs, max_tokens)
   int64_t stride_r2t;
   int32_t state_slot_offset;
+  uint32_t active_bs;
   uint32_t num_c;
   uint32_t num_w;
 };
@@ -746,6 +747,10 @@ __global__ void plan_c128_online_prefill_kernel(const OnlinePrefillStage1Params 
   auto plan = *plan_ptr;
   if (plan.is_invalid()) return;
   const auto batch_id = plan.read_page_0;
+  if (batch_id >= params.active_bs) {
+    *plan_ptr = CompressPlan::invalid();
+    return;
+  }
   const auto rid = params.req_pool_indices[batch_id];
   const int32_t main_slot = static_cast<int32_t>(rid);
   plan.read_page_0 = main_slot + params.state_slot_offset;
@@ -765,7 +770,8 @@ inline OnlinePrefillPlan plan_online_prefill(
     const tvm::ffi::TensorView plan_c_dev_,
     const tvm::ffi::TensorView plan_w_dev_,
     const int32_t state_slot_offset,
-    const bool use_cuda_graph) {
+    const bool use_cuda_graph,
+    const int32_t active_bs) {
   auto B = SymbolicSize{"batch_size"};
   auto N = SymbolicSize{"num_q_tokens"};
   auto cpu = SymbolicDevice{};
@@ -797,6 +803,8 @@ inline OnlinePrefillPlan plan_online_prefill(
       .verify(plan_c_dev_)
       .verify(plan_w_dev_);
   RuntimeCheck(state_slot_offset >= 0);
+  RuntimeCheck(active_bs >= 0);
+  RuntimeCheck(active_bs <= B.unwrap());
 
   const auto stage0_params = OnlinePrefillStage0Params{
       .plan_c = static_cast<CompressPlan*>(plan_c_pin.data_ptr()),
@@ -913,6 +921,7 @@ inline OnlinePrefillPlan plan_online_prefill(
         .req_to_token = static_cast<const int32_t*>(req_to_token.data_ptr()),
         .stride_r2t = req_to_token.stride(0),
         .state_slot_offset = state_slot_offset,
+        .active_bs = static_cast<uint32_t>(active_bs),
         .num_c = num_c_padded,
         .num_w = num_w_padded,
     };

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
@@ -42,6 +42,7 @@ struct Prefill0Params {
   const IDX_T* seq_lens_ptr;     // [batch_size]
   const IDX_T* extend_lens_ptr;  // [batch_size]
   uint32_t batch_size;
+  uint32_t active_bs;
   uint32_t num_q_tokens;
   int32_t compress_ratio;
   int32_t swa_page_size;
@@ -60,6 +61,7 @@ struct Prefill1Params {
   uint32_t num_c_padded;
   uint32_t num_w_padded;
   uint32_t num_work;
+  uint32_t active_bs;
   int32_t swa_page_size;
   int32_t ring_size;
   int32_t compress_ratio;
@@ -139,7 +141,7 @@ __global__ __launch_bounds__(1024, 1)  //
 
   // === Stage A: load per-batch fields, init shared scratch ===
   int32_t seq_len = 0, extend_len = 0, prefix_len = 0;
-  if (tx < params.batch_size) {
+  if (tx < params.active_bs) {
     seq_len = static_cast<int32_t>(params.seq_lens_ptr[tx]);
     extend_len = static_cast<int32_t>(params.extend_lens_ptr[tx]);
     prefix_len = seq_len - extend_len;
@@ -156,9 +158,10 @@ __global__ __launch_bounds__(1024, 1)  //
   }
 
   // === Stage B: min/max(extend_len) for MTP-uniform detection ===
-  // For min, treat threads outside `batch_size` as +inf so they don't pull the min down.
+  // For min, treat padded graph slots outside `active_bs` as +inf so they
+  // don't pull the min down or read uninitialized padded metadata.
   const uint32_t e_for_max = static_cast<uint32_t>(extend_len);
-  const uint32_t e_for_min = (tx < params.batch_size) ? e_for_max : 0xFFFFFFFFu;
+  const uint32_t e_for_min = (tx < params.active_bs) ? e_for_max : 0xFFFFFFFFu;
   warp_max[warp_id] = warp::reduce_max(e_for_max);
   warp_min[warp_id] = warp::reduce_min(e_for_min);
   __syncthreads();
@@ -183,6 +186,7 @@ __global__ __launch_bounds__(1024, 1)  //
     const uint32_t num_real_q = params.batch_size * E;
     for (uint32_t k = tx; k < num_real_q; k += block_size) {
       const uint32_t batch_id = k / E;
+      if (batch_id >= params.active_bs) continue;
       const uint32_t j = k % E;
       const int32_t pl = s_prefix_len[batch_id];
       const int32_t sl = s_seq_len[batch_id];
@@ -192,13 +196,15 @@ __global__ __launch_bounds__(1024, 1)  //
       if ((position + 1) % cr == 0) {
         const int32_t buffer_len = window_size - min(static_cast<int32_t>(j) + 1, window_size);
         const uint32_t out_idx = atomicAdd(&counter_c, 1u);
-        params.plan_c[out_idx] = {
-            .seq_len = static_cast<uint32_t>(position + 1),
-            .ragged_id = static_cast<uint16_t>(ragged_id),
-            .buffer_len = static_cast<uint16_t>(buffer_len),
-            .read_page_0 = -1,
-            .read_page_1 = static_cast<int32_t>(batch_id),
-        };
+        if (out_idx < num_q) {
+          params.plan_c[out_idx] = {
+              .seq_len = static_cast<uint32_t>(position + 1),
+              .ragged_id = static_cast<uint16_t>(ragged_id),
+              .buffer_len = static_cast<uint16_t>(buffer_len),
+              .read_page_0 = -1,
+              .read_page_1 = static_cast<int32_t>(batch_id),
+          };
+        }
       }
 
       const int32_t last_c_pos = (sl / cr) * cr;
@@ -207,14 +213,16 @@ __global__ __launch_bounds__(1024, 1)  //
       if (!do_write && is_overlap) do_write = (position % sps) >= (sps - cr);
       if (do_write) {
         const uint32_t out_idx = atomicAdd(&counter_w, 1u);
-        params.plan_w[out_idx] = pack_w(ragged_id, batch_id, position + 1);
+        if (out_idx < num_q) {
+          params.plan_w[out_idx] = pack_w(ragged_id, batch_id, position + 1);
+        }
       }
     }
   } else {
     // Path 2: general prefill (long extend_len). Iterate batches in an outer loop;
     // the whole block sweeps each batch's tokens in parallel.
     uint32_t base_e = 0;
-    for (uint32_t batch_id = 0; batch_id < params.batch_size; ++batch_id) {
+    for (uint32_t batch_id = 0; batch_id < params.active_bs; ++batch_id) {
       const int32_t pl = s_prefix_len[batch_id];
       const int32_t sl = s_seq_len[batch_id];
       const int32_t el = sl - pl;
@@ -227,20 +235,24 @@ __global__ __launch_bounds__(1024, 1)  //
         if ((position + 1) % cr == 0) {
           const int32_t buffer_len = window_size - min(j + 1, window_size);
           const uint32_t out_idx = atomicAdd(&counter_c, 1u);
-          params.plan_c[out_idx] = {
-              .seq_len = static_cast<uint32_t>(position + 1),
-              .ragged_id = static_cast<uint16_t>(ragged_id),
-              .buffer_len = static_cast<uint16_t>(buffer_len),
-              .read_page_0 = -1,
-              .read_page_1 = static_cast<int32_t>(batch_id),
-          };
+          if (out_idx < num_q) {
+            params.plan_c[out_idx] = {
+                .seq_len = static_cast<uint32_t>(position + 1),
+                .ragged_id = static_cast<uint16_t>(ragged_id),
+                .buffer_len = static_cast<uint16_t>(buffer_len),
+                .read_page_0 = -1,
+                .read_page_1 = static_cast<int32_t>(batch_id),
+            };
+          }
         }
 
         bool do_write = position >= first_w_pos;
         if (!do_write && is_overlap) do_write = (position % sps) >= (sps - cr);
         if (do_write) {
           const uint32_t out_idx = atomicAdd(&counter_w, 1u);
-          params.plan_w[out_idx] = pack_w(ragged_id, static_cast<uint32_t>(batch_id), position + 1);
+          if (out_idx < num_q) {
+            params.plan_w[out_idx] = pack_w(ragged_id, static_cast<uint32_t>(batch_id), position + 1);
+          }
         }
       }
       base_e += static_cast<uint32_t>(el);
@@ -249,8 +261,8 @@ __global__ __launch_bounds__(1024, 1)  //
   __syncthreads();
 
   // === Stage D: pad [counter_c, num_q) / [counter_w, num_q) with invalid ===
-  const auto total_c = counter_c;
-  const auto total_w = counter_w;
+  const auto total_c = min(counter_c, num_q);
+  const auto total_w = min(counter_w, num_q);
   for (uint32_t k = total_c + tx; k < num_q; k += block_size) {
     params.plan_c[k] = PlanC::invalid();
   }
@@ -276,8 +288,10 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
   };
 
   if (!plan_c.is_invalid()) {  // 1. in bound. 2. not masked
-    if (plan_c.buffer_len > 0) {
-      const auto batch_id = plan_c.read_page_1;
+    const auto batch_id = plan_c.read_page_1;
+    if (batch_id >= params.active_bs) {
+      params.plan_c[idx] = PlanC::invalid();
+    } else if (plan_c.buffer_len > 0) {
       const auto rid = params.rid_ptr[batch_id];
       const auto mapping = params.r2t_ptr + rid * params.stride_r2t;
       // `seq_len` should be ratio-aligned here
@@ -294,8 +308,8 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
         const auto state_loc_1 = params.f2s_ptr[raw_loc_1];
         plan_c.read_page_0 = compute_loc(state_loc_0) / params.compress_ratio;
         plan_c.read_page_1 = compute_loc(state_loc_1) / params.compress_ratio;
+        params.plan_c[idx] = plan_c;
       }
-      params.plan_c[idx] = plan_c;
     }
   } else if (idx < params.num_c_padded) {
     params.plan_c[idx] = PlanC::invalid();
@@ -462,7 +476,8 @@ inline PrefillPlan plan_compress_prefill(
     const int32_t compress_ratio,
     const int32_t swa_page_size,
     const int32_t ring_size,
-    const bool use_cuda_graph) {
+    const bool use_cuda_graph,
+    const int32_t active_bs) {
   auto B = SymbolicSize{"batch_size"};
   auto N = SymbolicSize{"num_q_tokens"};
   auto cpu_or_gpu = SymbolicDevice{};
@@ -504,7 +519,9 @@ inline PrefillPlan plan_compress_prefill(
   const auto batch_size = static_cast<uint32_t>(B.unwrap());
   constexpr auto kMaxTokens = static_cast<uint32_t>(std::numeric_limits<uint16_t>::max());
   RuntimeCheck(compress_ratio == 4 || compress_ratio == 128);
-  RuntimeCheck(batch_size <= num_q_tokens && num_q_tokens <= kMaxTokens);
+  RuntimeCheck(active_bs >= 0);
+  RuntimeCheck(static_cast<uint32_t>(active_bs) <= batch_size);
+  RuntimeCheck(static_cast<uint32_t>(active_bs) <= num_q_tokens && num_q_tokens <= kMaxTokens);
   // `swa_page_size` >= `ring_size` >= `compress_ratio`
   RuntimeCheck(swa_page_size % ring_size == 0 && ring_size % compress_ratio == 0);
 
@@ -528,6 +545,7 @@ inline PrefillPlan plan_compress_prefill(
         .seq_lens_ptr = seq_ptr,
         .extend_lens_ptr = ext_ptr,
         .batch_size = batch_size,
+        .active_bs = static_cast<uint32_t>(active_bs),
         .num_q_tokens = num_q_tokens,
         .compress_ratio = compress_ratio,
         .swa_page_size = swa_page_size,
@@ -547,6 +565,7 @@ inline PrefillPlan plan_compress_prefill(
         .num_c_padded = num_q_tokens,
         .num_w_padded = num_q_tokens,
         .num_work = num_q_tokens,
+        .active_bs = static_cast<uint32_t>(active_bs),
         .swa_page_size = swa_page_size,
         .ring_size = ring_size,
         .compress_ratio = compress_ratio,
@@ -568,7 +587,7 @@ inline PrefillPlan plan_compress_prefill(
   uint32_t counter_w = 0;
 
   const auto should_compress = [=](int32_t position) { return (position + 1) % compress_ratio == 0; };
-  for (const auto i : irange(batch_size)) {
+  for (const auto i : irange(static_cast<uint32_t>(active_bs))) {
     const int32_t seq_len = seq_ptr[i];
     const int32_t extend_len = ext_ptr[i];
     const int32_t prefix_len = seq_len - extend_len;
@@ -599,7 +618,7 @@ inline PrefillPlan plan_compress_prefill(
     }
     counter += extend_len;
   }
-  RuntimeCheck(counter == num_q_tokens);
+  RuntimeCheck(counter <= num_q_tokens);
 
   const auto copy_to_device = [stream](void* cuda_ptr, auto* host_ptr, size_t count) {
     const auto size_bytes = count * sizeof(*host_ptr);
@@ -623,6 +642,7 @@ inline PrefillPlan plan_compress_prefill(
       .num_c_padded = num_c_padded,
       .num_w_padded = num_w_padded,
       .num_work = std::max(num_c_padded, num_w_padded),
+      .active_bs = static_cast<uint32_t>(active_bs),
       .swa_page_size = swa_page_size,
       .ring_size = ring_size,
       .compress_ratio = compress_ratio,

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/fused_norm_rope_v2.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/fused_norm_rope_v2.cuh
@@ -49,12 +49,25 @@ struct FusedNormRopeStoreParams {
   float eps;
   uint32_t compress_ratio;
   uint32_t num_tokens;
+  int32_t dcp_world_size;
+  int32_t dcp_rank;
 };
 
 enum class ForwardMode : bool {
   CompressExtend = 0,
   CompressDecode = 1,
 };
+
+SGL_DEVICE int32_t map_dcp_token_loc(
+    const int32_t loc,
+    const int32_t dcp_world_size,
+    const int32_t dcp_rank) {
+  if (loc < 0) return -1;
+  if (dcp_world_size <= 1) return loc;
+  if (loc == 0) return -1;
+  if (loc % dcp_world_size != dcp_rank) return -1;
+  return loc / dcp_world_size;
+}
 
 #define INDEXER_KERNEL __global__ __launch_bounds__(kBlockSize, 8)
 #define FLASHMLA_KERNEL __global__ __launch_bounds__(kBlockSize, 8)
@@ -98,12 +111,15 @@ INDEXER_KERNEL void fused_norm_rope_indexer(const __grid_constant__ FusedNormRop
     out_loc = params.out_loc[plan.ragged_id];
   } else if constexpr (kMode == CompressDecode) {
     const auto plan = static_cast<const PlanD*>(params.handle)[work_id];
+    if (plan.write_loc < 0 || plan.read_page_0 < 0) return;
     if (plan.seq_len % params.compress_ratio != 0) return;
     position = plan.seq_len - params.compress_ratio;
     out_loc = params.out_loc[work_id];
   } else {
     static_assert(host::dependent_false_v<DType>, "Unsupported Mode");
   }
+  out_loc = map_dcp_token_loc(out_loc, params.dcp_world_size, params.dcp_rank);
+  if (out_loc < 0) return;
   const auto freqs_cis = params.freqs_cis + position * kRopeDim;
 
   PDLWaitPrimary<kUsePDL>();
@@ -406,12 +422,15 @@ FLASHMLA_KERNEL void fused_norm_rope_flashmla(const __grid_constant__ FusedNormR
     out_loc = params.out_loc[plan.ragged_id];
   } else if constexpr (kMode == CompressDecode) {
     const auto plan = static_cast<const PlanD*>(params.handle)[work_id];
+    if (plan.write_loc < 0 || plan.read_page_0 < 0) return;
     if (plan.seq_len % params.compress_ratio != 0) return;
     position = plan.seq_len - params.compress_ratio;
     out_loc = params.out_loc[work_id];
   } else {
     static_assert(host::dependent_false_v<DType>, "Unsupported Mode");
   }
+  out_loc = map_dcp_token_loc(out_loc, params.dcp_world_size, params.dcp_rank);
+  if (out_loc < 0) return;
   const auto freqs_cis = params.freqs_cis + position * kRopeDim;
 
   PDLWaitPrimary<kUsePDL>();
@@ -537,7 +556,9 @@ struct FusedNormRopeKernel {
       const tvm::ffi::TensorView out_loc,
       const tvm::ffi::TensorView kvcache,
       const bool is_decode,
-      const uint32_t compress_ratio) {
+      const uint32_t compress_ratio,
+      const int32_t dcp_world_size,
+      const int32_t dcp_rank) {
     using namespace host;
     using enum ForwardMode;
 
@@ -579,6 +600,8 @@ struct FusedNormRopeKernel {
         RuntimeCheck(out_loc.size(0) == N.unwrap());
         break;
     }
+    RuntimeCheck(dcp_world_size >= 1);
+    RuntimeCheck(dcp_rank >= 0 && dcp_rank < dcp_world_size);
 
     const auto num_tokens = static_cast<uint32_t>(N.unwrap());
     if (num_tokens == 0) return;
@@ -592,6 +615,8 @@ struct FusedNormRopeKernel {
         .eps = eps,
         .compress_ratio = compress_ratio,
         .num_tokens = num_tokens,
+        .dcp_world_size = dcp_world_size,
+        .dcp_rank = dcp_rank,
     };
     // Indexer packs `kNumWarps` tokens per block (warp-major); FlashMLA uses
     // a whole block per token (cta-major sum-reduce over head_dim=512).

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/online_c128_mtp.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/online_c128_mtp.cuh
@@ -34,6 +34,7 @@ struct OnlineC128MTPWritePrefixParams {
   int64_t layer_bs;
   int64_t num_verify_tokens;
   int64_t state_slot_stride;
+  int64_t max_num_reqs;
 };
 
 template <typename TSeq, typename TReq>
@@ -87,6 +88,7 @@ online_c128_mtp_commit_pending_kernel(const OnlineC128MTPCommitPendingParams<TSe
   if (old_seq < 0) return;
 
   const int64_t cur_seq = static_cast<int64_t>(params.cur_seq_lens[bid]);
+  if (cur_seq < 0) return;
   const int64_t accept = clamp_accept_len(cur_seq - old_seq, params.num_verify_tokens);
   if (accept <= 0) return;
 
@@ -110,6 +112,7 @@ online_c128_mtp_write_prefix_kernel(const OnlineC128MTPWritePrefixParams<TSeq, T
 
   const int64_t seq_before = static_cast<int64_t>(params.seq_lens[bid]);
   const int64_t req_idx = static_cast<int64_t>(params.req_pool_indices[bid]);
+  if (seq_before < 0 || req_idx < 0 || req_idx >= params.max_num_reqs) return;
   const int64_t start_pos = seq_before & 127;
   const bool has_partial = seq_before > 0 && start_pos != 0;
 
@@ -207,6 +210,7 @@ struct OnlineC128MTPWritePrefixKernel {
       int64_t layer_bs,
       int64_t num_verify_tokens,
       int64_t state_slot_stride,
+      int64_t max_num_reqs,
       DLDevice device) {
     using namespace host;
 
@@ -224,6 +228,7 @@ struct OnlineC128MTPWritePrefixKernel {
         .layer_bs = layer_bs,
         .num_verify_tokens = num_verify_tokens,
         .state_slot_stride = state_slot_stride,
+        .max_num_reqs = max_num_reqs,
     };
 
     static_assert(kHeadDim == 512, "online c128 MTP write-prefix only supports head_dim=512");
@@ -241,7 +246,8 @@ struct OnlineC128MTPWritePrefixKernel {
       tvm::ffi::TensorView state,
       int64_t layer_bs,
       int64_t num_verify_tokens,
-      int64_t state_slot_stride) {
+      int64_t state_slot_stride,
+      int64_t max_num_reqs) {
     using namespace host;
 
     auto device = SymbolicDevice{};
@@ -260,6 +266,11 @@ struct OnlineC128MTPWritePrefixKernel {
     RuntimeCheck(layer_bs <= seq_lens.shape()[0], "layer_bs exceeds seq_lens rows");
     RuntimeCheck(layer_bs <= req_pool_indices.shape()[0], "layer_bs exceeds req_pool_indices rows");
     RuntimeCheck(layer_bs * num_verify_tokens <= kv_score_input.shape()[0], "kv_score_input is too small");
+    RuntimeCheck(max_num_reqs > 0, "max_num_reqs must be positive");
+    RuntimeCheck(max_num_reqs <= req_to_token.shape()[0], "max_num_reqs exceeds req_to_token rows");
+    RuntimeCheck(
+        state_slot_stride * (num_verify_tokens + 1) <= state.shape()[0],
+        "state buffer is too small for online MTP slots");
 
     launch(
         kv_score_input,
@@ -271,6 +282,7 @@ struct OnlineC128MTPWritePrefixKernel {
         layer_bs,
         num_verify_tokens,
         state_slot_stride,
+        max_num_reqs,
         device.unwrap());
   }
 };
@@ -387,6 +399,10 @@ struct OnlineC128MTPCommitPendingKernel {
     RuntimeCheck(cur_bs <= cur_seq_lens.shape()[0], "cur_bs exceeds seq_lens rows");
     RuntimeCheck(cur_bs <= cur_req_pool_indices.shape()[0], "cur_bs exceeds req rows");
     RuntimeCheck(max_num_reqs <= pending_seq_lens.shape()[0], "max_num_reqs exceeds pending rows");
+    RuntimeCheck(max_num_reqs <= req_to_token.shape()[0], "max_num_reqs exceeds req_to_token rows");
+    RuntimeCheck(
+        state_slot_stride * (num_verify_tokens + 1) <= state.shape()[0],
+        "state buffer is too small for online MTP slots");
 
     launch(
         cur_seq_lens,

--- a/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v1.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/topk_v1.cuh
@@ -1,7 +1,7 @@
-#include <sgl_kernel/tensor.h>
-#include <sgl_kernel/utils.h>
+#include <sgl_kernel/tensor.h>  // For TensorMatcher and symbolic tensor metadata
+#include <sgl_kernel/utils.h>   // For RuntimeCheck
 
-#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/utils.cuh>  // For LaunchKernel, PDL helpers, and SGL_DEVICE
 
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
@@ -29,6 +29,42 @@ struct TopKParams {
   const int64_t page_table_stride;
   uint32_t page_bits;
 };
+
+struct DCPTopKCandidateParams {
+  const float* __restrict__ scores;
+  const int32_t* __restrict__ seq_lens;
+  int64_t* __restrict__ candidates;
+  int64_t score_stride;
+  uint32_t page_bits;
+  uint32_t dcp_size;
+  uint32_t dcp_rank;
+};
+
+struct DCPTopKMergeParams {
+  const int64_t* __restrict__ candidates;
+  const int32_t* __restrict__ seq_lens;
+  const int32_t* __restrict__ page_table;
+  int32_t* __restrict__ page_indices;
+  int32_t* __restrict__ raw_indices;
+  int64_t page_table_stride;
+  uint32_t batch_size;
+  uint32_t page_bits;
+  uint32_t dcp_size;
+};
+
+SGL_DEVICE int64_t pack_candidate(float score, int32_t raw_index) {
+  const uint64_t score_bits = static_cast<uint64_t>(__float_as_uint(score));
+  const uint64_t index_bits = static_cast<uint32_t>(raw_index);
+  return static_cast<int64_t>((score_bits << 32) | index_bits);
+}
+
+SGL_DEVICE float unpack_candidate_score(int64_t candidate) {
+  return __uint_as_float(static_cast<uint64_t>(candidate) >> 32);
+}
+
+SGL_DEVICE int32_t unpack_candidate_index(int64_t candidate) {
+  return static_cast<int32_t>(static_cast<uint32_t>(candidate));
+}
 
 SGL_DEVICE uint8_t convert_to_uint8(float x) {
   __half h = __float2half_rn(x);
@@ -262,6 +298,85 @@ __global__ void topk_transform_kernel(const __grid_constant__ TopKParams params)
   device::PDLTriggerSecondary<kUsePDL>();
 }
 
+template <bool kUsePDL>
+__global__ void dcp_topk_candidates_kernel(const __grid_constant__ DCPTopKCandidateParams params) {
+  const uint32_t work_id = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t seq_len = params.seq_lens[work_id];
+  const auto score_ptr = params.scores + work_id * params.score_stride;
+  const auto candidate_ptr = params.candidates + work_id * kTopK;
+
+  device::PDLWaitPrimary<kUsePDL>();
+
+  uint32_t local_raw = tx;
+  bool valid = tx < seq_len;
+  if (seq_len > kTopK) {
+    __shared__ int32_t s_topk_indices[kTopK];
+    radix_topk(score_ptr, s_topk_indices, seq_len);
+    local_raw = s_topk_indices[tx];
+    valid = true;
+  }
+
+  if (tx < kTopK) {
+    int32_t global_raw = -1;
+    float score = __int_as_float(static_cast<int>(0xff800000u));
+    if (valid) {
+      const uint32_t page = local_raw >> params.page_bits;
+      const uint32_t offset = local_raw & ((1u << params.page_bits) - 1u);
+      global_raw = static_cast<int32_t>(
+          (((page * params.dcp_size) + params.dcp_rank) << params.page_bits) | offset);
+      score = score_ptr[local_raw];
+    }
+    candidate_ptr[tx] = pack_candidate(score, global_raw);
+  }
+
+  device::PDLTriggerSecondary<kUsePDL>();
+}
+
+template <bool kUsePDL, uint32_t kDCPSize>
+__global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams params) {
+  static_assert(kDCPSize == 2 || kDCPSize == 4 || kDCPSize == 8);
+  constexpr uint32_t kCandidateCount = kDCPSize * kTopK;
+  const uint32_t work_id = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t seq_len = params.seq_lens[work_id];
+  const auto page_ptr = params.page_table + work_id * params.page_table_stride;
+  const auto page_indices_ptr = params.page_indices + work_id * kTopK;
+  const auto raw_indices_ptr = params.raw_indices != nullptr ? params.raw_indices + work_id * kTopK : nullptr;
+
+  __shared__ float s_candidate_scores[kCandidateCount];
+  __shared__ int32_t s_candidate_raw[kCandidateCount];
+  __shared__ int32_t s_topk_indices[kTopK];
+
+  device::PDLWaitPrimary<kUsePDL>();
+
+  for (uint32_t candidate_id = tx; candidate_id < kCandidateCount; candidate_id += kTopKBlockSize) {
+    const uint32_t rank = candidate_id / kTopK;
+    const uint32_t local_id = candidate_id % kTopK;
+    const auto candidate = params.candidates[(rank * params.batch_size + work_id) * kTopK + local_id];
+    s_candidate_scores[candidate_id] = unpack_candidate_score(candidate);
+    s_candidate_raw[candidate_id] = unpack_candidate_index(candidate);
+  }
+  __syncthreads();
+
+  if (seq_len <= kTopK) {
+    if (tx < seq_len) {
+      page_indices_ptr[tx] = page_to_indices(page_ptr, tx, params.page_bits);
+      if (raw_indices_ptr != nullptr) raw_indices_ptr[tx] = tx;
+    } else {
+      page_indices_ptr[tx] = -1;
+      if (raw_indices_ptr != nullptr) raw_indices_ptr[tx] = -1;
+    }
+  } else {
+    radix_topk(s_candidate_scores, s_topk_indices, kCandidateCount);
+    const auto raw_index = s_candidate_raw[s_topk_indices[tx]];
+    page_indices_ptr[tx] = page_to_indices(page_ptr, raw_index, params.page_bits);
+    if (raw_indices_ptr != nullptr) raw_indices_ptr[tx] = raw_index;
+  }
+
+  device::PDLTriggerSecondary<kUsePDL>();
+}
+
 template <auto* f, size_t kMaxDynamicSMEM>
 void setup_kernel_smem_once(host::DebugInfo where = {}) {
   [[maybe_unused]]
@@ -275,6 +390,15 @@ void setup_kernel_smem_once(host::DebugInfo where = {}) {
 template <bool kUsePDL>
 struct TopKKernel {
   static constexpr auto kernel = topk_transform_kernel<kUsePDL>;
+  static constexpr auto candidate_kernel = dcp_topk_candidates_kernel<kUsePDL>;
+
+  template <uint32_t kDCPSize>
+  static void launch_merge_kernel(const DCPTopKMergeParams& params, uint32_t batch_size, DLDevice device) {
+    constexpr auto merge_kernel = dcp_topk_merge_kernel<kUsePDL, kDCPSize>;
+    constexpr auto kSMEM_ = kSMEM + sizeof(int32_t);
+    setup_kernel_smem_once<merge_kernel, kSMEM_>();
+    host::LaunchKernel(batch_size, kTopKBlockSize, device, kSMEM_).enable_pdl(kUsePDL)(merge_kernel, params);
+  }
 
   static void transform(
       const tvm::ffi::TensorView scores,
@@ -334,6 +458,127 @@ struct TopKKernel {
     constexpr auto kSMEM_ = kSMEM + sizeof(int32_t);  // align up a little
     setup_kernel_smem_once<kernel, kSMEM_>();
     LaunchKernel(batch_size, kTopKBlockSize, device.unwrap(), kSMEM_).enable_pdl(kUsePDL)(kernel, params);
+  }
+
+  static void candidates(
+      const tvm::ffi::TensorView scores,
+      const tvm::ffi::TensorView seq_lens,
+      const tvm::ffi::TensorView candidates,
+      const uint32_t page_size,
+      const uint32_t dcp_size,
+      const uint32_t dcp_rank) {
+    using namespace host;
+    auto B = SymbolicSize{"batch_size"};
+    auto S = SymbolicSize{"score_stride"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+
+    TensorMatcher({B, -1})  // strided scores
+        .with_strides({S, 1})
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(scores);
+    TensorMatcher({B})  // contiguous local sequence lengths
+        .with_dtype<int32_t>()
+        .with_device(device)
+        .verify(seq_lens);
+    TensorMatcher({B, kTopK})  // packed score/index payload
+        .with_dtype<int64_t>()
+        .with_device(device)
+        .verify(candidates);
+
+    RuntimeCheck(std::has_single_bit(page_size), "page_size must be power of 2");
+    RuntimeCheck(
+        dcp_size == 2 || dcp_size == 4 || dcp_size == 8,
+        "DCP candidate path requires dcp_size in {2, 4, 8}");
+    RuntimeCheck(dcp_rank < dcp_size, "dcp_rank must be smaller than dcp_size");
+    const auto params = DCPTopKCandidateParams{
+        .scores = static_cast<const float*>(scores.data_ptr()),
+        .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),
+        .candidates = static_cast<int64_t*>(candidates.data_ptr()),
+        .score_stride = S.unwrap(),
+        .page_bits = static_cast<uint32_t>(std::countr_zero(page_size)),
+        .dcp_size = dcp_size,
+        .dcp_rank = dcp_rank,
+    };
+    constexpr auto kSMEM_ = kSMEM + sizeof(int32_t);
+    setup_kernel_smem_once<candidate_kernel, kSMEM_>();
+    LaunchKernel(B.unwrap(), kTopKBlockSize, device.unwrap(), kSMEM_)
+        .enable_pdl(kUsePDL)(candidate_kernel, params);
+  }
+
+  static void merge_dcp_candidates(
+      const tvm::ffi::TensorView candidates,
+      const tvm::ffi::TensorView seq_lens,
+      const tvm::ffi::TensorView page_table,
+      const tvm::ffi::TensorView page_indices,
+      const uint32_t page_size,
+      const uint32_t dcp_size,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> raw_indices) {
+    using namespace host;
+    auto B = SymbolicSize{"batch_size"};
+    auto P = SymbolicSize{"page_table_stride"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+
+    TensorMatcher({B})
+        .with_dtype<int32_t>()
+        .with_device(device)
+        .verify(seq_lens);
+    TensorMatcher({B, -1})
+        .with_strides({P, 1})
+        .with_dtype<int32_t>()
+        .with_device(device)
+        .verify(page_table);
+    TensorMatcher({B, kTopK})
+        .with_dtype<int32_t>()
+        .with_device(device)
+        .verify(page_indices);
+    TensorMatcher({-1, kTopK})
+        .with_dtype<int64_t>()
+        .with_device(device)
+        .verify(candidates);
+
+    int32_t* raw_indices_ptr = nullptr;
+    if (raw_indices.has_value()) {
+      TensorMatcher({B, kTopK})
+          .with_dtype<int32_t>()
+          .with_device(device)
+          .verify(raw_indices.value());
+      raw_indices_ptr = static_cast<int32_t*>(raw_indices.value().data_ptr());
+    }
+
+    RuntimeCheck(std::has_single_bit(page_size), "page_size must be power of 2");
+    RuntimeCheck(
+        dcp_size == 2 || dcp_size == 4 || dcp_size == 8,
+        "DCP candidate merge requires dcp_size in {2, 4, 8}");
+    RuntimeCheck(
+        candidates.size(0) == B.unwrap() * dcp_size,
+        "invalid gathered candidate shape");
+    const auto params = DCPTopKMergeParams{
+        .candidates = static_cast<const int64_t*>(candidates.data_ptr()),
+        .seq_lens = static_cast<const int32_t*>(seq_lens.data_ptr()),
+        .page_table = static_cast<const int32_t*>(page_table.data_ptr()),
+        .page_indices = static_cast<int32_t*>(page_indices.data_ptr()),
+        .raw_indices = raw_indices_ptr,
+        .page_table_stride = P.unwrap(),
+        .batch_size = static_cast<uint32_t>(B.unwrap()),
+        .page_bits = static_cast<uint32_t>(std::countr_zero(page_size)),
+        .dcp_size = dcp_size,
+    };
+    switch (dcp_size) {
+      case 2:
+        launch_merge_kernel<2>(params, B.unwrap(), device.unwrap());
+        break;
+      case 4:
+        launch_merge_kernel<4>(params, B.unwrap(), device.unwrap());
+        break;
+      case 8:
+        launch_merge_kernel<8>(params, B.unwrap(), device.unwrap());
+        break;
+      default:
+        Panic("unsupported dcp_size: ", dcp_size);
+    }
   }
 };
 

--- a/python/sglang/jit_kernel/dsv4/__init__.py
+++ b/python/sglang/jit_kernel/dsv4/__init__.py
@@ -29,7 +29,13 @@ from .moe import (
     silu_and_mul_contig_post_quant,
     silu_and_mul_masked_post_quant,
 )
-from .topk import plan_topk_v2, topk_transform_512, topk_transform_512_v2
+from .topk import (
+    merge_dcp_topk_candidates_512,
+    plan_topk_v2,
+    topk_candidates_512,
+    topk_transform_512,
+    topk_transform_512_v2,
+)
 from .utils import make_name
 
 __all__ = [
@@ -53,6 +59,8 @@ __all__ = [
     "triton_create_paged_compress_data",
     "topk_transform_512",
     "topk_transform_512_v2",
+    "topk_candidates_512",
+    "merge_dcp_topk_candidates_512",
     "plan_topk_v2",
     "hash_topk",
     "mega_moe_pre_dispatch",

--- a/python/sglang/jit_kernel/dsv4/compress.py
+++ b/python/sglang/jit_kernel/dsv4/compress.py
@@ -38,6 +38,18 @@ if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
 
+def _get_dcp_world_rank() -> tuple[int, int]:
+    try:
+        from sglang.srt.distributed.parallel_state import get_dcp_group_no_assert
+
+        group = get_dcp_group_no_assert()
+        if group is not None and group.world_size > 1:
+            return int(group.world_size), int(group.rank_in_group)
+    except Exception:
+        pass
+    return 1, 0
+
+
 @cache_once
 def _jit_compress_norm_rope_module(
     dtype: torch.dtype,
@@ -55,7 +67,7 @@ def _jit_compress_norm_rope_module(
             ("forward_fp4", f"FusedNormRopeKernel<{args}>::forward_fp4")
         )
     return load_jit(
-        make_name(f"fused_norm_rope_v2"),
+        make_name(f"fused_norm_rope_v2_dcp"),
         *args,
         cuda_files=[f"deepseek_v4/fused_norm_rope_v2.cuh"],
         cuda_wrappers=cuda_wrappers,
@@ -94,7 +106,7 @@ def _jit_compress_128_online_module(
     args = make_cpp_args(head_dim, dtype_buffer, is_arch_support_pdl())
     kernel_class = f"FlashCompress128OnlineKernel<{args}>"
     return load_jit(
-        make_name(f"compress_128_online_v2"),
+        make_name(f"compress_128_online_v2_activebs"),
         *args,
         cuda_files=["deepseek_v4/c128_online_v2.cuh"],
         cuda_wrappers=[
@@ -110,7 +122,7 @@ def _jit_compress_128_online_module(
 @cache_once
 def _jit_compress_plan_module() -> Module:
     return load_jit(
-        make_name(f"compress_plan"),
+        make_name(f"compress_plan_activebs_v4"),
         cuda_files=[f"deepseek_v4/c_plan.cuh"],
         cuda_wrappers=[
             ("plan_prefill", "plan_compress_prefill"),
@@ -222,6 +234,8 @@ class CompressorPrefillPlan(NamedTuple):
     def copy_(self, other) -> None:
         assert isinstance(other, CompressorPrefillPlan)
         assert self.compress_ratio == other.compress_ratio
+        if self.pin_buffer is not None and other.pin_buffer is not None:
+            self.pin_buffer.copy_(other.pin_buffer)
         self.plan_c.copy_(other.plan_c)
         self.plan_w.copy_(other.plan_w)
 
@@ -237,6 +251,7 @@ class CompressorPrefillPlan(NamedTuple):
         ring_size: int,
         num_q_tokens: int,
         use_cuda_graph: bool = False,
+        active_bs: Optional[int] = None,
     ) -> CompressorPrefillPlan:
         is_gpu_input = seq_lens.device.type in ["cuda", "xpu"]
         pin_buffer = torch.empty(
@@ -276,6 +291,7 @@ class CompressorPrefillPlan(NamedTuple):
             int(swa_page_size),
             int(ring_size),
             bool(use_cuda_graph),
+            int(seq_lens.shape[0] if active_bs is None else active_bs),
         )
         return CompressorPrefillPlan(
             compress_ratio,
@@ -330,6 +346,7 @@ class CompressorPrefillPlan(NamedTuple):
         num_q_tokens: int,
         use_cuda_graph: bool = False,
         state_slot_offset: int = 0,
+        active_bs: Optional[int] = None,
     ) -> CompressorPrefillPlan:
         seq_lens_cpu = seq_lens.detach().to(torch.int64).cpu()
         extend_lens_cpu = extend_lens.detach().to(torch.int64).cpu()
@@ -354,6 +371,7 @@ class CompressorPrefillPlan(NamedTuple):
             plan_w_dev,
             int(state_slot_offset),
             bool(use_cuda_graph),
+            int(seq_lens.shape[0] if active_bs is None else active_bs),
         )
         return CompressorPrefillPlan(
             128,
@@ -438,6 +456,7 @@ def compress_norm_rope_store(
             kv.dtype, kv.shape[-1], freq_cis.shape[-1], page_size, bf16_store
         )
         fn = module.forward_fp4 if use_fp4 else module.forward
+        dcp_world_size, dcp_rank = _get_dcp_world_rank()
         fn(
             kv,
             plan[1],
@@ -448,4 +467,6 @@ def compress_norm_rope_store(
             kvcache,
             plan.is_decode,
             plan.compress_ratio,
+            int(dcp_world_size),
+            int(dcp_rank),
         )

--- a/python/sglang/jit_kernel/dsv4/elementwise.py
+++ b/python/sglang/jit_kernel/dsv4/elementwise.py
@@ -66,10 +66,12 @@ def _jit_main_k_norm_rope_flashmla_module(
 
 @cache_once
 def _jit_main_q_indexer_rope_hadamard_quant_module(dtype: torch.dtype):
-    """C4 indexer Q kernel: RoPE + 128-pt Hadamard + fp8 act-quant"""
-    args = make_cpp_args(dtype, is_arch_support_pdl())
+    """C4 indexer Q kernel: RoPE + 128-pt Hadamard + fp8 act-quant."""
+    # This kernel runs in target-verify CUDA graph warmup for DSV4 MTP. PDL has
+    # shown illegal accesses there on H20, so keep this small Q path non-PDL.
+    args = make_cpp_args(dtype, False)
     return load_jit(
-        make_name("main_q_indexer_rope_hadamard_quant"),
+        make_name("main_q_indexer_rope_hadamard_quant_no_pdl"),
         *args,
         cuda_files=["deepseek_v4/main_norm_rope.cuh"],
         cuda_wrappers=[

--- a/python/sglang/jit_kernel/dsv4/online_c128_mtp.py
+++ b/python/sglang/jit_kernel/dsv4/online_c128_mtp.py
@@ -22,7 +22,7 @@ def _jit_online_c128_mtp_module(
 ) -> Module:
     args = make_cpp_args(head_dim, seq_dtype, req_dtype, dtype_buffer)
     return load_jit(
-        make_name(f"online_c128_mtp_{head_dim}"),
+        make_name(f"online_c128_mtp_bounds_{head_dim}"),
         *args,
         cuda_files=["deepseek_v4/online_c128_mtp.cuh"],
         cuda_wrappers=[
@@ -112,11 +112,12 @@ class OnlineC128MTPController:
             self.clear()
             return 0
 
+        if verify_bs is None and logical_forward_mode.is_target_verify():
+            verify_bs = req_pool_indices.shape[0]
+
         active_req_pool_indices = req_pool_indices
         active_seq_lens = seq_lens
-        if logical_forward_mode.is_target_verify():
-            if verify_bs is None:
-                verify_bs = req_pool_indices.shape[0]
+        if verify_bs is not None:
             active_req_pool_indices = req_pool_indices[:verify_bs]
             active_seq_lens = seq_lens[:verify_bs]
             if verify_bs == 0:
@@ -179,6 +180,7 @@ class OnlineC128MTPController:
             layer_bs,
             num_verify_tokens,
             state_pool.online_mtp_state_slot_offset,
+            token_to_kv_pool.get_online_c128_state_num_req_slots(),
         )
 
     def commit_pending(

--- a/python/sglang/jit_kernel/dsv4/topk.py
+++ b/python/sglang/jit_kernel/dsv4/topk.py
@@ -19,11 +19,16 @@ from .utils import make_name
 def _jit_topk_v1_module(topk: int):
     args = make_cpp_args(is_arch_support_pdl())
     assert topk in (512, 1024), "Only support topk=512 or 1024"
+    kernel_class = f"TopKKernel<{args}>"
     return load_jit(
         make_name(f"topk_v1_{topk}"),
         *args,
         cuda_files=["deepseek_v4/topk_v1.cuh"],
-        cuda_wrappers=[("topk_transform", f"TopKKernel<{args}>::transform")],
+        cuda_wrappers=[
+            ("topk_transform", f"{kernel_class}::transform"),
+            ("topk_candidates", f"{kernel_class}::candidates"),
+            ("merge_dcp_candidates", f"{kernel_class}::merge_dcp_candidates"),
+        ],
         extra_cuda_cflags=[f"-DSGL_TOPK={topk}"],
     )
 
@@ -59,6 +64,50 @@ def topk_transform_512(
         module.topk_transform(
             scores, seq_lens, page_tables, out_page_indices, page_size, out_raw_indices
         )
+
+
+def topk_candidates_512(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out_candidates: torch.Tensor,
+    page_size: int,
+    dcp_size: int,
+    dcp_rank: int,
+) -> None:
+    if is_hip_runtime():
+        raise NotImplementedError("DCP packed topK candidates require CUDA")
+    module = _jit_topk_v1_module(out_candidates.shape[1])
+    module.topk_candidates(
+        scores,
+        seq_lens,
+        out_candidates,
+        page_size,
+        dcp_size,
+        dcp_rank,
+    )
+
+
+def merge_dcp_topk_candidates_512(
+    gathered_candidates: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_tables: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    page_size: int,
+    dcp_size: int,
+    out_raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+    if is_hip_runtime():
+        raise NotImplementedError("DCP packed topK merge requires CUDA")
+    module = _jit_topk_v1_module(out_page_indices.shape[1])
+    module.merge_dcp_candidates(
+        gathered_candidates,
+        seq_lens,
+        page_tables,
+        out_page_indices,
+        page_size,
+        dcp_size,
+        out_raw_indices,
+    )
 
 
 # metadata is (batch+1, 2) int32: row 0 = {cluster_threshold, num_cluster_items};

--- a/python/sglang/kernels/ops/attention/dsa/index_buf_accessor.py
+++ b/python/sglang/kernels/ops/attention/dsa/index_buf_accessor.py
@@ -259,7 +259,7 @@ class SetKAndS:
         cls.triton(*args, **kwargs, buf=buf)
 
     @classmethod
-    def triton(cls, pool, buf, loc, index_k, index_k_scale):
+    def triton(cls, pool, buf, loc, index_k, index_k_scale, write_mask=None):
         loc = loc.to(torch.int64)
 
         _set_k_and_s_triton(
@@ -268,6 +268,7 @@ class SetKAndS:
             index_k=index_k,
             index_k_scale=index_k_scale,
             page_size=pool.page_size,
+            write_mask=write_mask,
         )
 
 
@@ -277,6 +278,7 @@ def _set_k_and_s_triton(
     index_k: torch.Tensor,
     index_k_scale: torch.Tensor,
     page_size: int,
+    write_mask: torch.Tensor | None = None,
 ):
     """
     :param buf: (num_pages, page_size 64 * (128B data + 4B scale)), uint8
@@ -323,6 +325,14 @@ def _set_k_and_s_triton(
     assert loc.is_contiguous()
     assert index_k.is_contiguous()
     assert index_k_scale.is_contiguous()
+    if write_mask is None:
+        write_mask = loc
+        has_write_mask = False
+    else:
+        assert write_mask.shape == loc.shape, f"{write_mask.shape=} {loc.shape=}"
+        assert write_mask.dtype == torch.bool, f"{write_mask.dtype=}"
+        assert write_mask.is_contiguous()
+        has_write_mask = True
 
     if _is_fp8_fnuz:
         buf_fp8 = buf.view(torch.float8_e4m3fnuz)
@@ -334,6 +344,7 @@ def _set_k_and_s_triton(
         buf_fp8,
         buf_fp32,
         loc,
+        write_mask,
         index_k,
         index_k_scale,
         index_k.stride(0),
@@ -341,6 +352,7 @@ def _set_k_and_s_triton(
         BUF_NUMEL_PER_PAGE=buf_numel_per_page,
         NUM_K_ELEMS_PER_TOKEN=index_head_dim,
         S_OFFSET_NBYTES_IN_PAGE=page_size * index_head_dim,
+        HAS_WRITE_MASK=has_write_mask,
     )
 
 
@@ -349,6 +361,7 @@ def _set_k_and_s_triton_kernel(
     buf_fp8_ptr,
     buf_fp32_ptr,
     loc_ptr,
+    write_mask_ptr,
     index_k_ptr,
     index_k_scale_ptr,
     index_k_ptr_stride_0,
@@ -356,8 +369,12 @@ def _set_k_and_s_triton_kernel(
     BUF_NUMEL_PER_PAGE: tl.constexpr,
     NUM_K_ELEMS_PER_TOKEN: tl.constexpr,
     S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
 ):
     token_id = tl.program_id(0)
+    if HAS_WRITE_MASK:
+        if not tl.load(write_mask_ptr + token_id):
+            return
 
     loc = tl.load(loc_ptr + token_id)
 

--- a/python/sglang/kernels/ops/attention/dsv4/index_buf_accessor.py
+++ b/python/sglang/kernels/ops/attention/dsv4/index_buf_accessor.py
@@ -33,16 +33,60 @@ class NopeFp8RopeBf16Pack:
 
 class SetKAndS:
     @classmethod
-    def execute(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
-        cls.triton(pool, buf, loc, nope_fp8_rope_bf16_pack)
+    def execute(
+        cls,
+        pool,
+        buf,
+        loc,
+        nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: torch.Tensor | None = None,
+    ):
+        cls.triton(
+            pool,
+            buf,
+            loc,
+            nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
 
     @classmethod
-    def torch(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
+    def torch(
+        cls,
+        pool,
+        buf,
+        loc,
+        nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        write_mask: torch.Tensor | None = None,
+    ):
+        if write_mask is not None:
+            nope_fp8_rope_bf16_pack = nope_fp8_rope_bf16_pack.slice_pack(write_mask)
+            loc = loc[write_mask]
         _set_k_and_s_torch(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
 
     @classmethod
-    def triton(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
-        _set_k_and_s_triton(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
+    def triton(
+        cls,
+        pool,
+        buf,
+        loc,
+        nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: torch.Tensor | None = None,
+    ):
+        _set_k_and_s_triton(
+            buf,
+            loc,
+            nope_fp8_rope_bf16_pack,
+            pool.page_size,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
 
 
 def _set_k_and_s_triton(
@@ -50,6 +94,9 @@ def _set_k_and_s_triton(
     loc: torch.Tensor,
     nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
     page_size: int,
+    dcp_world_size: int = 1,
+    dcp_rank: int = 0,
+    write_mask: torch.Tensor | None = None,
 ):
     num_pages, buf_numel_per_page = buf.shape
     (num_tokens_to_write,) = loc.shape
@@ -83,6 +130,14 @@ def _set_k_and_s_triton(
     assert k_nope.is_contiguous()
     assert k_rope.is_contiguous()
     assert scale_k_nope.is_contiguous()
+    if write_mask is None:
+        write_mask = loc
+        has_write_mask = False
+    else:
+        assert write_mask.shape == loc.shape, f"{write_mask.shape=} {loc.shape=}"
+        assert write_mask.dtype == torch.bool, f"{write_mask.dtype=}"
+        assert write_mask.is_contiguous()
+        has_write_mask = True
 
     buf_fp8 = buf.view(fp8_dtype)
     buf_bf16 = buf.view(torch.bfloat16)
@@ -96,6 +151,7 @@ def _set_k_and_s_triton(
         buf_bf16,
         buf_uint8,
         loc,
+        write_mask,
         k_nope,
         k_rope,
         scale_k_nope,
@@ -113,6 +169,9 @@ def _set_k_and_s_triton(
         BLOCK_NOPE=512,
         BLOCK_ROPE=64,
         BLOCK_SCALE=8,
+        DCP_WORLD_SIZE=dcp_world_size,
+        DCP_RANK=dcp_rank,
+        HAS_WRITE_MASK=has_write_mask,
     )
 
 
@@ -122,6 +181,7 @@ def _set_k_and_s_triton_kernel(
     buf_bf16_ptr,
     buf_uint8_ptr,
     loc_ptr,
+    write_mask_ptr,
     k_nope_ptr,
     k_rope_ptr,
     scale_k_nope_ptr,
@@ -139,9 +199,26 @@ def _set_k_and_s_triton_kernel(
     BLOCK_NOPE: tl.constexpr,
     BLOCK_ROPE: tl.constexpr,
     BLOCK_SCALE: tl.constexpr,
+    DCP_WORLD_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
 ):
     token_id = tl.program_id(0)
+    if HAS_WRITE_MASK:
+        if not tl.load(write_mask_ptr + token_id):
+            return
+
     loc = tl.load(loc_ptr + token_id)
+
+    # DCP: each rank only owns the slots whose global ``loc`` satisfies
+    # ``loc % world_size == rank``. Skip the ones that don't belong to us
+    # so this rank's local buffer keeps an interleaved (every-Nth-token)
+    # view of the full sequence. When DCP is disabled (world_size==1)
+    # the modulo is always zero and the divide is a no-op.
+    if DCP_WORLD_SIZE > 1:
+        if (loc % DCP_WORLD_SIZE) != DCP_RANK:
+            return
+        loc = loc // DCP_WORLD_SIZE
 
     nope_range = tl.arange(0, BLOCK_NOPE)
     nope_mask = nope_range < NUM_NOPE_ELEMS_PER_TOKEN

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -48,6 +48,7 @@ from sglang.kernels.ops.kvcache.kv_indices import (
 from sglang.kernels.ops.kvcache.rope_cache import (
     fused_qk_rope_reshape_and_cache as fused_qk_rope_reshape_and_cache,
 )
+from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.utils import is_cuda
 
 _is_cuda = is_cuda()
@@ -183,6 +184,331 @@ def concat_mla_absorb_q_general(q_nope, q_rope):
     else:
         return torch.cat([q_nope, q_rope], dim=-1)
 
+
+# ---------------------------------------------------------------------------
+# Decode Context Parallel (DCP) helpers.
+#
+# Not part of upstream main (PR #26000 centralized the other Triton utility
+# kernels into triton_ops/*). These three live here because they are DCP-only:
+#   - create_triton_kv_indices_for_dcp_triton: per-rank local KV indices
+#   - get_dcp_lens: per-rank visible KV length
+#   - cp_lse_ag_out_rs: merge DCP partial attention via natural-log LSE
+# ---------------------------------------------------------------------------
+@triton.jit
+def create_triton_kv_indices_for_dcp_triton(
+    req_to_token_ptr,  # [max_batch, max_context_len]
+    req_pool_indices_ptr,
+    dcp_kernel_lens_ptr,
+    kv_indptr,
+    kv_start_idx,
+    kv_indices_ptr,
+    req_to_token_ptr_stride: tl.constexpr,
+    dcp_size: tl.constexpr,
+    dcp_rank: tl.constexpr,
+):
+    BLOCK_SIZE: tl.constexpr = 512
+    pid = tl.program_id(axis=0)
+    req_pool_index = tl.load(req_pool_indices_ptr + pid)
+    kv_indices_offset = tl.load(kv_indptr + pid)
+
+    kv_start = 0
+    if kv_start_idx:
+        kv_start = tl.load(kv_start_idx + pid).to(tl.int32)
+
+    # First absolute token position in this range owned by dcp_rank.
+    # Triton follows C-style remainder for negative values, so avoid
+    # computing the offset as a negative remainder when kv_start > dcp_rank.
+    kv_start_mod = kv_start % dcp_size
+    first = kv_start + ((dcp_rank + dcp_size - kv_start_mod) % dcp_size)
+    local_len = tl.load(dcp_kernel_lens_ptr + pid).to(tl.int32)
+
+    num_loop = tl.cdiv(local_len, BLOCK_SIZE)
+    for i in range(num_loop):
+        offset = tl.arange(0, BLOCK_SIZE).to(tl.int64) + i * BLOCK_SIZE
+        mask = offset < local_len
+        abs_pos = first + offset * dcp_size
+        data = tl.load(
+            req_to_token_ptr + req_pool_index * req_to_token_ptr_stride + abs_pos,
+            mask=mask,
+        )
+        tl.store(
+            kv_indices_ptr + kv_indices_offset + offset, data // dcp_size, mask=mask
+        )
+
+
+def get_dcp_lens(
+    lens: torch.Tensor,
+    dcp_size: int,
+    dcp_rank: int,
+    start: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if dcp_size == 1:
+        return lens
+    if start is None:
+        return lens // dcp_size + (dcp_rank < lens % dcp_size)
+
+    first = start + torch.remainder(dcp_rank - start, dcp_size)
+    remaining = start + lens - first
+    return torch.clamp((remaining + dcp_size - 1) // dcp_size, min=0)
+
+
+def cp_lse_ag_out_rs(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group: GroupCoordinator,
+    return_lse: bool = False,
+):
+    """Merge DCP partial attention outputs using natural-log LSE."""
+    if cp_group.world_size == 1:
+        return (cp_attn_out, cp_attn_lse) if return_lse else cp_attn_out
+
+    cp_attn_lse = cp_attn_lse.contiguous()
+    lses = cp_group.all_gather(cp_attn_lse, dim=0).view(
+        (cp_group.world_size,) + cp_attn_lse.shape
+    )
+    global_lse = torch.logsumexp(lses, dim=0)
+    scale = torch.exp(cp_attn_lse - global_lse).unsqueeze(-1)
+    scale = torch.nan_to_num(scale, nan=0.0, posinf=0.0, neginf=0.0)
+
+    out = torch.nan_to_num(cp_attn_out, nan=0.0, posinf=0.0, neginf=0.0) * scale
+    out = cp_group.all_reduce(out)
+
+    cp_num_heads = global_lse.shape[1] // cp_group.world_size
+    cp_rank = cp_group.rank_in_group
+    head_start = cp_num_heads * cp_rank
+    head_end = cp_num_heads * (cp_rank + 1)
+    out = out[:, head_start:head_end, :].contiguous()
+    if return_lse:
+        return out, global_lse[:, head_start:head_end].contiguous()
+    return out
+
+
+@triton.jit
+def _dcp_lse_pack_for_reduce_scatter_kernel(
+    out_ptr,
+    lses_ptr,
+    packed_ptr,
+    global_lse_ptr,
+    out_stride_B,
+    out_stride_H,
+    out_stride_D,
+    lses_stride_N,
+    lses_stride_B,
+    lses_stride_H,
+    packed_stride_B,
+    packed_stride_H,
+    packed_stride_D,
+    global_lse_stride_B,
+    global_lse_stride_H,
+    rank,
+    N: tl.constexpr,
+    N_ROUNDED: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    LOCAL_HEADS: tl.constexpr,
+):
+    batch_idx = tl.program_id(0).to(tl.int64)
+    head_idx = tl.program_id(1).to(tl.int64)
+    rank_offsets = tl.arange(0, N_ROUNDED)
+    lse_offsets = (
+        rank_offsets * lses_stride_N
+        + batch_idx * lses_stride_B
+        + head_idx * lses_stride_H
+    )
+    lses = tl.load(
+        lses_ptr + lse_offsets, mask=rank_offsets < N, other=-float("inf")
+    )
+    lses = tl.where(
+        (lses != lses) | (lses == float("inf")), -float("inf"), lses
+    )
+
+    lse_max = tl.max(lses, axis=0)
+    lse_max = tl.where(lse_max == -float("inf"), 0.0, lse_max)
+    global_lse = tl.log(tl.sum(tl.exp(lses - lse_max), axis=0)) + lse_max
+    tl.store(
+        global_lse_ptr
+        + batch_idx * global_lse_stride_B
+        + head_idx * global_lse_stride_H,
+        global_lse,
+    )
+
+    local_lse = tl.load(
+        lses_ptr
+        + rank * lses_stride_N
+        + batch_idx * lses_stride_B
+        + head_idx * lses_stride_H
+    )
+    lse_diff = local_lse - global_lse
+    lse_diff = tl.where(
+        (lse_diff != lse_diff) | (lse_diff == float("inf")),
+        -float("inf"),
+        lse_diff,
+    )
+    scale = tl.exp(lse_diff)
+
+    d_offsets = tl.arange(0, HEAD_DIM)
+    out_offsets = (
+        batch_idx * out_stride_B
+        + head_idx * out_stride_H
+        + d_offsets * out_stride_D
+    )
+    output = tl.load(out_ptr + out_offsets).to(tl.float32)
+    output = tl.where(
+        (output != output)
+        | (output == float("inf"))
+        | (output == -float("inf")),
+        0.0,
+        output,
+    )
+
+    destination = head_idx // LOCAL_HEADS
+    local_head = head_idx - destination * LOCAL_HEADS
+    packed_batch = destination * tl.num_programs(0) + batch_idx
+    packed_offsets = (
+        packed_batch * packed_stride_B
+        + local_head * packed_stride_H
+        + d_offsets * packed_stride_D
+    )
+    tl.store(packed_ptr + packed_offsets, output * scale)
+
+
+def cp_lse_ag_out_reduce_scatter(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group: GroupCoordinator,
+    return_lse: bool = False,
+):
+    """Merge DCP partial attention outputs with LSE AG and output RS."""
+    if cp_group.world_size == 1:
+        return (cp_attn_out, cp_attn_lse) if return_lse else cp_attn_out
+
+    if cp_attn_out.ndim != 3 or cp_attn_lse.ndim != 2:
+        raise ValueError(
+            "DCP reduce-scatter LSE merge expects output [T, H, D] and "
+            f"LSE [T, H], got {tuple(cp_attn_out.shape)=}, "
+            f"{tuple(cp_attn_lse.shape)=}"
+        )
+    if cp_attn_out.shape[:2] != cp_attn_lse.shape:
+        raise ValueError(
+            "DCP reduce-scatter LSE merge output/LSE shape mismatch: "
+            f"{tuple(cp_attn_out.shape)=}, {tuple(cp_attn_lse.shape)=}"
+        )
+
+    world_size = cp_group.world_size
+    num_tokens, total_heads, head_dim = cp_attn_out.shape
+    if total_heads % world_size != 0:
+        raise ValueError(
+            "DCP reduce-scatter LSE merge requires the full head dimension "
+            f"to be divisible by world size, got {total_heads=} and "
+            f"{world_size=}"
+        )
+
+    cp_attn_lse = cp_attn_lse.contiguous()
+    lses = cp_group.all_gather(cp_attn_lse, dim=0).view(
+        (world_size,) + cp_attn_lse.shape
+    )
+    local_heads = total_heads // world_size
+    packed_out = torch.empty(
+        (world_size * num_tokens, local_heads, head_dim),
+        dtype=torch.float32,
+        device=cp_attn_out.device,
+    )
+    global_lse = torch.empty_like(cp_attn_lse, dtype=torch.float32)
+    _dcp_lse_pack_for_reduce_scatter_kernel[(num_tokens, total_heads)](
+        cp_attn_out,
+        lses,
+        packed_out,
+        global_lse,
+        cp_attn_out.stride(0),
+        cp_attn_out.stride(1),
+        cp_attn_out.stride(2),
+        lses.stride(0),
+        lses.stride(1),
+        lses.stride(2),
+        packed_out.stride(0),
+        packed_out.stride(1),
+        packed_out.stride(2),
+        global_lse.stride(0),
+        global_lse.stride(1),
+        cp_group.rank_in_group,
+        N=world_size,
+        N_ROUNDED=triton.next_power_of_2(world_size),
+        HEAD_DIM=head_dim,
+        LOCAL_HEADS=local_heads,
+    )
+    out = cp_group.reduce_scatter_along_dim(packed_out, dim=0)
+    if return_lse:
+        head_start = local_heads * cp_group.rank_in_group
+        head_end = head_start + local_heads
+        return out, global_lse[:, head_start:head_end].contiguous()
+    return out
+
+
+def cp_lse_a2a_out_rs(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    cp_group: GroupCoordinator,
+    return_lse: bool = False,
+):
+    """Merge DCP partial attention with head-chunk all-to-all exchange.
+
+    Each rank computes all query heads over its local KV shard. Rank ``d`` only
+    needs head chunk ``d`` from every source rank, so exchange the per-rank
+    chunks first and merge them locally. This is equivalent to
+    ``cp_lse_ag_out_rs`` but avoids materializing and reducing all heads on
+    every rank.
+    """
+    if cp_group.world_size == 1:
+        return (cp_attn_out, cp_attn_lse) if return_lse else cp_attn_out
+
+    if cp_attn_out.ndim != 3 or cp_attn_lse.ndim != 2:
+        raise ValueError(
+            "DCP all-to-all LSE merge expects output [T, H, D] and "
+            f"LSE [T, H], got {tuple(cp_attn_out.shape)=}, "
+            f"{tuple(cp_attn_lse.shape)=}"
+        )
+    if cp_attn_out.shape[:2] != cp_attn_lse.shape:
+        raise ValueError(
+            "DCP all-to-all LSE merge output/LSE shape mismatch: "
+            f"{tuple(cp_attn_out.shape)=}, {tuple(cp_attn_lse.shape)=}"
+        )
+
+    world_size = cp_group.world_size
+    total_heads = cp_attn_out.shape[1]
+    if total_heads % world_size != 0:
+        raise ValueError(
+            "DCP all-to-all LSE merge requires the full head dimension to be "
+            f"divisible by world size, got {total_heads=} and {world_size=}"
+        )
+
+    local_heads = total_heads // world_size
+    # all_to_all_single splits the first dimension by destination rank. Move
+    # the logical [T, destination_head_chunk, ...] dimension to the front.
+    out_send = (
+        cp_attn_out.contiguous()
+        .view(cp_attn_out.shape[0], world_size, local_heads, cp_attn_out.shape[2])
+        .permute(1, 0, 2, 3)
+        .contiguous()
+    )
+    lse_send = (
+        cp_attn_lse.contiguous()
+        .view(cp_attn_lse.shape[0], world_size, local_heads)
+        .permute(1, 0, 2)
+        .contiguous()
+    )
+
+    out_recv = torch.empty_like(out_send)
+    lse_recv = torch.empty_like(lse_send)
+    cp_group.all_to_all_single(out_recv, out_send)
+    cp_group.all_to_all_single(lse_recv, lse_send)
+
+    global_lse = torch.logsumexp(lse_recv, dim=0)
+    scale = torch.exp(lse_recv - global_lse.unsqueeze(0)).unsqueeze(-1)
+    scale = torch.nan_to_num(scale, nan=0.0, posinf=0.0, neginf=0.0)
+    out = torch.nan_to_num(out_recv, nan=0.0, posinf=0.0, neginf=0.0)
+    out = (out * scale).sum(dim=0)
+    if return_lse:
+        return out, global_lse.contiguous()
+    return out
 
 @triton.jit
 def reshape_and_cache_flash(

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -62,6 +62,51 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
                 server_args.speculative_eagle_topk == 1
             ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
 
+    validate_deepseek_v4_dcp(server_args)
+
+
+def validate_deepseek_v4_dcp(server_args: ServerArgs) -> None:
+    """Validate DeepSeek V4 DCP (decode context parallel) compatibility."""
+    if server_args.dcp_size <= 1:
+        return
+
+    if not envs.SGLANG_DSV4_ENABLE_DCP.get():
+        raise ValueError(
+            "DeepSeekV4 DCP (--dcp-size > 1) is gated behind "
+            "SGLANG_DSV4_ENABLE_DCP=1. Set the env var explicitly after "
+            "verifying numerical equivalence vs. dcp_size=1 on your cluster."
+        )
+
+    # DSV4 DCP reduce-scatters attention output across the attention-TP head
+    # dimension, so the DCP group must match the attention-TP group.
+    attn_tp = server_args.tp_size // max(server_args.dp_size, 1)
+    if attn_tp != server_args.dcp_size:
+        raise ValueError(
+            f"DeepSeekV4 DCP currently requires dcp_size ({server_args.dcp_size}) "
+            f"== attn_tp ({attn_tp}); configure tp/dp_size/dcp_size accordingly."
+        )
+
+    # Online c128 + DCP: untested combination; warn but allow.
+    if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+        logger.warning(
+            "DeepSeekV4 DCP + SGLANG_OPT_USE_ONLINE_COMPRESS combo is "
+            "experimental; numerical correctness has not been validated."
+        )
+
+    # HiSparse + DCP: HiSparse C4 device pool uses index translation that is
+    # not yet DCP-aware in the fused C++ kernels; only the Triton fallback
+    # write path supports DCP.
+    if server_args.enable_hisparse:
+        logger.warning(
+            "DeepSeekV4 DCP + enable_hisparse falls back to Triton write "
+            "path for KV writes; expect throughput regression vs. fused C++."
+        )
+
+    logger.info(
+        f"DeepSeekV4 DCP enabled: dcp_size={server_args.dcp_size}, "
+        f"attn_tp={attn_tp}"
+    )
+
 
 def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
     """Validate DeepSeek V4 context-parallel configuration."""

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -62,6 +62,9 @@ class KVArgs:
     kv_head_num: int
     total_kv_head_num: int
     page_size: int
+    # Optional SWA page size for heterogeneous KV pools such as DeepSeek V4.
+    # DSV4 compressor states are indexed from SWA locs, not full-KV page locs.
+    swa_page_size: Optional[int] = None
     # for system dp
     system_dp_rank: int
     # for pp prefill
@@ -81,6 +84,14 @@ class KVArgs:
     kv_buf_groups: int
     # Only used of npu, for decode total kv layers
     total_kv_layers: int
+    # Decode-Context-Parallel topology of *this* engine. Required so the
+    # transfer layer can convert the logical token loc carried in KV
+    # indices into the per-rank physical offset that the underlying buffer
+    # actually uses (DCP storage rule: token loc i lives on rank
+    # ``i % dcp_size`` at local offset ``i // dcp_size``). Defaults to a
+    # no-DCP topology so non-DCP backends remain bit-identical.
+    dcp_size: int = 1
+    dcp_rank: int = 0
 
 
 class KVPoll:
@@ -133,6 +144,7 @@ class BaseKVSender(ABC):
         self,
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
+        token_position_offset: int = 0,
     ):
         """
         Send the kv cache at the given kv indices and the extra cache/state at the given indices to the decoder server.

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -74,6 +74,8 @@ class PrefillServerInfo:
     kv_cache_dtype: Optional[str]
     follow_bootstrap_room: bool
     enable_dsa_cache_layer_split: bool = False
+    cp_strategy: Optional[str] = None
+    disaggregation_pcp_dcp_rank_affinity: bool = False
 
     # PD true-retraction rebootstrap: the prefill's HTTP API port. The decode
     # already knows the prefill host (the bootstrap_addr host), so it can POST
@@ -100,6 +102,12 @@ class PrefillServerInfo:
         )
         self.follow_bootstrap_room = bool(self.follow_bootstrap_room)
         self.enable_dsa_cache_layer_split = bool(self.enable_dsa_cache_layer_split)
+        self.cp_strategy = (
+            str(self.cp_strategy) if self.cp_strategy is not None else None
+        )
+        self.disaggregation_pcp_dcp_rank_affinity = bool(
+            self.disaggregation_pcp_dcp_rank_affinity
+        )
         self.prefill_http_port = (
             int(self.prefill_http_port) if self.prefill_http_port is not None else None
         )
@@ -145,6 +153,17 @@ class CommonKVManager(BaseKVManager):
         self.attn_cp_rank = get_parallel().attn_cp_rank
         self.attn_dp_size = get_attention_dp_size()
         self.attn_dp_rank = get_attention_dp_rank()
+        # DCP topology of this engine. Sourced from KVArgs (filled by
+        # prefill/decode side at init); falls back to 1/0 for backward
+        # compatibility when the field is missing.
+        self.dcp_size = getattr(self.kv_args, "dcp_size", 1) or 1
+        self.dcp_rank = getattr(self.kv_args, "dcp_rank", 0) or 0
+        # Backends that have a DCP-aware transfer path must override this
+        # to True. Subclasses are expected to set the attribute *before*
+        # calling ``super().__init__`` so we don't clobber it; only set
+        # the default when the subclass hasn't already declared support.
+        if not hasattr(self, "supports_dcp_transfer"):
+            self.supports_dcp_transfer = False
         self.system_dp_size = (
             1 if server_args.enable_dp_attention else server_args.dp_size
         )
@@ -154,6 +173,13 @@ class CommonKVManager(BaseKVManager):
         self.pp_size = server_args.pp_size
         self.pp_rank = self.kv_args.pp_rank
         self.local_ip = get_local_ip_auto()
+        # DeepSeek-V4 PCP -> DCP transfer must use a one-to-one rank mapping.
+        # The generic all-CP fan-out cannot make forward progress in this
+        # topology, so this is an invariant rather than a user-tunable option.
+        self.enable_pcp_dcp_rank_affinity = (
+            self._should_enable_pcp_dcp_rank_affinity()
+        )
+        self._check_pcp_dcp_rank_affinity_local_topology()
         cp_sharded_prefill = self.attn_cp_size > 1 and (
             self.is_hybrid_mla_backend or server_args.enable_dsa_cache_layer_split
         )
@@ -166,7 +192,9 @@ class CommonKVManager(BaseKVManager):
             envs.SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER.get()
             or cp_sharded_prefill
             or hybrid_decode_pulls_all_ranks
+            or self.enable_pcp_dcp_rank_affinity
         )
+        self._check_dcp_compat()
 
         # bind zmq socket
         self._zmq_ctx = zmq.Context()
@@ -179,6 +207,7 @@ class CommonKVManager(BaseKVManager):
         self._socket_cache: Dict[str, zmq.Socket] = {}
         self._monitor_cache: Dict[str, zmq.Socket] = {}
         self._socket_lock = threading.Lock()
+        self._socket_send_locks: Dict[str, threading.Lock] = {}
         self.failure_records: Dict[int, str] = {}
         self.failure_lock = threading.Lock()
 
@@ -282,6 +311,81 @@ class CommonKVManager(BaseKVManager):
 
     def pop_pd_hidden_done(self, bootstrap_room: int) -> bool:
         return self.pop_pd_hidden_request_done(bootstrap_room)
+
+    def _check_dcp_compat(self) -> None:
+        """Refuse to start if this engine is configured with DCP but the
+        backend's transfer path has not declared explicit DCP support.
+
+        ``supports_dcp_transfer`` defaults to ``False`` in CommonKVManager.
+        Any backend that has been adapted to honor the
+        ``loc % dcp_size == dcp_rank`` storage rule must override it to
+        ``True`` before this check runs (i.e. set the flag in __init__
+        before calling super().__init__, or re-call the check after).
+        """
+        if self.dcp_size > 1 and not self.supports_dcp_transfer:
+            backend = type(self).__name__
+            raise RuntimeError(
+                f"{backend} does not yet implement DCP-aware KV transfer, "
+                f"but engine is configured with dcp_size={self.dcp_size}. "
+                "PD disaggregation under DCP requires the transfer layer "
+                "to remap logical token loc -> per-rank physical offset; "
+                "running without that remap would silently corrupt the "
+                "transferred KV cache. Use --dcp-size 1 on the "
+                "disaggregated engine, or pick a backend that has been "
+                "adapted for DCP."
+            )
+
+    def _should_enable_pcp_dcp_rank_affinity(self) -> bool:
+        """Detect the DeepSeek-V4 PCP -> DCP topology.
+
+        Keep generic CP fan-out behavior for other model families and transfer
+        backends. For the supported Mooncake DSV4 path, rank affinity is
+        mandatory whenever prefill uses PCP or decode uses DCP.
+        """
+        if not envs.SGLANG_DSV4_ENABLE_DCP.get():
+            return False
+        if self.server_args.disaggregation_transfer_backend != "mooncake":
+            return False
+        if not getattr(self.kv_args, "mla_compression_ratios", None):
+            return False
+        if self.server_args.enable_dsa_cache_layer_split:
+            return False
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            return self.attn_cp_size > 1
+        if self.disaggregation_mode == DisaggregationMode.DECODE:
+            return self.dcp_size > 1
+        return False
+
+    def _check_pcp_dcp_rank_affinity_local_topology(self) -> None:
+        if not self.enable_pcp_dcp_rank_affinity:
+            return
+        if not getattr(self.kv_args, "mla_compression_ratios", None):
+            raise RuntimeError(
+                "PCP-DCP rank affinity supports only DeepSeek-V4 compressed "
+                "KV transfer"
+            )
+        if self.server_args.enable_dsa_cache_layer_split:
+            raise RuntimeError(
+                "PCP-DCP rank affinity is incompatible with "
+                "DSA cache layer split"
+            )
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            if self.dcp_size != 1:
+                raise RuntimeError(
+                    "PCP-DCP rank affinity requires the prefill cache to be "
+                    f"unsharded (prefill dcp_size=1), got {self.dcp_size}"
+                )
+            if self.attn_cp_size <= 1 or self.server_args.cp_strategy != "interleave":
+                raise RuntimeError(
+                    "PCP-DCP rank affinity on prefill requires interleave CP "
+                    "with attn_cp_size greater than 1"
+                )
+        elif self.disaggregation_mode == DisaggregationMode.DECODE:
+            if self.attn_cp_size != 1 or self.dcp_size <= 1:
+                raise RuntimeError(
+                    "PCP-DCP rank affinity on decode requires attn_cp_size=1 "
+                    "and dcp_size greater than 1"
+                )
 
     def check_status(self, bootstrap_room: int) -> KVPoll:
         return self.request_status[bootstrap_room]
@@ -516,6 +620,15 @@ class CommonKVManager(BaseKVManager):
                 f"Both servers must use the same --kv-cache-dtype value."
             )
 
+        if (
+            info.disaggregation_pcp_dcp_rank_affinity
+            != self.enable_pcp_dcp_rank_affinity
+        ):
+            raise RuntimeError(
+                "DeepSeek-V4 PCP-DCP rank affinity topology mismatch between "
+                "prefill and decode servers"
+            )
+
         self._resolve_rank_mapping(info)
         self.prefill_info_table[bootstrap_addr] = info
         logger.debug(f"Prefill parallel info for [{bootstrap_addr}]: {info}")
@@ -569,7 +682,19 @@ class CommonKVManager(BaseKVManager):
         assert self.attn_cp_size == 1, (
             f"Decode cp size ({self.attn_cp_size}) should be equal to 1",
         )
-        if self.attn_cp_size == info.attn_cp_size:
+        if self.enable_pcp_dcp_rank_affinity:
+            self._validate_pcp_dcp_rank_affinity(info, required_dst_info_num)
+            target_cp_ranks = [self.dcp_rank]
+            # The strict topology validated above has one decode TP/DCP rank
+            # for each prefill CP rank, so each sender waits for one receiver.
+            required_dst_info_num = 1
+            logger.debug(
+                "Using PCP-DCP rank affinity: prefill_cp_rank=%d -> "
+                "decode_dcp_rank=%d",
+                self.dcp_rank,
+                self.dcp_rank,
+            )
+        elif self.attn_cp_size == info.attn_cp_size:
             assert info.attn_cp_size == 1, (
                 f"When prefill cp size is 1, attn cp size should be 1, but got {self.attn_cp_size}",
             )
@@ -603,6 +728,43 @@ class CommonKVManager(BaseKVManager):
         info.target_pp_ranks = target_pp_ranks
         info.required_dst_info_num = required_dst_info_num
         info.required_prefill_response_num = required_prefill_response_num
+
+    def _validate_pcp_dcp_rank_affinity(
+        self, info: PrefillServerInfo, required_dst_info_num: int
+    ) -> None:
+        ratios = getattr(self.kv_args, "mla_compression_ratios", None)
+        if not ratios:
+            raise RuntimeError(
+                "PCP-DCP rank affinity supports only DeepSeek-V4 compressed "
+                "KV transfer"
+            )
+        if info.enable_dsa_cache_layer_split:
+            raise RuntimeError(
+                "PCP-DCP rank affinity cannot be used when prefill enables "
+                "DSA cache layer split"
+            )
+        if info.cp_strategy != "interleave":
+            raise RuntimeError(
+                "PCP-DCP rank affinity requires prefill CP strategy "
+                f"'interleave', got {info.cp_strategy!r}"
+            )
+        if info.attn_cp_size != self.dcp_size:
+            raise RuntimeError(
+                "PCP-DCP rank affinity requires prefill CP "
+                f"size ({info.attn_cp_size}) == decode DCP size ({self.dcp_size})"
+            )
+        if self.attn_tp_size != self.dcp_size or info.attn_tp_size != 1:
+            raise RuntimeError(
+                "PCP-DCP rank affinity requires "
+                "decode attention TP == DCP and prefill attention TP == 1; "
+                f"got decode TP={self.attn_tp_size}, DCP={self.dcp_size}, "
+                f"prefill TP={info.attn_tp_size}"
+            )
+        if required_dst_info_num != self.dcp_size:
+            raise RuntimeError(
+                "Unexpected destination fan-out for PCP-DCP rank affinity: "
+                f"expected {self.dcp_size}, got {required_dst_info_num}"
+            )
 
     def _sync_bootstrap_port_across_nodes(self, local_port: int) -> int:
         """Broadcast world-rank-0's bootstrap port to all prefill ranks.
@@ -670,6 +832,8 @@ class CommonKVManager(BaseKVManager):
             "enable_dsa_cache_layer_split": getattr(
                 self.server_args, "enable_dsa_cache_layer_split", False
             ),
+            "cp_strategy": self.server_args.cp_strategy,
+            "disaggregation_pcp_dcp_rank_affinity": (self.enable_pcp_dcp_rank_affinity),
             # Self-register the HTTP API port so the decode can derive the PD
             # retract rebootstrap /generate URL from bootstrap info instead of a
             # router-injected pd_rebootstrap_prefill_url.
@@ -742,6 +906,22 @@ class CommonKVManager(BaseKVManager):
                 zmq.EVENT_DISCONNECTED
             )
             return sock
+
+    def _send_multipart(
+        self, endpoint: str, frames: List[bytes], is_ipv6: bool = False
+    ):
+        """Thread-safe multipart send on a cached ZMQ socket.
+
+        ZMQ sockets are not thread-safe. Transfer workers can concurrently send
+        control messages to the same endpoint, so serialize the complete
+        multipart operation per endpoint to keep message frame boundaries
+        intact.
+        """
+        with self._socket_lock:
+            send_lock = self._socket_send_locks.setdefault(endpoint, threading.Lock())
+
+        with send_lock:
+            self._connect(endpoint, is_ipv6=is_ipv6).send_multipart(frames)
 
     def get_mha_kv_ptrs_with_pp(
         self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
@@ -1118,20 +1298,27 @@ class CommonKVSender(BaseKVSender):
         self,
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
-    ) -> Tuple[npt.NDArray[np.int32], slice, bool, bool]:
+        token_position_offset: int = 0,
+    ) -> Tuple[npt.NDArray[np.int32], slice, bool, bool, int]:
         """Common pre-processing for send(): index tracking and CP-rank handling.
 
         Returns:
-            (kv_indices, index_slice, is_last_chunk, should_skip)
+            (kv_indices, index_slice, is_last_chunk, should_skip,
+            token_position_offset)
             If should_skip is True, the caller should return immediately.
         """
-        index_slice = slice(self.curr_idx, self.curr_idx + len(kv_indices))
+        chunk_start = self.curr_idx
+        index_slice = slice(chunk_start, chunk_start + len(kv_indices))
         self.curr_idx += len(kv_indices)
         is_last_chunk = self.curr_idx == self.num_kv_indices
 
+        # Affinity deliberately keeps the complete token mapping on each
+        # replicated PCP source. The DSV4 Mooncake path selects the matched
+        # destination's C4/C128 owners after computing compressed slot locs.
         if (
             self.kv_mgr.enable_all_cp_ranks_for_transfer
             and not self.kv_mgr.server_args.enable_dsa_cache_layer_split
+            and not self.kv_mgr.enable_pcp_dcp_rank_affinity
         ):
             kv_indices, index_slice = filter_kv_indices_for_cp_rank(
                 self.kv_mgr,
@@ -1139,19 +1326,41 @@ class CommonKVSender(BaseKVSender):
                 index_slice,
                 total_pages=self.num_kv_indices,
             )
+            # ``token_position_offset`` describes the sequence position before
+            # the unfiltered chunk. CP filtering slices that chunk by
+            # request-local position, so advance the offset by the number of
+            # entries removed from its front. DSV4 uses this offset to select
+            # c4/c128 compression boundaries; keeping the old chunk offset can
+            # address a neighboring compressed slot when the CP split is not
+            # aligned to the compression ratio.
+            assert index_slice.start is not None
+            token_position_offset += index_slice.start - chunk_start
         elif self.kv_mgr.is_dummy_cp_rank:
             if not is_last_chunk:
-                return kv_indices, index_slice, is_last_chunk, True
+                return (
+                    kv_indices,
+                    index_slice,
+                    is_last_chunk,
+                    True,
+                    token_position_offset,
+                )
             else:
                 self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Success)
-                return kv_indices, index_slice, is_last_chunk, True
+                return (
+                    kv_indices,
+                    index_slice,
+                    is_last_chunk,
+                    True,
+                    token_position_offset,
+                )
 
-        return kv_indices, index_slice, is_last_chunk, False
+        return kv_indices, index_slice, is_last_chunk, False, token_position_offset
 
     def send(
         self,
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
+        token_position_offset: int = 0,
     ):
         pass
 
@@ -1493,6 +1702,8 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.kv_cache_dtype: Optional[str] = None
         self.follow_bootstrap_room: Optional[bool] = None
         self.enable_dsa_cache_layer_split: Optional[bool] = None
+        self.cp_strategy: Optional[str] = None
+        self.disaggregation_pcp_dcp_rank_affinity: Optional[bool] = None
         self.prefill_http_port: Optional[int] = None
         self.prefill_port_table: Dict[
             int, Dict[int, Dict[int, Dict[int, PrefillRankInfo]]]
@@ -1594,6 +1805,14 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 data.get("enable_dsa_cache_layer_split", False)
             )
 
+        if self.cp_strategy is None:
+            self.cp_strategy = data.get("cp_strategy")
+
+        if self.disaggregation_pcp_dcp_rank_affinity is None:
+            self.disaggregation_pcp_dcp_rank_affinity = bool(
+                data.get("disaggregation_pcp_dcp_rank_affinity", False)
+            )
+
         if system_dp_size == 1:
             dp_group = attn_dp_rank
         else:
@@ -1658,6 +1877,10 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                     else True
                 ),
                 enable_dsa_cache_layer_split=bool(self.enable_dsa_cache_layer_split),
+                cp_strategy=self.cp_strategy,
+                disaggregation_pcp_dcp_rank_affinity=bool(
+                    self.disaggregation_pcp_dcp_rank_affinity
+                ),
                 prefill_http_port=self.prefill_http_port,
             )
             return web.json_response(dataclasses.asdict(info), status=200)

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -24,6 +24,7 @@ class TransferKVChunk:
     is_last_chunk: bool
     prefill_aux_index: Optional[int]
     state_indices: Optional[List]
+    token_position_offset: int = 0
     chunk_id: Optional[int] = None
     kv_sent: bool = False
     pd_hidden_packet_idx: int = 0

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -38,6 +38,7 @@ class TransferKVChunk:
     pd_hidden_is_last_chunk: bool = False
     pd_hidden_release_indices: Optional[List[int]] = None
     enqueue_time: float = 0.0
+    queue_index: Optional[int] = None
     source_event: Optional[Any] = None
     trace_ctx: Union[TraceReqContext, TraceNullContext] = dataclasses.field(
         default_factory=TraceNullContext

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -58,6 +58,7 @@ from sglang.srt.disaggregation.utils import (
     ReqToMetadataIdxAllocator,
     TransferBackend,
     _is_fake_transfer,
+    filter_kv_indices_for_dcp_rank,
     get_dsv4_c128_state_indices,
     get_kv_class,
     is_dsv4_c128_online_enabled,
@@ -67,6 +68,7 @@ from sglang.srt.disaggregation.utils import (
     prepare_abort,
     setup_state_kv_args,
 )
+from sglang.srt.distributed.parallel_state import get_dcp_rank, get_dcp_world_size
 from sglang.srt.distributed.utils import get_pp_indices
 from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import (
@@ -560,6 +562,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
         kv_args.pp_rank = self.pp_rank
         kv_args.system_dp_rank = self.scheduler.ps.dp_rank
+        kv_args.dcp_size = get_dcp_world_size()
+        kv_args.dcp_rank = get_dcp_rank()
         transfer_kv_pool = (
             self.scheduler.hisparse_coordinator.mem_pool_host
             if self.scheduler.enable_hisparse
@@ -601,6 +605,18 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         if self.transfer_backend == TransferBackend.NIXL:
             kv_args.kv_data_mem_kinds = kv_data_mem_kinds
         kv_args.page_size = self.token_to_kv_pool.page_size
+        kv_args.swa_page_size = getattr(self.token_to_kv_pool, "swa_page_size", None)
+        kv_args.prefill_start_layer = getattr(self.token_to_kv_pool, "start_layer", 0)
+        kv_args.prefill_end_layer = getattr(
+            self.token_to_kv_pool,
+            "end_layer",
+            self.scheduler.model_config.num_hidden_layers,
+        )
+        kv_args.mla_compression_ratios = None
+        if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+            kv_args.mla_compression_ratios = list(
+                self.token_to_kv_pool.compression_ratios
+            )
 
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (
             self.metadata_buffers.get_buf_infos()
@@ -1567,6 +1583,25 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     decode_req.req.req_pool_idx
                 ][total_prefix_len:origin_input_len]
 
+            # DCP: ``req_to_token`` (and the hisparse host pool too, when
+            # used as the RDMA destination) stores cluster-wide global
+            # token loc. The transfer layer addresses GPU buffers using
+            # per-rank physical offsets, so convert before
+            # ``kv_to_page_indices``. No-op when dcp_size == 1.
+            dcp_size_local = getattr(self.kv_manager, "dcp_size", 1) or 1
+            dcp_rank_local = getattr(self.kv_manager, "dcp_rank", 0) or 0
+            token_to_kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
+            dsv4_dcp_transfer = (
+                isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool)
+                or isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)
+            ) and (
+                dcp_size_local > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get()
+            )
+            if dcp_size_local > 1 and not dsv4_dcp_transfer:
+                kv_indices = filter_kv_indices_for_dcp_rank(
+                    kv_indices, dcp_size_local, dcp_rank_local
+                )
+
             seq_len = origin_input_len
 
             def _mamba_payload():
@@ -1590,7 +1625,20 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                         window_kv_indices_full
                     )
                 )
-                return kv_to_page_indices(window_kv_indices_swa, page_size)
+                window_kv_indices_swa_np = window_kv_indices_swa.cpu().numpy()
+                if dsv4_dcp_transfer:
+                    # DSV4 state_data is heterogeneous. Carry the full-token
+                    # locs and sequence offset so Mooncake can derive the
+                    # matching compressed-slot/state rows.
+                    return [
+                        window_kv_indices_swa_np,
+                        kv_to_page_indices(window_kv_indices_swa_np, page_size),
+                        window_kv_indices_full.cpu().numpy(),
+                        np.array([window_start], dtype=np.int32),
+                    ]
+                return kv_to_page_indices(
+                    window_kv_indices_swa_np, page_size
+                )
 
             def _dsa_payload():
                 kv_indices_full = self.req_to_token_pool.req_to_token[
@@ -1662,6 +1710,24 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             ):
                 state_indices = None
 
+            metadata_state_indices = state_indices
+            if dsv4_dcp_transfer and state_indices and isinstance(
+                state_indices[0], (list, tuple)
+            ):
+                # DSV4 transfer carries an expanded SWA payload:
+                # [swa_locs, swa_pages, full_locs, position_offset].
+                # It describes all heterogeneous DSV4 state buffers, including
+                # c128 chunk positions. Online c128 state is request-scoped,
+                # so append its component row separately for the transfer
+                # backend.
+                metadata_state_indices = list(state_indices[0])
+                if StateType.SWA_RING in state_types:
+                    swa_ring_state_idx = state_types.index(StateType.SWA_RING)
+                    metadata_state_indices.append(state_indices[swa_ring_state_idx])
+                if StateType.C128_STATE in state_types:
+                    c128_state_idx = state_types.index(StateType.C128_STATE)
+                    metadata_state_indices.append(state_indices[c128_state_idx])
+
             spec_metadata = None
             if pd_hidden_dst_indices_by_pp is not None:
                 model_runner = self.scheduler.tp_worker.model_runner
@@ -1714,10 +1780,19 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 self.req_to_metadata_buffer_idx_allocator.alloc()
             )
             assert decode_req.metadata_buffer_index is not None
+            page_indices = kv_to_page_indices(kv_indices, kv_transfer_page_size)
+            if dsv4_dcp_transfer:
+                # DSV4+DCP transfer derives c4/c128 compressed slots from the
+                # original token locs on both prefill and decode. Page indices
+                # would collapse several prompt tokens into one entry and break
+                # the positional pairing in the transfer backend.
+                page_indices = (
+                    kv_indices.cpu().numpy()
+                    if isinstance(kv_indices, torch.Tensor)
+                    else kv_indices
+                )
             # int32 for ZMQ serialization -- from_zmq reads np.int32.
-            page_indices = kv_to_page_indices(kv_indices, kv_transfer_page_size).astype(
-                np.int32
-            )
+            page_indices = np.asarray(page_indices, dtype=np.int32)
             if (
                 self._uses_dsv4_decode_radix_cache()
                 and envs.SGLANG_DEBUG_DSV4_DECODE_RADIX_TRANSFER.get()
@@ -1736,7 +1811,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             decode_req.kv_receiver.send_metadata(
                 page_indices,
                 decode_req.metadata_buffer_index,
-                state_indices,
+                metadata_state_indices,
                 decode_prefix_len=total_prefix_len,
                 spec_metadata=spec_metadata,
             )

--- a/python/sglang/srt/disaggregation/fake/conn.py
+++ b/python/sglang/srt/disaggregation/fake/conn.py
@@ -78,6 +78,7 @@ class FakeKVSender(BaseKVSender):
         self,
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
+        token_position_offset: int = 0,
     ):
         self.has_sent = True
         logger.debug(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -39,6 +39,9 @@ from sglang.srt.disaggregation.common.utils import (
     unpack_int_lists,
 )
 from sglang.srt.disaggregation.hidden_events import PDHiddenEventManager
+from sglang.srt.disaggregation.mooncake.transfer_debug import (
+    MooncakeTransferDebugStats,
+)
 from sglang.srt.disaggregation.mooncake.utils import (
     check_mooncake_custom_mem_pool_enabled,
 )
@@ -231,6 +234,7 @@ class MooncakeKVManager(CommonKVManager):
         self.pd_hidden_events = PDHiddenEventManager(self)
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         self.enable_trace = server_args.enable_trace
+        self.transfer_debug_stats: Optional[MooncakeTransferDebugStats] = None
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self.session_failures = defaultdict(int)
             self.failed_sessions = set()
@@ -247,6 +251,14 @@ class MooncakeKVManager(CommonKVManager):
             self.transfer_queues: List[FastQueue] = [
                 FastQueue() for _ in range(transfer_queue_size)
             ]
+            if envs.SGLANG_DISAGGREGATION_TRANSFER_DEBUG.get():
+                self.transfer_debug_stats = MooncakeTransferDebugStats(
+                    rank_label=(
+                        f"tp{self.attn_tp_rank}/pp{self.pp_rank}/cp{self.attn_cp_rank}"
+                    ),
+                    queue_count=transfer_queue_size,
+                )
+                self.transfer_debug_stats.start()
             self._session_group_queue_shards: dict[Tuple[str, ...], int] = {}
             self._session_group_queue_lock = threading.Lock()
             assert transfer_thread_pool_size >= transfer_queue_size, (
@@ -683,6 +695,12 @@ class MooncakeKVManager(CommonKVManager):
                     f"chunk exceeds ring buffer total size (room={kv_chunk.room}). "
                     f"Increase SGLANG_DISAGG_STAGING_POOL_SIZE_MB."
                 )
+            if (
+                self.transfer_debug_stats is not None
+                and kv_chunk.queue_index is not None
+            ):
+                kv_chunk.enqueue_time = time.perf_counter()
+                self.transfer_debug_stats.record_enqueue(kv_chunk.queue_index)
             queue.put(kv_chunk)
             return (-1, True)
 
@@ -837,13 +855,47 @@ class MooncakeKVManager(CommonKVManager):
             )
         return ret
 
+    def _batch_transfer_sync(
+        self,
+        mooncake_session_id: str,
+        src_addrs: list[int],
+        dst_addrs: list[int],
+        lengths: list[int],
+    ) -> int:
+        stats = self.transfer_debug_stats
+        start_time = 0.0
+        error = False
+        if stats is not None:
+            start_time = time.perf_counter()
+            stats.record_engine_start()
+        try:
+            ret = self.engine.batch_transfer_sync(
+                mooncake_session_id, src_addrs, dst_addrs, lengths
+            )
+            error = ret != 0
+            return ret
+        except Exception:
+            error = True
+            raise
+        finally:
+            if stats is not None:
+                stats.record_engine_done(
+                    time.perf_counter() - start_time,
+                    sum(lengths),
+                    len(lengths),
+                    error=error,
+                )
+
     def _transfer_data(self, mooncake_session_id, transfer_blocks):
         if not transfer_blocks:
             return 0
 
         src_addrs, dst_addrs, lengths = zip(*transfer_blocks)
-        return self.engine.batch_transfer_sync(
-            mooncake_session_id, list(src_addrs), list(dst_addrs), list(lengths)
+        return self._batch_transfer_sync(
+            mooncake_session_id,
+            list(src_addrs),
+            list(dst_addrs),
+            list(lengths),
         )
 
     def _send_kvcache_generic(
@@ -1921,7 +1973,7 @@ class MooncakeKVManager(CommonKVManager):
             dst_addr_list = dst_slice_addrs.reshape(-1).tolist()
             total_slices = len(src_addr_list)
             length_list = [heads_bytes_per_token_to_send] * total_slices
-            return self.engine.batch_transfer_sync(
+            return self._batch_transfer_sync(
                 mooncake_session_id, src_addr_list, dst_addr_list, length_list
             )
 
@@ -2515,16 +2567,25 @@ class MooncakeKVManager(CommonKVManager):
     def sync_status_to_decode_endpoint(
         self, remote: str, dst_port: int, room: int, status: int, prefill_rank: int
     ):
-        na = NetworkAddress(remote, dst_port)
-        self._send_multipart(
-            na.to_tcp(),
-            [
-                str(room).encode("ascii"),
-                str(status).encode("ascii"),
-                str(prefill_rank).encode("ascii"),
-            ],
-            is_ipv6=na.is_ipv6,
+        start_time = (
+            time.perf_counter() if self.transfer_debug_stats is not None else 0.0
         )
+        na = NetworkAddress(remote, dst_port)
+        try:
+            self._send_multipart(
+                na.to_tcp(),
+                [
+                    str(room).encode("ascii"),
+                    str(status).encode("ascii"),
+                    str(prefill_rank).encode("ascii"),
+                ],
+                is_ipv6=na.is_ipv6,
+            )
+        finally:
+            if self.transfer_debug_stats is not None:
+                self.transfer_debug_stats.record_status_sync(
+                    time.perf_counter() - start_time
+                )
 
     def transfer_worker(
         self,
@@ -2542,8 +2603,19 @@ class MooncakeKVManager(CommonKVManager):
             )
 
         while True:
+            chunk_debug_active = False
+            chunk_debug_start = 0.0
             try:
                 kv_chunk: TransferKVChunk = queue.get()
+                if self.transfer_debug_stats is not None:
+                    chunk_debug_start = time.perf_counter()
+                    queue_wait = (
+                        chunk_debug_start - kv_chunk.enqueue_time
+                        if kv_chunk.enqueue_time > 0
+                        else 0.0
+                    )
+                    self.transfer_debug_stats.record_dequeue(worker_index, queue_wait)
+                    chunk_debug_active = True
                 if self.enable_trace:
                     kv_chunk.trace_ctx.rebuild_thread_context()
                     kv_chunk.trace_ctx.trace_slice_start(
@@ -2576,6 +2648,13 @@ class MooncakeKVManager(CommonKVManager):
                             MooncakeRequestStage.MOONCAKE_WORKER_SEND.level,
                             thread_finish_flag=True,
                         )
+                    if self.transfer_debug_stats is not None:
+                        self.transfer_debug_stats.record_chunk_done(
+                            worker_index,
+                            time.perf_counter() - chunk_debug_start,
+                            skipped=True,
+                        )
+                        chunk_debug_active = False
                     continue
 
                 if (
@@ -2838,9 +2917,17 @@ class MooncakeKVManager(CommonKVManager):
                         skip_kv, skip_state = self._get_dsa_cache_transfer_skip_flags(
                             target_rank_registration_info
                         )
-                        if kv_chunk.kv_sent:
-                            ret = 0
-                        elif len(kv_chunk.prefill_kv_indices) == 0 or skip_kv:
+                        kv_skipped = (
+                            kv_chunk.kv_sent
+                            or len(kv_chunk.prefill_kv_indices) == 0
+                            or skip_kv
+                        )
+                        kv_send_start = (
+                            time.perf_counter()
+                            if self.transfer_debug_stats is not None
+                            else 0.0
+                        )
+                        if kv_skipped:
                             ret = 0
                         else:
                             if (
@@ -2874,6 +2961,12 @@ class MooncakeKVManager(CommonKVManager):
                                 )
                                 if deferred:
                                     staging_deferred = True
+                                    if self.transfer_debug_stats is not None:
+                                        self.transfer_debug_stats.record_kv_send(
+                                            time.perf_counter() - kv_send_start,
+                                            len(kv_chunk.prefill_kv_indices),
+                                            skipped=False,
+                                        )
                                     # Chunk re-enqueued; stop processing remaining reqs for this chunk
                                     break
                             else:
@@ -2887,6 +2980,12 @@ class MooncakeKVManager(CommonKVManager):
                                     target_rank_registration_info.dst_kv_item_len,
                                     executor,
                                 )
+                        if self.transfer_debug_stats is not None:
+                            self.transfer_debug_stats.record_kv_send(
+                                time.perf_counter() - kv_send_start,
+                                len(kv_chunk.prefill_kv_indices),
+                                skipped=kv_skipped,
+                            )
                         if ret != 0:
                             self._mark_session_failed_and_sync(
                                 kv_chunk=kv_chunk,
@@ -2901,6 +3000,11 @@ class MooncakeKVManager(CommonKVManager):
 
                         if kv_chunk.is_last_chunk:
                             if kv_chunk.state_indices and not skip_state:
+                                state_send_start = (
+                                    time.perf_counter()
+                                    if self.transfer_debug_stats is not None
+                                    else 0.0
+                                )
                                 self.maybe_send_extra(
                                     req,
                                     self._without_pd_hidden_state(
@@ -2909,13 +3013,26 @@ class MooncakeKVManager(CommonKVManager):
                                     executor,
                                     target_rank_registration_info,
                                 )
+                                if self.transfer_debug_stats is not None:
+                                    self.transfer_debug_stats.record_state_send(
+                                        time.perf_counter() - state_send_start
+                                    )
 
                             # Only the last chunk we need to send the aux data
+                            aux_send_start = (
+                                time.perf_counter()
+                                if self.transfer_debug_stats is not None
+                                else 0.0
+                            )
                             ret = self.send_aux(
                                 req,
                                 kv_chunk.prefill_aux_index,
                                 target_rank_registration_info.dst_aux_ptrs,
                             )
+                            if self.transfer_debug_stats is not None:
+                                self.transfer_debug_stats.record_aux_send(
+                                    time.perf_counter() - aux_send_start
+                                )
                             polls.append(True if ret == 0 else False)
                             dst_ranks_infos.append(
                                 (req.endpoint, req.dst_port, req.room)
@@ -2953,6 +3070,12 @@ class MooncakeKVManager(CommonKVManager):
                     )
 
                 if staging_deferred:
+                    if self.transfer_debug_stats is not None:
+                        self.transfer_debug_stats.record_chunk_done(
+                            worker_index,
+                            time.perf_counter() - chunk_debug_start,
+                        )
+                        chunk_debug_active = False
                     continue
                 current_status = self.request_status.get(kv_chunk.room)
                 if current_status is not None and current_status != KVPoll.Failed:
@@ -2987,7 +3110,19 @@ class MooncakeKVManager(CommonKVManager):
                         self.transfer_infos.pop(kv_chunk.room)
                     self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
 
+                if self.transfer_debug_stats is not None:
+                    self.transfer_debug_stats.record_chunk_done(
+                        worker_index,
+                        time.perf_counter() - chunk_debug_start,
+                    )
+                    chunk_debug_active = False
             except Exception as e:
+                if self.transfer_debug_stats is not None and chunk_debug_active:
+                    self.transfer_debug_stats.record_chunk_done(
+                        worker_index,
+                        time.perf_counter() - chunk_debug_start,
+                        error=True,
+                    )
                 # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
                 raise RuntimeError(
                     f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
@@ -3289,23 +3424,26 @@ class MooncakeKVManager(CommonKVManager):
         if trace_ctx is None:
             trace_ctx = TraceNullContext()
 
-        self.transfer_queues[shard_idx].put(
-            TransferKVChunk(
-                room=bootstrap_room,
-                prefill_kv_indices=kv_indices,
-                index_slice=index_slice,
-                is_last_chunk=is_last_chunk,
-                prefill_aux_index=aux_index,
-                state_indices=state_indices,
-                token_position_offset=token_position_offset,
-                source_event=source_event,
-                pd_hidden_start=pd_hidden_start,
-                pd_hidden_row_len=pd_hidden_row_len,
-                pd_hidden_is_last_chunk=pd_hidden_is_last_chunk,
-                pd_hidden_release_indices=pd_hidden_release_indices,
-                trace_ctx=trace_ctx,
-            )
+        kv_chunk = TransferKVChunk(
+            room=bootstrap_room,
+            prefill_kv_indices=kv_indices,
+            index_slice=index_slice,
+            is_last_chunk=is_last_chunk,
+            prefill_aux_index=aux_index,
+            state_indices=state_indices,
+            token_position_offset=token_position_offset,
+            source_event=source_event,
+            pd_hidden_start=pd_hidden_start,
+            pd_hidden_row_len=pd_hidden_row_len,
+            pd_hidden_is_last_chunk=pd_hidden_is_last_chunk,
+            pd_hidden_release_indices=pd_hidden_release_indices,
+            trace_ctx=trace_ctx,
         )
+        if self.transfer_debug_stats is not None:
+            kv_chunk.enqueue_time = time.perf_counter()
+            kv_chunk.queue_index = shard_idx
+            self.transfer_debug_stats.record_enqueue(shard_idx)
+        self.transfer_queues[shard_idx].put(kv_chunk)
 
     def get_session_id(self):
         return self.engine.get_session_id()

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -69,6 +69,32 @@ FAILED_SESSION_RECOVERIES = Counter(
 )
 
 
+def _parse_transfer_status_message(
+    msg: List[bytes],
+) -> Optional[Tuple[int, int, int]]:
+    if len(msg) != 3:
+        logger.error(
+            "Ignoring malformed Mooncake transfer status message: "
+            "expected 3 frames, got %d (header=%r)",
+            len(msg),
+            msg[0][:64] if msg else None,
+        )
+        return None
+
+    try:
+        bootstrap_room, status, prefill_rank = (
+            int(frame.decode("ascii")) for frame in msg
+        )
+    except (UnicodeDecodeError, ValueError):
+        logger.exception(
+            "Ignoring malformed Mooncake transfer status fields (header=%r)",
+            msg[0][:64],
+        )
+        return None
+
+    return bootstrap_room, status, prefill_rank
+
+
 # decode
 @dataclasses.dataclass
 class TransferInfo:
@@ -135,11 +161,16 @@ class KVArgsRegisterInfo:
     # for mamba state different tp slice transfer
     dst_state_item_lens: List[List[int]]
     dst_state_dim_per_tensor: List[List[int]]
+    enable_hisparse: bool = False
+    dst_dcp_size: int = 1
+    dst_dcp_rank: int = 0
     # Note: always put the staging field at the final (since the staging field is optional and contains multiple inputs)
     staging: Optional[StagingRegisterInfo] = None
 
     @classmethod
     def from_zmq(cls, msg: List[bytes]):
+        has_dcp_fields = len(msg) > 14 and msg[12] in (b"0", b"1")
+        staging_offset = 15 if has_dcp_fields else 12
         return cls(
             room=str(msg[0].decode("ascii")),
             endpoint=msg[1].decode("ascii"),
@@ -157,8 +188,13 @@ class KVArgsRegisterInfo:
             dst_state_dim_per_tensor=(
                 unpack_int_lists(msg[11], "I") if len(msg) > 11 else []
             ),
+            enable_hisparse=(
+                msg[12].decode("ascii") == "1" if has_dcp_fields else False
+            ),
+            dst_dcp_size=int(msg[13].decode("ascii")) if has_dcp_fields else 1,
+            dst_dcp_rank=int(msg[14].decode("ascii")) if has_dcp_fields else 0,
             # Note: always put the staging field at the final
-            staging=StagingRegisterInfo.from_zmq_fields(msg, 12),
+            staging=StagingRegisterInfo.from_zmq_fields(msg, staging_offset),
         )
 
 
@@ -174,6 +210,20 @@ class MooncakeKVManager(CommonKVManager):
         server_args: ServerArgs,
         is_mla_backend: Optional[bool] = False,
     ):
+        # Mooncake's RDMA path (``_send_kvcache_generic``) addresses GPU
+        # buffers with ``ptr + index * item_len``. In DCP mode the transfer
+        # path passes rank-local token-loc arrays and switches ``item_len``
+        # from per-page to per-token (see ``send_kvcache``), so the
+        # backend supports DCP without protocol changes.
+        #
+        # Limit DCP support to Mooncake paths implemented here. Standard
+        # MLA/MHA single-pool DCP uses token-level item strides; DSV4 uses
+        # dedicated bucket-aware routines for c4/c128/state buffers. HiSparse's
+        # host-pool path still needs its own transfer routine and remains
+        # blocked.
+        dcp_size_init = getattr(args, "dcp_size", 1) or 1
+        is_hisparse = bool(getattr(server_args, "enable_hisparse", False))
+        self.supports_dcp_transfer = dcp_size_init <= 1 or not is_hisparse
         super().__init__(args, disaggregation_mode, server_args, is_mla_backend)
         self.init_engine()
         self.register_buffer_to_engine()
@@ -197,6 +247,8 @@ class MooncakeKVManager(CommonKVManager):
             self.transfer_queues: List[FastQueue] = [
                 FastQueue() for _ in range(transfer_queue_size)
             ]
+            self._session_group_queue_shards: dict[Tuple[str, ...], int] = {}
+            self._session_group_queue_lock = threading.Lock()
             assert transfer_thread_pool_size >= transfer_queue_size, (
                 f"The environment variable SGLANG_DISAGGREGATION_THREAD_POOL_SIZE={transfer_thread_pool_size} must be "
                 f"greater than or equal to SGLANG_DISAGGREGATION_QUEUE_SIZE={transfer_queue_size}."
@@ -584,10 +636,8 @@ class MooncakeKVManager(CommonKVManager):
         """Notify decode that a non-last staging chunk RDMA is complete."""
         try:
             na = NetworkAddress(req.endpoint, req.dst_port)
-            self._connect(
+            self._send_multipart(
                 na.to_tcp(),
-                is_ipv6=na.is_ipv6,
-            ).send_multipart(
                 [
                     b"CHUNK_READY",
                     str(req.room).encode("ascii"),
@@ -596,7 +646,8 @@ class MooncakeKVManager(CommonKVManager):
                     str(len(kv_chunk.prefill_kv_indices)).encode("ascii"),
                     req.mooncake_session_id.encode("ascii"),
                     str(prefill_unique_rank).encode("ascii"),
-                ]
+                ],
+                is_ipv6=na.is_ipv6,
             )
         except Exception:
             pass
@@ -909,6 +960,812 @@ class MooncakeKVManager(CommonKVManager):
             # compared to using multiple threads
             return process_layers(layers_params)
 
+    def _send_indexed_layers(
+        self,
+        mooncake_session_id: str,
+        src_data_ptrs: list[int],
+        dst_data_ptrs: list[int],
+        item_lens: list[int],
+        prefill_data_indices: npt.NDArray[np.int32],
+        dst_data_indices: npt.NDArray[np.int32],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ) -> int:
+        """Send already-aligned layer buffers with caller-provided indices.
+
+        This is the same transfer primitive as ``_send_kvcache_generic``, but
+        without MHA/MLA pointer slicing. DSV4+DCP needs to split the flat DSV4
+        layout into buckets first because c4/c128 buffers use different local
+        index spaces from the SWA/token buffer.
+        """
+        if len(src_data_ptrs) == 0 or len(prefill_data_indices) == 0:
+            return 0
+
+        prefill_blocks, dst_blocks = group_concurrent_contiguous(
+            prefill_data_indices, dst_data_indices
+        )
+        layers_params = list(zip(src_data_ptrs, dst_data_ptrs, item_lens))
+
+        def set_transfer_blocks(
+            src_ptr: int, dst_ptr: int, item_len: int
+        ) -> List[Tuple[int, int, int]]:
+            transfer_blocks = []
+            for prefill_index, decode_index in zip(prefill_blocks, dst_blocks):
+                src_addr = src_ptr + int(prefill_index[0]) * item_len
+                dst_addr = dst_ptr + int(decode_index[0]) * item_len
+                transfer_blocks.append(
+                    (src_addr, dst_addr, item_len * len(prefill_index))
+                )
+            return transfer_blocks
+
+        if self.enable_custom_mem_pool:
+            futures = [
+                executor.submit(
+                    self._transfer_data,
+                    mooncake_session_id,
+                    set_transfer_blocks(src_ptr, dst_ptr, item_len),
+                )
+                for (src_ptr, dst_ptr, item_len) in layers_params
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                status = future.result()
+                if status != 0:
+                    for f in futures:
+                        f.cancel()
+                    return status
+            return 0
+
+        transfer_blocks = []
+        for src_ptr, dst_ptr, item_len in layers_params:
+            transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, item_len))
+        return self._transfer_data(mooncake_session_id, transfer_blocks)
+
+    def _send_dsv4_packed_token_layers(
+        self,
+        mooncake_session_id: str,
+        src_data_ptrs: list[int],
+        dst_data_ptrs: list[int],
+        page_item_lens: list[int],
+        src_token_locs: npt.NDArray[np.int32],
+        dst_token_locs: npt.NDArray[np.int32],
+        page_size: int,
+        token_segments: List[Tuple[int, int]],
+        executor: concurrent.futures.ThreadPoolExecutor,
+    ) -> int:
+        """Send token-indexed slices from DSV4 packed page buffers.
+
+        DSV4 KV pages are not laid out as one contiguous record per token.
+        FlashMLA buffers store all tokens' nope/rope bytes first, followed by
+        all tokens' scale bytes; indexer buffers follow the same two-segment
+        page pattern. A token-level RDMA copy therefore has to copy each page
+        segment separately instead of using ``page_bytes / page_size`` as a
+        fake per-token stride.
+        """
+        if (
+            len(src_data_ptrs) == 0
+            or len(src_token_locs) == 0
+            or len(dst_token_locs) == 0
+        ):
+            return 0
+        if src_token_locs.size != dst_token_locs.size:
+            min_len = min(src_token_locs.size, dst_token_locs.size)
+            logger.warning(
+                "DSV4 packed token transfer loc count mismatch: src=%d dst=%d, clipping to %d",
+                src_token_locs.size,
+                dst_token_locs.size,
+                min_len,
+            )
+            src_token_locs = src_token_locs[:min_len]
+            dst_token_locs = dst_token_locs[:min_len]
+
+        src_blocks, dst_blocks = group_concurrent_contiguous(
+            src_token_locs, dst_token_locs
+        )
+        layers_params = list(zip(src_data_ptrs, dst_data_ptrs, page_item_lens))
+
+        def set_transfer_blocks(
+            src_ptr: int, dst_ptr: int, page_item_len: int
+        ) -> List[Tuple[int, int, int]]:
+            transfer_blocks = []
+            for src_group, dst_group in zip(src_blocks, dst_blocks):
+                src_start = int(src_group[0])
+                dst_start = int(dst_group[0])
+                count = len(src_group)
+                offset = 0
+                while offset < count:
+                    src_loc = src_start + offset
+                    dst_loc = dst_start + offset
+                    src_page = src_loc // page_size
+                    dst_page = dst_loc // page_size
+                    src_in_page = src_loc % page_size
+                    dst_in_page = dst_loc % page_size
+                    chunk = min(
+                        count - offset,
+                        page_size - src_in_page,
+                        page_size - dst_in_page,
+                    )
+                    for segment_page_offset, segment_len in token_segments:
+                        src_addr = (
+                            src_ptr
+                            + src_page * page_item_len
+                            + segment_page_offset
+                            + src_in_page * segment_len
+                        )
+                        dst_addr = (
+                            dst_ptr
+                            + dst_page * page_item_len
+                            + segment_page_offset
+                            + dst_in_page * segment_len
+                        )
+                        transfer_blocks.append(
+                            (src_addr, dst_addr, segment_len * chunk)
+                        )
+                    offset += chunk
+            return transfer_blocks
+
+        if self.enable_custom_mem_pool:
+            futures = [
+                executor.submit(
+                    self._transfer_data,
+                    mooncake_session_id,
+                    set_transfer_blocks(src_ptr, dst_ptr, page_item_len),
+                )
+                for (src_ptr, dst_ptr, page_item_len) in layers_params
+            ]
+            for future in concurrent.futures.as_completed(futures):
+                status = future.result()
+                if status != 0:
+                    for f in futures:
+                        f.cancel()
+                    return status
+            return 0
+
+        transfer_blocks = []
+        for src_ptr, dst_ptr, page_item_len in layers_params:
+            transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, page_item_len))
+        return self._transfer_data(mooncake_session_id, transfer_blocks)
+
+    def _is_dsv4_pool(self) -> bool:
+        return bool(getattr(self.kv_args, "mla_compression_ratios", None))
+
+    def _dsv4_stage_bucket_counts(self) -> Tuple[int, int, int]:
+        ratios = getattr(self.kv_args, "mla_compression_ratios", None) or []
+        start_layer = self.kv_args.prefill_start_layer
+        end_layer = getattr(self.kv_args, "prefill_end_layer", None)
+        assert end_layer is not None
+        stage_ratios = ratios[start_layer:end_layer]
+        c4_count = sum(1 for r in stage_ratios if r == 4)
+        c128_count = sum(1 for r in stage_ratios if r == 128)
+        swa_count = end_layer - start_layer
+        return swa_count, c4_count, c128_count
+
+    def _dsv4_bucket_locs_from_token_locs(
+        self,
+        token_locs: npt.NDArray[np.int32],
+        compression_ratio: int,
+        position_offset: int = 0,
+    ) -> npt.NDArray[np.int32]:
+        """Map full-token locs to DSV4 c4/c128 global pool locs.
+
+        DSV4 writes compressed KV only at compression boundaries. The metadata
+        kernel stores those slots as ``raw_out_loc // ratio`` when
+        ``(seq_len % ratio) == 0``. The predicate is sequence-position based,
+        while ``raw_out_loc`` is allocator state and must only be used for the
+        compressed destination slot. DCP sharding is applied by the caller
+        because source and destination DCP topologies may differ.
+        """
+        if token_locs.size == 0:
+            return np.array([], dtype=np.int32)
+
+        positions = np.arange(
+            position_offset + 1,
+            position_offset + token_locs.size + 1,
+            dtype=np.int64,
+        )
+        mask = (positions % compression_ratio) == 0
+        return (token_locs[mask] // compression_ratio).astype(np.int32, copy=False)
+
+    def _dcp_transfer_index_pair(
+        self,
+        src_global_locs: npt.NDArray[np.int32],
+        dst_global_locs: npt.NDArray[np.int32],
+        src_dcp_size: int,
+        src_dcp_rank: int,
+        dst_dcp_size: int,
+        dst_dcp_rank: int,
+    ) -> Tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]:
+        """Build source/destination physical indices for a DCP transfer.
+
+        Source and destination engines allocate KV locs independently, so the
+        numeric loc value for the same sequence position can differ. Select by
+        destination ownership, apply the same position mask to the source locs,
+        and then map each side into its own local physical address space.
+        """
+        if src_global_locs.size == 0 or dst_global_locs.size == 0:
+            empty = np.array([], dtype=np.int32)
+            return empty, empty
+        if src_global_locs.size != dst_global_locs.size:
+            min_len = min(src_global_locs.size, dst_global_locs.size)
+            logger.warning(
+                "DCP transfer loc count mismatch: src=%d dst=%d, clipping to %d",
+                src_global_locs.size,
+                dst_global_locs.size,
+                min_len,
+            )
+            src_global_locs = src_global_locs[:min_len]
+            dst_global_locs = dst_global_locs[:min_len]
+
+        mask = np.ones(dst_global_locs.shape, dtype=bool)
+        if dst_dcp_size > 1:
+            mask &= (dst_global_locs % dst_dcp_size) == dst_dcp_rank
+        if src_dcp_size > 1:
+            mask &= (src_global_locs % src_dcp_size) == src_dcp_rank
+        selected_src = src_global_locs[mask].astype(np.int32, copy=False)
+        selected_dst = dst_global_locs[mask].astype(np.int32, copy=False)
+        if src_dcp_size > 1:
+            src_indices = (selected_src // src_dcp_size).astype(np.int32, copy=False)
+        else:
+            src_indices = selected_src
+        if dst_dcp_size > 1:
+            dst_indices = (selected_dst // dst_dcp_size).astype(np.int32, copy=False)
+        else:
+            dst_indices = selected_dst
+        return src_indices, dst_indices
+
+    def _send_dsv4_kvcache_dcp(
+        self,
+        mooncake_session_id: str,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        executor: concurrent.futures.ThreadPoolExecutor,
+        target_rank_registration_info: Optional[KVArgsRegisterInfo],
+        token_position_offset: int = 0,
+    ) -> int:
+        """DSV4 compressed KV transfer under DCP.
+
+        The DSV4 kv_data flat layout is [c4_kv, c4_indexer, c128_kv].
+        c4/c128 attention KV buffers use compressed-slot loc spaces and are
+        DCP-local. The c4 indexer is a scoring cache read with the global c4
+        page table, so it stays in global/replicated c4-index space.
+        """
+        _, c4_count, c128_count = self._dsv4_stage_bucket_counts()
+        src_ptrs, dst_ptrs, _ = self.get_mla_kv_ptrs_with_pp(
+            self.kv_args.kv_data_ptrs, dst_kv_ptrs
+        )
+        item_lens = self.kv_args.kv_item_lens
+        dst_dcp_size = (
+            target_rank_registration_info.dst_dcp_size
+            if target_rank_registration_info is not None
+            else self.dcp_size
+        )
+        dst_dcp_rank = (
+            target_rank_registration_info.dst_dcp_rank
+            if target_rank_registration_info is not None
+            else self.dcp_rank
+        )
+
+        c4_slots_per_page = max(self.kv_args.page_size // 4, 1)
+        c128_slots_per_page = max(self.kv_args.page_size // 128, 1)
+        dsv4_kv_segments = [
+            (0, 576),
+            (c4_slots_per_page * 576, 8),
+        ]
+
+        c4_src_global_locs = self._dsv4_bucket_locs_from_token_locs(
+            prefill_kv_indices, 4, token_position_offset
+        )
+        c4_dst_global_locs = self._dsv4_bucket_locs_from_token_locs(
+            dst_kv_indices, 4, token_position_offset
+        )
+        src_c4, dst_c4 = self._dcp_transfer_index_pair(
+            c4_src_global_locs,
+            c4_dst_global_locs,
+            self.dcp_size,
+            self.dcp_rank,
+            dst_dcp_size,
+            dst_dcp_rank,
+        )
+        c128_src_global_locs = self._dsv4_bucket_locs_from_token_locs(
+            prefill_kv_indices, 128, token_position_offset
+        )
+        c128_dst_global_locs = self._dsv4_bucket_locs_from_token_locs(
+            dst_kv_indices, 128, token_position_offset
+        )
+        src_c128, dst_c128 = self._dcp_transfer_index_pair(
+            c128_src_global_locs,
+            c128_dst_global_locs,
+            self.dcp_size,
+            self.dcp_rank,
+            dst_dcp_size,
+            dst_dcp_rank,
+        )
+        logger.debug(
+            "DSV4 KV transfer: tokens=%d dst_tokens=%d offset=%d "
+            "c4=%d/%d c128=%d/%d dcp=%d:%d dst_dcp=%d:%d",
+            prefill_kv_indices.size,
+            dst_kv_indices.size,
+            token_position_offset,
+            src_c4.size,
+            c4_src_global_locs.size,
+            src_c128.size,
+            c128_src_global_locs.size,
+            self.dcp_size,
+            self.dcp_rank,
+            dst_dcp_size,
+            dst_dcp_rank,
+        )
+        rc = 0
+        if c4_count > 0:
+            c4_kv_src_ptrs = src_ptrs[:c4_count]
+            c4_kv_dst_ptrs = dst_ptrs[:c4_count]
+            c4_kv_item_lens = item_lens[:c4_count]
+            c4_indexer_src_ptrs = src_ptrs[c4_count : 2 * c4_count]
+            c4_indexer_dst_ptrs = dst_ptrs[c4_count : 2 * c4_count]
+            c4_indexer_item_lens = item_lens[c4_count : 2 * c4_count]
+            c4_indexer_segments = [
+                (0, 128),
+                (c4_slots_per_page * 128, 4),
+            ]
+            rc = (
+                self._send_dsv4_packed_token_layers(
+                    mooncake_session_id,
+                    c4_kv_src_ptrs,
+                    c4_kv_dst_ptrs,
+                    c4_kv_item_lens,
+                    src_c4,
+                    dst_c4,
+                    c4_slots_per_page,
+                    dsv4_kv_segments,
+                    executor,
+                )
+                or rc
+            )
+            rc = (
+                self._send_dsv4_packed_token_layers(
+                    mooncake_session_id,
+                    c4_indexer_src_ptrs,
+                    c4_indexer_dst_ptrs,
+                    c4_indexer_item_lens,
+                    c4_src_global_locs,
+                    c4_dst_global_locs,
+                    c4_slots_per_page,
+                    c4_indexer_segments,
+                    executor,
+                )
+                or rc
+            )
+        if c128_count > 0:
+            c128_start = 2 * c4_count
+            c128_src_ptrs = src_ptrs[c128_start : c128_start + c128_count]
+            c128_dst_ptrs = dst_ptrs[c128_start : c128_start + c128_count]
+            c128_item_lens = item_lens[c128_start : c128_start + c128_count]
+            c128_kv_segments = [
+                (0, 576),
+                (c128_slots_per_page * 576, 8),
+            ]
+            rc = (
+                self._send_dsv4_packed_token_layers(
+                    mooncake_session_id,
+                    c128_src_ptrs,
+                    c128_dst_ptrs,
+                    c128_item_lens,
+                    src_c128,
+                    dst_c128,
+                    c128_slots_per_page,
+                    c128_kv_segments,
+                    executor,
+                )
+                or rc
+            )
+        return rc
+
+    def _send_dsv4_state_dcp(
+        self,
+        req: TransferInfo,
+        prefill_state_indices: List,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        target_rank_registration_info: Optional[KVArgsRegisterInfo],
+    ) -> int:
+        """Send DSV4 state_data for DeepSeek-V4 PD transfer.
+
+        Expanded DSV4 SWA payload layout:
+        - [0]: global SWA-token locs for the SWA KV buffer.
+        - [1]: SWA page indices for c4/indexer compress_state.
+        - [2]: global full-token locs for c128 compress_state.
+        - [3]: optional sequence-position offset for [0] and [2].
+        - extras: optional StateType.SWA_RING rows, then optional online
+          c128 request-scoped state rows.
+
+        State buffers are addressed by StateType. Non-unified CUDA keeps SWA KV
+        inside StateType.SWA before c4/indexer compressor states; unified KV
+        ships its SWA ring as a separate StateType.SWA_RING component.
+        """
+        if target_rank_registration_info is None:
+            return 0
+        if len(prefill_state_indices) < 2 or len(req.dst_state_indices) < 2:
+            raise RuntimeError(
+                "DSV4+DCP state transfer expects expanded state_indices "
+                "[swa_token_locs, state_page_indices, full_token_locs, "
+                "position_offset] on both prefill and decode."
+            )
+
+        state_types = getattr(self.kv_args, "state_types", []) or []
+        if StateType.SWA not in state_types:
+            raise RuntimeError("DSV4 state transfer requires StateType.SWA")
+        swa_state_idx = state_types.index(StateType.SWA)
+        swa_ring_state_idx = (
+            state_types.index(StateType.SWA_RING)
+            if StateType.SWA_RING in state_types
+            else None
+        )
+
+        src_state_data_ptrs = self.kv_args.state_data_ptrs[swa_state_idx]
+        src_state_item_lens = self.kv_args.state_item_lens[swa_state_idx]
+        dst_state_data_ptrs = target_rank_registration_info.dst_state_data_ptrs[
+            swa_state_idx
+        ]
+
+        src_state_ptrs, dst_state_ptrs, _ = self.get_mla_kv_ptrs_with_pp(
+            src_state_data_ptrs, dst_state_data_ptrs, StateType.SWA
+        )
+        swa_count, _, _ = self._dsv4_stage_bucket_counts()
+        kv_page_size = max(self.kv_args.page_size, 1)
+        swa_page_size = max(
+            getattr(self.kv_args, "swa_page_size", None) or kv_page_size, 1
+        )
+        dst_dcp_size = target_rank_registration_info.dst_dcp_size
+        dst_dcp_rank = target_rank_registration_info.dst_dcp_rank
+
+        src_swa_global_locs = np.array(prefill_state_indices[0], dtype=np.int32)
+        dst_swa_global_locs = np.array(req.dst_state_indices[0], dtype=np.int32)
+        src_full_global_locs = (
+            np.array(prefill_state_indices[2], dtype=np.int32)
+            if len(prefill_state_indices) > 2
+            else None
+        )
+        dst_full_global_locs = (
+            np.array(req.dst_state_indices[2], dtype=np.int32)
+            if len(req.dst_state_indices) > 2
+            else None
+        )
+        extra_index = 4
+        src_swa_ring_state_indices = None
+        dst_swa_ring_state_indices = None
+        if swa_ring_state_idx is not None:
+            if (
+                len(prefill_state_indices) <= extra_index
+                or len(req.dst_state_indices) <= extra_index
+            ):
+                raise RuntimeError(
+                    "DSV4 state transfer requires SWA_RING indices when "
+                    "StateType.SWA_RING is registered."
+                )
+            src_swa_ring_state_indices = np.array(
+                prefill_state_indices[extra_index], dtype=np.int32
+            )
+            dst_swa_ring_state_indices = np.array(
+                req.dst_state_indices[extra_index], dtype=np.int32
+            )
+            extra_index += 1
+
+        src_c128_state_indices = (
+            np.array(prefill_state_indices[extra_index], dtype=np.int32)
+            if StateType.C128_STATE in state_types
+            and len(prefill_state_indices) > extra_index
+            else None
+        )
+        dst_c128_state_indices = (
+            np.array(req.dst_state_indices[extra_index], dtype=np.int32)
+            if StateType.C128_STATE in state_types
+            and len(req.dst_state_indices) > extra_index
+            else None
+        )
+
+        def state_position_offset(state_indices: List) -> int:
+            if len(state_indices) <= 3 or state_indices[3] is None:
+                return 0
+            offset = np.array(state_indices[3], dtype=np.int64).reshape(-1)
+            return int(offset[0]) if offset.size > 0 else 0
+
+        src_state_position_offset = state_position_offset(prefill_state_indices)
+        dst_state_position_offset = state_position_offset(req.dst_state_indices)
+        src_swa_locs, dst_swa_locs = self._dcp_transfer_index_pair(
+            src_swa_global_locs,
+            dst_swa_global_locs,
+            self.dcp_size,
+            self.dcp_rank,
+            dst_dcp_size,
+            dst_dcp_rank,
+        )
+
+        def paired_state_locs_from_swa_locs(
+            src_swa_locs: npt.NDArray[np.int32],
+            dst_swa_locs: npt.NDArray[np.int32],
+            compress_ratio: int,
+        ) -> Tuple[npt.NDArray[np.int32], npt.NDArray[np.int32], int]:
+            # Match dsv4.compressor.create_paged_compress_data:
+            #   state_loc = swa_page * ring_size + (swa_loc % ring_size)
+            # where ``swa_page`` is based on the SWA KV page size, not the
+            # full-KV page size used by c4/c128 compressed KV buffers.
+            from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+                get_compress_state_ring_size,
+            )
+
+            ring_size = get_compress_state_ring_size(
+                compress_ratio,
+                self.server_args.speculative_algorithm is not None,
+            )
+            if src_swa_locs.size == 0 or dst_swa_locs.size == 0:
+                empty = np.array([], dtype=np.int32)
+                return empty, empty, ring_size
+            if src_swa_locs.size != dst_swa_locs.size:
+                min_len = min(src_swa_locs.size, dst_swa_locs.size)
+                logger.warning(
+                    "DSV4 c%d state loc count mismatch: src=%d dst=%d, clipping to %d",
+                    compress_ratio,
+                    src_swa_locs.size,
+                    dst_swa_locs.size,
+                    min_len,
+                )
+                src_swa_locs = src_swa_locs[:min_len]
+                dst_swa_locs = dst_swa_locs[:min_len]
+
+            src_state_locs = (src_swa_locs // swa_page_size) * ring_size + (
+                src_swa_locs % ring_size
+            )
+            dst_state_locs = (dst_swa_locs // swa_page_size) * ring_size + (
+                dst_swa_locs % ring_size
+            )
+            # The CUDA planner addresses compress state by ratio-sized pages.
+            src_state_locs = src_state_locs // compress_ratio
+            dst_state_locs = dst_state_locs // compress_ratio
+            keep = []
+            seen = set()
+            for i, (src_loc, dst_loc) in enumerate(zip(src_state_locs, dst_state_locs)):
+                key = (int(src_loc), int(dst_loc))
+                if key in seen:
+                    continue
+                seen.add(key)
+                keep.append(i)
+            if len(keep) != src_state_locs.size:
+                keep_arr = np.array(keep, dtype=np.int64)
+                src_state_locs = src_state_locs[keep_arr]
+                dst_state_locs = dst_state_locs[keep_arr]
+            return (
+                src_state_locs.astype(np.int32, copy=False),
+                dst_state_locs.astype(np.int32, copy=False),
+                ring_size,
+            )
+
+        def paired_c128_state_rows_from_full_locs() -> (
+            Tuple[npt.NDArray[np.int32], npt.NDArray[np.int32], int]
+        ):
+            from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+                get_compress_state_ring_size,
+            )
+
+            ring_size = get_compress_state_ring_size(
+                128,
+                self.server_args.speculative_algorithm is not None,
+            )
+            if src_full_global_locs is None or dst_full_global_locs is None:
+                src_rows, dst_rows, _ = paired_state_locs_from_swa_locs(
+                    src_swa_global_locs, dst_swa_global_locs, 128
+                )
+                return src_rows, dst_rows, ring_size
+
+            src_full = src_full_global_locs
+            dst_full = dst_full_global_locs
+            if src_full.size == 0 or dst_full.size == 0:
+                empty = np.array([], dtype=np.int32)
+                return empty, empty, ring_size
+
+            if ring_size == 1:
+                # Online c128 keeps one running state per 128-token sequence
+                # chunk. The runtime planner keys that state by the full-token
+                # loc at the chunk start, not by every physical row touched by
+                # the window. This matters when prefix cache makes the window's
+                # physical locs non-contiguous.
+                common_start = max(src_state_position_offset, dst_state_position_offset)
+                common_end = min(
+                    src_state_position_offset + src_full.size,
+                    dst_state_position_offset + dst_full.size,
+                )
+                first_chunk_start = ((common_start + 127) // 128) * 128
+                if first_chunk_start >= common_end:
+                    empty = np.array([], dtype=np.int32)
+                    return empty, empty, ring_size
+                chunk_positions = np.arange(
+                    first_chunk_start, common_end, 128, dtype=np.int64
+                )
+                src_full = src_full[
+                    (chunk_positions - src_state_position_offset).astype(np.int64)
+                ]
+                dst_full = dst_full[
+                    (chunk_positions - dst_state_position_offset).astype(np.int64)
+                ]
+            elif src_full.size != dst_full.size:
+                min_len = min(src_full.size, dst_full.size)
+                logger.warning(
+                    "DSV4 c128 state loc count mismatch: src=%d dst=%d, clipping to %d",
+                    src_full.size,
+                    dst_full.size,
+                    min_len,
+                )
+                src_full = src_full[:min_len]
+                dst_full = dst_full[:min_len]
+
+            src_rows = src_full.astype(np.int64, copy=False) // 128
+            dst_rows = dst_full.astype(np.int64, copy=False) // 128
+            mask = (src_full > 0) & (dst_full > 0)
+            selected_src = src_rows[mask]
+            selected_dst = dst_rows[mask]
+            selected_src = selected_src.astype(np.int32, copy=False)
+            selected_dst = selected_dst.astype(np.int32, copy=False)
+
+            keep = []
+            seen = set()
+            for i, (src_row, dst_row) in enumerate(zip(selected_src, selected_dst)):
+                key = (int(src_row), int(dst_row))
+                if key in seen:
+                    continue
+                seen.add(key)
+                keep.append(i)
+            if len(keep) != selected_src.size:
+                keep_arr = np.array(keep, dtype=np.int64)
+                selected_src = selected_src[keep_arr]
+                selected_dst = selected_dst[keep_arr]
+            return selected_src, selected_dst, ring_size
+
+        def state_rows_for_entry(
+            ratio: int, is_indexer_state: bool
+        ) -> Tuple[npt.NDArray[np.int32], npt.NDArray[np.int32], int]:
+            if ratio == 128 and not is_indexer_state:
+                return paired_c128_state_rows_from_full_locs()
+            # C4/indexer compressor states are replicated request-scoped state,
+            # unlike SWA KV, so every decode DCP rank receives the global rows.
+            return paired_state_locs_from_swa_locs(
+                src_swa_global_locs, dst_swa_global_locs, ratio
+            )
+
+        ratios = getattr(self.kv_args, "mla_compression_ratios", None) or []
+        start_layer = self.kv_args.prefill_start_layer
+        end_layer = getattr(self.kv_args, "prefill_end_layer", None)
+        assert end_layer is not None
+        stage_ratios = ratios[start_layer:end_layer]
+        c4_state_count = sum(1 for r in stage_ratios if r == 4)
+        state_entries = [(4, False)] * c4_state_count + [(4, True)] * c4_state_count
+        rc = 0
+        state_buffer_offset = 0
+        if swa_ring_state_idx is not None:
+            assert src_swa_ring_state_indices is not None
+            assert dst_swa_ring_state_indices is not None
+            src_swa_ring_ptrs = self.kv_args.state_data_ptrs[swa_ring_state_idx]
+            src_swa_ring_item_lens = self.kv_args.state_item_lens[swa_ring_state_idx]
+            dst_swa_ring_ptrs = target_rank_registration_info.dst_state_data_ptrs[
+                swa_ring_state_idx
+            ]
+            src_swa_ring_ptrs, dst_swa_ring_ptrs, _ = self.get_mla_kv_ptrs_with_pp(
+                src_swa_ring_ptrs, dst_swa_ring_ptrs, StateType.SWA_RING
+            )
+            rc = (
+                self._send_indexed_layers(
+                    req.mooncake_session_id,
+                    src_swa_ring_ptrs,
+                    dst_swa_ring_ptrs,
+                    src_swa_ring_item_lens,
+                    src_swa_ring_state_indices,
+                    dst_swa_ring_state_indices,
+                    executor,
+                )
+                or rc
+            )
+        elif swa_count > 0:
+            swa_kv_segments = [
+                (0, 576),
+                (swa_page_size * 576, 8),
+            ]
+            rc = (
+                self._send_dsv4_packed_token_layers(
+                    req.mooncake_session_id,
+                    src_state_ptrs[:swa_count],
+                    dst_state_ptrs[:swa_count],
+                    src_state_item_lens[:swa_count],
+                    src_swa_locs,
+                    dst_swa_locs,
+                    swa_page_size,
+                    swa_kv_segments,
+                    executor,
+                )
+                or rc
+            )
+            state_buffer_offset = swa_count
+
+        state_src_ptrs = src_state_ptrs[state_buffer_offset:]
+        state_dst_ptrs = dst_state_ptrs[state_buffer_offset:]
+        state_item_lens = src_state_item_lens[state_buffer_offset:]
+        if state_src_ptrs:
+            if len(state_src_ptrs) != len(state_entries):
+                raise RuntimeError(
+                    "DSV4 state buffer/ratio count mismatch: "
+                    f"buffers={len(state_src_ptrs)} entries={len(state_entries)} "
+                    f"stage_ratios={stage_ratios}"
+                )
+            for src_ptr, dst_ptr, item_len, (ratio, is_indexer_state) in zip(
+                state_src_ptrs, state_dst_ptrs, state_item_lens, state_entries
+            ):
+                src_rows, dst_rows, ring_size = state_rows_for_entry(
+                    ratio, is_indexer_state
+                )
+                slot_item_len = item_len // ring_size
+                state_page_item_len = slot_item_len * ratio
+                rc = (
+                    self._send_indexed_layers(
+                        req.mooncake_session_id,
+                        [src_ptr],
+                        [dst_ptr],
+                        [state_page_item_len],
+                        src_rows,
+                        dst_rows,
+                        executor,
+                    )
+                    or rc
+                )
+
+        if StateType.C128_STATE in state_types:
+            c128_state_idx = state_types.index(StateType.C128_STATE)
+            src_c128_ptrs = self.kv_args.state_data_ptrs[c128_state_idx]
+            src_c128_item_lens = self.kv_args.state_item_lens[c128_state_idx]
+            dst_c128_ptrs = target_rank_registration_info.dst_state_data_ptrs[
+                c128_state_idx
+            ]
+            src_c128_ptrs, dst_c128_ptrs, _ = self.get_mla_kv_ptrs_with_pp(
+                src_c128_ptrs, dst_c128_ptrs, StateType.C128_STATE
+            )
+            if (
+                src_c128_state_indices is not None
+                and dst_c128_state_indices is not None
+            ):
+                c128_src_rows = src_c128_state_indices
+                c128_dst_rows = dst_c128_state_indices
+                for src_ptr, dst_ptr, item_len in zip(
+                    src_c128_ptrs, dst_c128_ptrs, src_c128_item_lens
+                ):
+                    rc = (
+                        self._send_indexed_layers(
+                            req.mooncake_session_id,
+                            [src_ptr],
+                            [dst_ptr],
+                            [item_len],
+                            c128_src_rows,
+                            c128_dst_rows,
+                            executor,
+                        )
+                        or rc
+                    )
+            else:
+                c128_src_rows, c128_dst_rows, c128_ring_size = (
+                    paired_c128_state_rows_from_full_locs()
+                )
+                for src_ptr, dst_ptr, item_len in zip(
+                    src_c128_ptrs, dst_c128_ptrs, src_c128_item_lens
+                ):
+                    slot_item_len = item_len // c128_ring_size
+                    row_item_len = slot_item_len * min(128, c128_ring_size)
+                    rc = (
+                        self._send_indexed_layers(
+                            req.mooncake_session_id,
+                            [src_ptr],
+                            [dst_ptr],
+                            [row_item_len],
+                            c128_src_rows,
+                            c128_dst_rows,
+                            executor,
+                        )
+                        or rc
+                    )
+        return rc
+
     def send_kvcache(
         self,
         mooncake_session_id: str,
@@ -916,12 +1773,44 @@ class MooncakeKVManager(CommonKVManager):
         dst_kv_ptrs: list[int],
         dst_kv_indices: npt.NDArray[np.int32],
         executor: concurrent.futures.ThreadPoolExecutor,
+        token_position_offset: int = 0,
     ):
+        target_rank_registration_info = self.decode_kv_args_table.get(
+            mooncake_session_id
+        )
+        dst_dcp_size = (
+            target_rank_registration_info.dst_dcp_size
+            if target_rank_registration_info is not None
+            else 1
+        )
+        if self._is_dsv4_pool() and (
+            self.dcp_size > 1 or dst_dcp_size > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get()
+        ):
+            return self._send_dsv4_kvcache_dcp(
+                mooncake_session_id,
+                prefill_kv_indices,
+                dst_kv_ptrs,
+                dst_kv_indices,
+                executor,
+                target_rank_registration_info,
+                token_position_offset,
+            )
+        item_lens = self.kv_args.kv_item_lens
+        if self.dcp_size > 1:
+            # DCP path: caller passes rank-local *token* loc arrays
+            # instead of page-level page-id arrays. Switch ``item_len``
+            # from per-page bytes to per-token bytes so ``ptr + idx *
+            # item_len`` lands on the right slot. ``kv_item_lens`` is
+            # populated as ``per_token_bytes * page_size`` (see
+            # MHATokenToKVPool.get_contiguous_buf_infos), so dividing by
+            # ``page_size`` recovers the per-token stride.
+            page_size = max(self.kv_args.page_size, 1)
+            item_lens = [il // page_size for il in item_lens]
         return self._send_kvcache_generic(
             mooncake_session_id=mooncake_session_id,
             src_data_ptrs=self.kv_args.kv_data_ptrs,
             dst_data_ptrs=dst_kv_ptrs,
-            item_lens=self.kv_args.kv_item_lens,
+            item_lens=item_lens,
             prefill_data_indices=prefill_kv_indices,
             dst_data_indices=dst_kv_indices,
             executor=executor,
@@ -1114,9 +2003,8 @@ class MooncakeKVManager(CommonKVManager):
         data: bytes,
     ):
         na = NetworkAddress(remote, dst_port)
-        socket = self._connect(na.to_tcp(), is_ipv6=na.is_ipv6)
-
-        socket.send_multipart(
+        self._send_multipart(
+            na.to_tcp(),
             [
                 MooncakeKVManager.AUX_DATA_HEADER,
                 str(room).encode("ascii"),
@@ -1124,7 +2012,8 @@ class MooncakeKVManager(CommonKVManager):
                 str(aux_index).encode("ascii"),
                 struct.pack(">I", len(data)),
                 data,
-            ]
+            ],
+            is_ipv6=na.is_ipv6,
         )
 
     def _handle_aux_data(self, msg: List[bytes]):
@@ -1167,7 +2056,10 @@ class MooncakeKVManager(CommonKVManager):
             self.attn_cp_size > 1
             and self.attn_cp_rank != 0
             and not self.server_args.enable_dsa_cache_layer_split
+            and not self.enable_pcp_dcp_rank_affinity
         ):
+            # Without affinity rank 0 is the sole source for replicated state.
+            # With affinity each PCP replica serves its matching DCP rank.
             skip_state = True
 
         return skip_kv, skip_state
@@ -1179,6 +2071,37 @@ class MooncakeKVManager(CommonKVManager):
         executor: concurrent.futures.ThreadPoolExecutor,
         target_rank_registration_info: Optional[KVArgsRegisterInfo] = None,
     ):
+        dst_dcp_size = (
+            target_rank_registration_info.dst_dcp_size
+            if target_rank_registration_info is not None
+            else 1
+        )
+        if self._is_dsv4_pool() and (
+            self.dcp_size > 1 or dst_dcp_size > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get()
+        ):
+            if prefill_state_indices and isinstance(
+                prefill_state_indices[0], (list, tuple)
+            ):
+                expanded_indices = list(prefill_state_indices[0])
+                state_types = getattr(self.kv_args, "state_types", []) or []
+                if StateType.SWA_RING in state_types:
+                    swa_ring_state_idx = state_types.index(StateType.SWA_RING)
+                    if swa_ring_state_idx < len(prefill_state_indices):
+                        expanded_indices.append(
+                            prefill_state_indices[swa_ring_state_idx]
+                        )
+                if StateType.C128_STATE in state_types:
+                    c128_state_idx = state_types.index(StateType.C128_STATE)
+                    if c128_state_idx < len(prefill_state_indices):
+                        expanded_indices.append(prefill_state_indices[c128_state_idx])
+                prefill_state_indices = expanded_indices
+            return self._send_dsv4_state_dcp(
+                req,
+                prefill_state_indices,
+                executor,
+                target_rank_registration_info,
+            )
+
         rc = 0
         state_types = getattr(self.kv_args, "state_types", [])
         for i, st in enumerate(state_types):
@@ -1593,12 +2516,14 @@ class MooncakeKVManager(CommonKVManager):
         self, remote: str, dst_port: int, room: int, status: int, prefill_rank: int
     ):
         na = NetworkAddress(remote, dst_port)
-        self._connect(na.to_tcp(), is_ipv6=na.is_ipv6).send_multipart(
+        self._send_multipart(
+            na.to_tcp(),
             [
                 str(room).encode("ascii"),
                 str(status).encode("ascii"),
                 str(prefill_rank).encode("ascii"),
-            ]
+            ],
+            is_ipv6=na.is_ipv6,
         )
 
     def transfer_worker(
@@ -1930,6 +2855,7 @@ class MooncakeKVManager(CommonKVManager):
                                     target_rank_registration_info.dst_kv_ptrs,
                                     chunked_dst_kv_indice,
                                     executor,
+                                    token_position_offset=kv_chunk.token_position_offset,
                                 )
                             elif (
                                 self.enable_staging
@@ -2123,11 +3049,13 @@ class MooncakeKVManager(CommonKVManager):
                     # Send ACK back to decode endpoint
                     try:
                         na = NetworkAddress(decode_ip, decode_port)
-                        self._connect(na.to_tcp(), is_ipv6=na.is_ipv6).send_multipart(
+                        self._send_multipart(
+                            na.to_tcp(),
                             [
                                 b"ABORT_ACK",
                                 str(room_to_be_aborted).encode("ascii"),
-                            ]
+                            ],
+                            is_ipv6=na.is_ipv6,
                         )
                         logger.debug(
                             f"Sent ABORT_ACK for room {room_to_be_aborted} to "
@@ -2274,10 +3202,10 @@ class MooncakeKVManager(CommonKVManager):
                     logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
                     continue
 
-                bootstrap_room, status, prefill_rank = msg
-                status = int(status.decode("ascii"))
-                bootstrap_room = int(bootstrap_room.decode("ascii"))
-                prefill_rank = int(prefill_rank.decode("ascii"))
+                parsed_status = _parse_transfer_status_message(msg)
+                if parsed_status is None:
+                    continue
+                bootstrap_room, status, prefill_rank = parsed_status
 
                 if status == KVPoll.Success:
                     if bootstrap_room in self.request_status:
@@ -2305,6 +3233,17 @@ class MooncakeKVManager(CommonKVManager):
         threading.Thread(target=decode_thread).start()
         self._start_heartbeat_checker_thread()
 
+    def _get_transfer_queue_shard(self, dst_infos) -> int:
+        session_group = tuple(sorted(dst_infos))
+        with self._session_group_queue_lock:
+            shard_idx = self._session_group_queue_shards.get(session_group)
+            if shard_idx is None:
+                shard_idx = len(self._session_group_queue_shards) % len(
+                    self.transfer_queues
+                )
+                self._session_group_queue_shards[session_group] = shard_idx
+            return shard_idx
+
     def add_transfer_request(
         self,
         bootstrap_room: int,
@@ -2313,6 +3252,7 @@ class MooncakeKVManager(CommonKVManager):
         is_last_chunk: bool,
         aux_index: Optional[int] = None,
         state_indices: Optional[List] = None,
+        token_position_offset: int = 0,
         trace_ctx: Optional[Union[TraceReqContext, TraceNullContext]] = None,
         source_event=None,
         pd_hidden_start: Optional[int] = None,
@@ -2338,12 +3278,13 @@ class MooncakeKVManager(CommonKVManager):
             # add further chunks into the transfer queue.
             return
 
-        # NOTE(shangming): sharding according to the dst_infos to make sure
-        # requests with the same dst_sessions will be added into the same
-        # queue, which enables early abort with failed sessions.
+        # Keep requests with the same destination-session group on one queue,
+        # which enables early abort with failed sessions. Assign new groups
+        # round-robin instead of hashing the sum of RPC ports: when multiple
+        # ranks allocate consecutive ports, different session groups can have
+        # the same port sum modulo queue count and accidentally serialize.
         dst_infos = self.transfer_infos[bootstrap_room].keys()
-        session_port_sum = sum(int(session.rsplit(":", 1)[1]) for session in dst_infos)
-        shard_idx = session_port_sum % len(self.transfer_queues)
+        shard_idx = self._get_transfer_queue_shard(dst_infos)
 
         if trace_ctx is None:
             trace_ctx = TraceNullContext()
@@ -2356,6 +3297,7 @@ class MooncakeKVManager(CommonKVManager):
                 is_last_chunk=is_last_chunk,
                 prefill_aux_index=aux_index,
                 state_indices=state_indices,
+                token_position_offset=token_position_offset,
                 source_event=source_event,
                 pd_hidden_start=pd_hidden_start,
                 pd_hidden_row_len=pd_hidden_row_len,
@@ -2460,9 +3402,10 @@ class MooncakeKVSender(CommonKVSender):
         self,
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
+        token_position_offset: int = 0,
     ):
-        kv_indices, index_slice, is_last_chunk, should_skip = (
-            self._prepare_send_indices(kv_indices, state_indices)
+        kv_indices, index_slice, is_last_chunk, should_skip, token_position_offset = (
+            self._prepare_send_indices(kv_indices, state_indices, token_position_offset)
         )
         if should_skip:
             self._source_event = None
@@ -2470,55 +3413,85 @@ class MooncakeKVSender(CommonKVSender):
 
         pd_hidden_chunk_meta = self._pd_hidden_chunk_meta
         self._pd_hidden_chunk_meta = None
-        if not is_last_chunk:
-            source_event = self._source_event
-            self._source_event = None
-            self.kv_mgr.add_transfer_request(
-                self.bootstrap_room,
-                kv_indices,
-                index_slice,
-                False,
-                state_indices=state_indices,
-                source_event=source_event,
-                trace_ctx=self.trace_ctx.copy_for_thread(),
-                pd_hidden_start=(
-                    pd_hidden_chunk_meta[0] if pd_hidden_chunk_meta else None
-                ),
-                pd_hidden_row_len=(
-                    pd_hidden_chunk_meta[1] if pd_hidden_chunk_meta else 0
-                ),
-                pd_hidden_is_last_chunk=(
-                    pd_hidden_chunk_meta[2] if pd_hidden_chunk_meta else False
-                ),
-                pd_hidden_release_indices=(
-                    pd_hidden_chunk_meta[3] if pd_hidden_chunk_meta else None
-                ),
-            )
+        source_event = self._source_event
+        self._source_event = None
+        transfer_chunk_size = envs.SGLANG_DISAGGREGATION_KV_TRANSFER_CHUNK_SIZE.get()
+        if transfer_chunk_size <= 0 or len(kv_indices) <= transfer_chunk_size:
+            chunks = [(0, len(kv_indices))]
         else:
-            source_event = self._source_event
-            self._source_event = None
-            self.kv_mgr.add_transfer_request(
-                self.bootstrap_room,
-                kv_indices,
-                index_slice,
-                True,
-                aux_index=self.aux_index,
-                state_indices=state_indices,
-                source_event=source_event,
-                trace_ctx=self.trace_ctx.copy_for_thread(),
-                pd_hidden_start=(
-                    pd_hidden_chunk_meta[0] if pd_hidden_chunk_meta else None
-                ),
-                pd_hidden_row_len=(
-                    pd_hidden_chunk_meta[1] if pd_hidden_chunk_meta else 0
-                ),
-                pd_hidden_is_last_chunk=(
-                    pd_hidden_chunk_meta[2] if pd_hidden_chunk_meta else False
-                ),
-                pd_hidden_release_indices=(
-                    pd_hidden_chunk_meta[3] if pd_hidden_chunk_meta else None
-                ),
+            chunks = [
+                (start, min(start + transfer_chunk_size, len(kv_indices)))
+                for start in range(0, len(kv_indices), transfer_chunk_size)
+            ]
+
+        # Preserve an empty final chunk: it carries aux/state completion even
+        # when decode already owns the full KV prefix.
+        if not chunks:
+            chunks = [(0, 0)]
+
+        index_start = index_slice.start if index_slice.start is not None else 0
+        for chunk_start, chunk_end in chunks:
+            chunk_is_last = is_last_chunk and chunk_end == len(kv_indices)
+            is_last_subchunk = chunk_end == len(kv_indices)
+            chunk_index_slice = slice(
+                index_start + chunk_start, index_start + chunk_end
             )
+            chunk_kv_indices = kv_indices[chunk_start:chunk_end]
+            chunk_position_offset = token_position_offset + chunk_start
+            chunk_state_indices = state_indices if is_last_subchunk else None
+            chunk_pd_hidden_meta = (
+                pd_hidden_chunk_meta if is_last_subchunk else None
+            )
+            chunk_source_event = source_event if chunk_start == 0 else None
+
+            if not chunk_is_last:
+                self.kv_mgr.add_transfer_request(
+                    self.bootstrap_room,
+                    chunk_kv_indices,
+                    chunk_index_slice,
+                    False,
+                    state_indices=chunk_state_indices,
+                    token_position_offset=chunk_position_offset,
+                    source_event=chunk_source_event,
+                    trace_ctx=self.trace_ctx.copy_for_thread(),
+                    pd_hidden_start=(
+                        chunk_pd_hidden_meta[0] if chunk_pd_hidden_meta else None
+                    ),
+                    pd_hidden_row_len=(
+                        chunk_pd_hidden_meta[1] if chunk_pd_hidden_meta else 0
+                    ),
+                    pd_hidden_is_last_chunk=(
+                        chunk_pd_hidden_meta[2] if chunk_pd_hidden_meta else False
+                    ),
+                    pd_hidden_release_indices=(
+                        chunk_pd_hidden_meta[3] if chunk_pd_hidden_meta else None
+                    ),
+                )
+            else:
+                self.kv_mgr.add_transfer_request(
+                    self.bootstrap_room,
+                    chunk_kv_indices,
+                    chunk_index_slice,
+                    True,
+                    aux_index=self.aux_index,
+                    state_indices=chunk_state_indices,
+                    token_position_offset=chunk_position_offset,
+                    source_event=chunk_source_event,
+                    trace_ctx=self.trace_ctx.copy_for_thread(),
+                    pd_hidden_start=(
+                        chunk_pd_hidden_meta[0] if chunk_pd_hidden_meta else None
+                    ),
+                    pd_hidden_row_len=(
+                        chunk_pd_hidden_meta[1] if chunk_pd_hidden_meta else 0
+                    ),
+                    pd_hidden_is_last_chunk=(
+                        chunk_pd_hidden_meta[2] if chunk_pd_hidden_meta else False
+                    ),
+                    pd_hidden_release_indices=(
+                        chunk_pd_hidden_meta[3] if chunk_pd_hidden_meta else None
+                    ),
+                )
+
         self._record_transfer_indices(kv_indices, state_indices)
 
     def poll(self) -> KVPoll:
@@ -2607,6 +3580,9 @@ class MooncakeKVReceiver(CommonKVReceiver):
             dst_tp_rank = str(tp_rank).encode("ascii")
             dst_attn_tp_size = str(self.kv_mgr.attn_tp_size).encode("ascii")
             dst_kv_item_len = str(kv_item_len).encode("ascii")
+            enable_hisparse = b"1" if self.kv_mgr.server_args.enable_hisparse else b"0"
+            dst_dcp_size = str(self.kv_mgr.dcp_size).encode("ascii")
+            dst_dcp_rank = str(self.kv_mgr.dcp_rank).encode("ascii")
             if (
                 self.kv_mgr.enable_staging
                 and self.kv_mgr._staging_ctx.allocator is not None
@@ -2634,6 +3610,9 @@ class MooncakeKVReceiver(CommonKVReceiver):
                         dst_kv_item_len,
                         packed_state_item_lens,
                         packed_state_dim_per_tensor,
+                        enable_hisparse,
+                        dst_dcp_size,
+                        dst_dcp_rank,
                         packed_staging_base_ptr,
                         staging_total_size_str,
                     ]

--- a/python/sglang/srt/disaggregation/mooncake/transfer_debug.py
+++ b/python/sglang/srt/disaggregation/mooncake/transfer_debug.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from collections import defaultdict
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _timing_summary(values: list[float]) -> str:
+    if not values:
+        return "-"
+    ordered = sorted(values)
+    p95_index = max(0, math.ceil(len(ordered) * 0.95) - 1)
+    return (
+        f"{sum(ordered) / len(ordered) * 1000:.2f}/"
+        f"{ordered[p95_index] * 1000:.2f}/"
+        f"{ordered[-1] * 1000:.2f}"
+    )
+
+
+class MooncakeTransferDebugStats:
+    """Low-frequency diagnostics for the prefill Mooncake transfer path."""
+
+    def __init__(
+        self,
+        rank_label: str,
+        queue_count: int,
+        report_interval: float = 5.0,
+    ):
+        self.rank_label = rank_label
+        self.report_interval = report_interval
+        self._lock = threading.Lock()
+        self._queue_pending = [0] * queue_count
+        self._queue_active = [0] * queue_count
+        self._engine_active = 0
+        self._engine_active_peak = 0
+        self._timings: dict[str, list[float]] = defaultdict(list)
+        self._counters: dict[str, int] = defaultdict(int)
+        self._last_report = time.monotonic()
+        self._started = False
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        logger.info(
+            "Mooncake transfer debug enabled rank=%s interval=%.1fs queues=%d",
+            self.rank_label,
+            self.report_interval,
+            len(self._queue_pending),
+        )
+        threading.Thread(
+            target=self._report_loop,
+            name="MooncakeTransferDebugStats",
+            daemon=True,
+        ).start()
+
+    def record_enqueue(self, queue_index: int) -> None:
+        with self._lock:
+            self._queue_pending[queue_index] += 1
+
+    def record_dequeue(self, queue_index: int, queue_wait: float) -> None:
+        with self._lock:
+            self._queue_pending[queue_index] = max(
+                0, self._queue_pending[queue_index] - 1
+            )
+            self._queue_active[queue_index] += 1
+            self._timings["queue"].append(queue_wait)
+
+    def record_chunk_done(
+        self,
+        queue_index: int,
+        duration: float,
+        *,
+        skipped: bool = False,
+        error: bool = False,
+    ) -> None:
+        with self._lock:
+            self._queue_active[queue_index] = max(
+                0, self._queue_active[queue_index] - 1
+            )
+            self._timings["chunk"].append(duration)
+            self._counters["chunks"] += 1
+            self._counters["skipped"] += int(skipped)
+            self._counters["errors"] += int(error)
+
+    def record_kv_send(
+        self, duration: float, token_count: int, *, skipped: bool = False
+    ) -> None:
+        with self._lock:
+            self._timings["kv"].append(duration)
+            self._counters["tokens"] += token_count
+            self._counters["kv_skipped"] += int(skipped)
+
+    def record_state_send(self, duration: float) -> None:
+        with self._lock:
+            self._timings["state"].append(duration)
+
+    def record_aux_send(self, duration: float) -> None:
+        with self._lock:
+            self._timings["aux"].append(duration)
+
+    def record_status_sync(self, duration: float) -> None:
+        with self._lock:
+            self._timings["status"].append(duration)
+
+    def record_engine_start(self) -> None:
+        with self._lock:
+            self._engine_active += 1
+            self._engine_active_peak = max(
+                self._engine_active_peak, self._engine_active
+            )
+
+    def record_engine_done(
+        self,
+        duration: float,
+        byte_count: int,
+        block_count: int,
+        *,
+        error: bool = False,
+    ) -> None:
+        with self._lock:
+            self._engine_active = max(0, self._engine_active - 1)
+            self._timings["engine"].append(duration)
+            self._counters["engine_calls"] += 1
+            self._counters["engine_bytes"] += byte_count
+            self._counters["engine_blocks"] += block_count
+            self._counters["engine_errors"] += int(error)
+
+    def _snapshot(self) -> Optional[dict]:
+        now = time.monotonic()
+        with self._lock:
+            interval = now - self._last_report
+            self._last_report = now
+            counters = dict(self._counters)
+            timings = dict(self._timings)
+            pending = self._queue_pending.copy()
+            active = self._queue_active.copy()
+            engine_active = self._engine_active
+            engine_active_peak = self._engine_active_peak
+            self._counters.clear()
+            self._timings.clear()
+            self._engine_active_peak = self._engine_active
+
+        if not counters and not any(pending) and not any(active) and engine_active == 0:
+            return None
+        return {
+            "interval": interval,
+            "counters": counters,
+            "timings": timings,
+            "pending": pending,
+            "active": active,
+            "engine_active": engine_active,
+            "engine_active_peak": engine_active_peak,
+        }
+
+    def _report_loop(self) -> None:
+        while True:
+            time.sleep(self.report_interval)
+            snapshot = self._snapshot()
+            if snapshot is None:
+                continue
+
+            counters = snapshot["counters"]
+            timings = snapshot["timings"]
+            interval = max(snapshot["interval"], 1e-9)
+            payload_gbps = counters.get("engine_bytes", 0) / interval / 1e9
+            logger.info(
+                "Mooncake transfer debug rank=%s interval=%.2fs "
+                "chunks=%d tokens=%d engine_calls=%d blocks=%d bytes=%d "
+                "payload=%.3fGB/s pending=%s active=%s "
+                "engine_active=%d/%d skipped=%d kv_skipped=%d errors=%d/%d "
+                "timing_ms(avg/p95/max) queue=%s chunk=%s kv=%s state=%s "
+                "aux=%s status=%s engine_sync=%s",
+                self.rank_label,
+                interval,
+                counters.get("chunks", 0),
+                counters.get("tokens", 0),
+                counters.get("engine_calls", 0),
+                counters.get("engine_blocks", 0),
+                counters.get("engine_bytes", 0),
+                payload_gbps,
+                snapshot["pending"],
+                snapshot["active"],
+                snapshot["engine_active"],
+                snapshot["engine_active_peak"],
+                counters.get("skipped", 0),
+                counters.get("kv_skipped", 0),
+                counters.get("errors", 0),
+                counters.get("engine_errors", 0),
+                _timing_summary(timings.get("queue", [])),
+                _timing_summary(timings.get("chunk", [])),
+                _timing_summary(timings.get("kv", [])),
+                _timing_summary(timings.get("state", [])),
+                _timing_summary(timings.get("aux", [])),
+                _timing_summary(timings.get("status", [])),
+                _timing_summary(timings.get("engine", [])),
+            )

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1417,9 +1417,10 @@ class MoriKVSender(CommonKVSender):
         self,
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
+        token_position_offset: int = 0,
     ):
-        kv_indices, index_slice, is_last_chunk, should_skip = (
-            self._prepare_send_indices(kv_indices, state_indices)
+        kv_indices, index_slice, is_last_chunk, should_skip, _ = (
+            self._prepare_send_indices(kv_indices, state_indices, token_position_offset)
         )
         if should_skip:
             return

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -2480,12 +2480,13 @@ class NixlKVSender(CommonKVSender):
         self,
         kv_indices: npt.NDArray[np.int32],
         state_indices: Optional[List] = None,
+        token_position_offset: int = 0,
     ):
         if self._send_failed:
             return
 
-        kv_indices, index_slice, is_last_chunk, should_skip = (
-            self._prepare_send_indices(kv_indices, state_indices)
+        kv_indices, index_slice, is_last_chunk, should_skip, _ = (
+            self._prepare_send_indices(kv_indices, state_indices, token_position_offset)
         )
         if should_skip:
             return

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -55,6 +55,7 @@ from sglang.srt.disaggregation.utils import (
     resolve_disagg_metadata_config,
     setup_state_kv_args,
 )
+from sglang.srt.distributed.parallel_state import get_dcp_rank, get_dcp_world_size
 from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
@@ -259,6 +260,8 @@ class PrefillBootstrapQueue:
             if layer_shard_enabled
             else self.token_to_kv_pool.start_layer
         )
+        kv_args.dcp_size = get_dcp_world_size()
+        kv_args.dcp_rank = get_dcp_rank()
         kv_args.mla_compression_ratios = None
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
@@ -288,6 +291,7 @@ class PrefillBootstrapQueue:
                 self.scheduler.model_config.get_total_num_kv_heads()
             )
         kv_args.page_size = self.token_to_kv_pool.page_size
+        kv_args.swa_page_size = getattr(self.token_to_kv_pool, "swa_page_size", None)
 
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (
             self.metadata_buffers.get_buf_infos()
@@ -409,7 +413,15 @@ class PrefillBootstrapQueue:
         num_pages = kv_to_page_num(
             num_kv_indices_to_send, self.token_to_kv_pool.page_size
         )
-        req.disagg_kv_sender.init(num_pages, req.metadata_buffer_index)
+        kv_mgr = self.kv_manager
+        uses_token_level_transfer = (
+            (getattr(kv_mgr, "dcp_size", 1) or 1) > 1
+            or self._uses_dsv4_token_level_transfer(req)
+        )
+        transfer_index_count = (
+            num_kv_indices_to_send if uses_token_level_transfer else num_pages
+        )
+        req.disagg_kv_sender.init(transfer_index_count, req.metadata_buffer_index)
         req.pending_bootstrap = False
         return True
 
@@ -604,6 +616,27 @@ class PrefillBootstrapQueue:
         Set max_new_tokens = 1, so PrefillAdder memory estimation is accurate
         """
         req.sampling_params.max_new_tokens = 1
+
+    def _uses_dsv4_token_level_transfer(self, req: Req) -> bool:
+        if not isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
+            return False
+
+        dcp_size_local = getattr(self.kv_manager, "dcp_size", 1) or 1
+        if dcp_size_local > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get():
+            return True
+
+        transfer_infos = getattr(self.kv_manager, "transfer_infos", {}).get(
+            req.bootstrap_room, {}
+        )
+        decode_kv_args_table = getattr(self.kv_manager, "decode_kv_args_table", {})
+        for session_id in transfer_infos.keys():
+            target_info = decode_kv_args_table.get(session_id)
+            if (
+                target_info is not None
+                and (getattr(target_info, "dst_dcp_size", 1) or 1) > 1
+            ):
+                return True
+        return False
 
     def pop_bootstrapped(
         self,
@@ -1855,6 +1888,7 @@ class SchedulerDisaggregationPrefillMixin:
         Send a prefilled chunk to the decode server
         """
         page_size = self.token_to_kv_pool_allocator.page_size
+        token_to_kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
         start_idx = req.start_send_idx
         transfer_input_len = len(req.origin_input_ids)
         end_idx = (
@@ -1887,6 +1921,29 @@ class SchedulerDisaggregationPrefillMixin:
             (pd_hidden_state(req).meta or {}).get("streaming_hidden", False)
         )
 
+        # DCP: req_to_token stores cluster-wide global token loc; the
+        # transfer layer addresses GPU buffers using per-rank physical
+        # offsets. Convert here before the kv_indices flow into both
+        # ``kv_to_page_indices`` below and the SWA/NSA state payloads.
+        # When dcp_size == 1 this is a no-op.
+        kv_mgr = self.disagg_prefill_bootstrap_queue.kv_manager
+        dcp_size_local = getattr(kv_mgr, "dcp_size", 1) or 1
+        dcp_rank_local = getattr(kv_mgr, "dcp_rank", 0) or 0
+        target_dcp_size = dcp_size_local
+        if isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool):
+            transfer_infos = getattr(kv_mgr, "transfer_infos", {}).get(
+                req.bootstrap_room, {}
+            )
+            decode_kv_args_table = getattr(kv_mgr, "decode_kv_args_table", {})
+            for session_id in transfer_infos.keys():
+                target_info = decode_kv_args_table.get(session_id)
+                if target_info is not None:
+                    target_dcp_size = max(
+                        target_dcp_size, getattr(target_info, "dst_dcp_size", 1) or 1
+                    )
+        dsv4_dcp_transfer = isinstance(
+            token_to_kv_pool, DeepSeekV4TokenToKVPool
+        ) and (target_dcp_size > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get())
         state_indices: Optional[List] = None
         if last_chunk or has_current_pd_hidden:
             if last_chunk:
@@ -1920,7 +1977,18 @@ class SchedulerDisaggregationPrefillMixin:
                         window_kv_indices_full
                     )
                 )
-                return kv_to_page_indices(window_kv_indices_swa, page_size)
+                window_kv_indices_swa_np = window_kv_indices_swa.cpu().numpy()
+                if dsv4_dcp_transfer:
+                    # DSV4 state_data is heterogeneous. Carry the full-token
+                    # locs and sequence offset so Mooncake can derive the
+                    # matching compressed-slot/state rows.
+                    return [
+                        window_kv_indices_swa_np,
+                        kv_to_page_indices(window_kv_indices_swa_np, page_size),
+                        window_kv_indices_full.cpu().numpy(),
+                        np.array([window_start], dtype=np.int32),
+                    ]
+                return kv_to_page_indices(window_kv_indices_swa_np, page_size)
 
             def _dsa_payload():
                 kv_indices_full = self.req_to_token_pool.req_to_token[
@@ -2007,6 +2075,26 @@ class SchedulerDisaggregationPrefillMixin:
             req.req_pool_idx, start_idx:end_idx
         ]
         page_indices = kv_to_page_indices(kv_indices, page_size)
+        if dcp_size_local > 1 or dsv4_dcp_transfer:
+            # DCP rerouting: page granularity does not divide cleanly under
+            # DCP (logical pages from the cluster-wide loc space scatter
+            # into partial local pages on each rank). Send the rank-local
+            # token-loc array unchanged and let the transfer backend issue
+            # token-level RDMA. The arg name stays ``page_indices`` to
+            # keep the MooncakeKVSender / NixlKVSender contract stable.
+            # DSV4 keeps the global token-loc array here because c4/c128
+            # buckets must derive their own compressed slot locs in the
+            # backend before applying DCP sharding.
+            # Mooncake consumes these indices in background CPU threads and
+            # its DCP helpers expect NumPy semantics (notably ``.size`` as an
+            # integer). Do not let a CUDA ``Tensor.size`` method escape into
+            # the transfer worker.
+            page_indices = (
+                kv_indices.cpu().numpy()
+                if isinstance(kv_indices, torch.Tensor)
+                else kv_indices
+            )
+            page_indices = np.asarray(page_indices, dtype=np.int32)
         should_send_kv_chunk = req.disagg_kv_sender.should_send_kv_chunk(
             len(page_indices), last_chunk
         )
@@ -2024,7 +2112,11 @@ class SchedulerDisaggregationPrefillMixin:
                 if streaming_pd_hidden
                 else pd_hidden_state(req).src_indices,
             )
-        req.disagg_kv_sender.send(page_indices, state_indices)
+        req.disagg_kv_sender.send(
+            page_indices,
+            state_indices,
+            token_position_offset=start_idx if dsv4_dcp_transfer else 0,
+        )
         if has_current_pd_hidden and streaming_pd_hidden:
             pd_hidden_state(req).src_indices = None
         pd_hidden_state(req).current_src_indices = None

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1052,6 +1052,34 @@ def page_indices_to_cp_rank_page_indices(
     return np.asarray(page_indices)[mask]
 
 
+def filter_kv_indices_for_dcp_rank(
+    kv_indices: np.ndarray, dcp_size: int, dcp_rank: int
+) -> np.ndarray:
+    """Filter token-level KV indices to those owned by this DCP rank, mapped
+    to per-rank-physical (local) offsets.
+
+    DCP storage rule: a global token loc ``i`` is persisted by rank
+    ``i % dcp_size`` at local offset ``i // dcp_size``. KV indices flowing
+    through the PD transfer protocol are *global* (cluster-wide) loc values
+    coming straight out of ``req_to_token``; backends, however, address GPU
+    buffers using local offsets. This helper performs the conversion at the
+    boundary so the rest of the transfer path can stay unchanged.
+
+    Note this works at *token* granularity. Page-level conversion is the
+    caller's responsibility (typically via ``kv_to_page_indices`` *after*
+    this filter).
+
+    Returns local-loc indices in the same dtype as the input. When
+    ``dcp_size <= 1`` the input is returned unchanged.
+    """
+    if dcp_size <= 1:
+        return kv_indices
+    if kv_indices.size == 0:
+        return kv_indices
+    mask = (kv_indices % dcp_size) == dcp_rank
+    return (kv_indices[mask] // dcp_size).astype(kv_indices.dtype, copy=False)
+
+
 def filter_kv_indices_for_cp_rank(
     kv_mgr: CommonKVManager,
     kv_indices: np.ndarray,

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1747,7 +1747,7 @@ def get_attn_tp_group() -> GroupCoordinator:
 def get_attn_cp_group() -> GroupCoordinator:
     assert (
         _ATTN_CP is not None
-    ), "attention context model parallel group is not initialized"
+    ), "attention context parallel group is not initialized"
     return _ATTN_CP
 
 
@@ -2397,7 +2397,6 @@ def initialize_model_parallel(
         max_world_size=max_world_size,
     )
 
-
 def create_custom_parallel_group(
     group_ranks: List[int], backend: str = "gloo"
 ) -> Optional[torch.distributed.ProcessGroup]:
@@ -2535,17 +2534,20 @@ def get_tensor_model_parallel_world_size():
     return get_tp_group().world_size
 
 
-def get_dcp_world_size():
-    return get_dcp_group().world_size
-
-
-def get_dcp_rank():
-    return get_dcp_group().rank_in_group
-
-
 def get_tensor_model_parallel_rank():
     """Return my rank for the tensor model parallel group."""
     return get_tp_group().rank_in_group
+
+
+# DCP helpers (return 1 / 0 when DCP is not enabled)
+def get_dcp_world_size() -> int:
+    """Return world size for the decode context parallel group, or 1 when off."""
+    return _DCP.world_size if _DCP is not None else 1
+
+
+def get_dcp_rank() -> int:
+    """Return my rank for the decode context parallel group, or 0 when off."""
+    return _DCP.rank_in_group if _DCP is not None else 0
 
 
 # ATTN_TP
@@ -2660,7 +2662,6 @@ def destroy_model_parallel():
     if _PDMUX_PREFILL_TP_GROUP:  # type: ignore[union-attr]
         _PDMUX_PREFILL_TP_GROUP.destroy()
     _PDMUX_PREFILL_TP_GROUP = None
-
 
 def destroy_distributed_environment():
     global _WORLD, _MODEL_PARALLEL_GROUP_TIMEOUT

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -919,6 +919,17 @@ class Envs:
     # Use one packed candidate collective for the sharded C4 top-k merge.
     # Set to 0 to use the legacy unpacked merge.
     SGLANG_DSV4_DCP_C4_PACKED_TOPK = EnvBool(True)
+    # Default DSV4 DCP attention merge: gather LSEs, then reduce-scatter the
+    # corrected FP32 output along the head dimension. Set to 0 for fallback.
+    SGLANG_DSV4_DCP_AG_RS = EnvBool(True)
+    # Experimental DSV4 DCP attention merge: exchange per-destination head
+    # chunks with all-to-all. This remains opt-in because it regresses smaller
+    # batches and increases CUDA graph memory.
+    SGLANG_DSV4_DCP_A2A_LSE = EnvBool(False)
+    # Debug-only validation for the A2A LSE merge. Run both the reference and
+    # A2A paths on the same real FlashMLA tensors and assert numerical parity.
+    # This mode requires decode CUDA graphs to be disabled.
+    SGLANG_DSV4_DCP_A2A_LSE_VERIFY = EnvBool(False)
     # Default reasoning_effort for dsv4 chat encoder when request doesn't set it.
     # Accepts "", "max", "high" (empty string means unset); other values filtered to None.
     SGLANG_DSV4_REASONING_EFFORT = EnvStr("")

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -907,6 +907,11 @@ class Envs:
     # Set False when using FP4-to-FP8 converted DeepSeek V4 checkpoint.
     SGLANG_DSV4_FP4_EXPERTS = EnvBool(True)
     SGLANG_DSV4_FP4_DEQUANT = EnvBool(False)
+    # Master gate for DeepSeek V4 Decode Context Parallel (DCP). When False
+    # (default), DSv4 hook rejects --dcp-size > 1 with a clear error so users
+    # cannot enable an unvalidated combination by accident. Flip to 1 once
+    # numerical-equivalence regression has been verified on the target cluster.
+    SGLANG_DSV4_ENABLE_DCP = EnvBool(False)
     # Default reasoning_effort for dsv4 chat encoder when request doesn't set it.
     # Accepts "", "max", "high" (empty string means unset); other values filtered to None.
     SGLANG_DSV4_REASONING_EFFORT = EnvStr("")

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -359,6 +359,10 @@ class Envs:
     # computed dynamically at runtime based on cpu_count; see disaggregation backends.
     SGLANG_DISAGGREGATION_THREAD_POOL_SIZE = EnvInt(None)
     SGLANG_DISAGGREGATION_QUEUE_SIZE = EnvInt(4)
+    # Maximum number of KV indices carried by one Mooncake transfer work item.
+    # 0 preserves the existing behavior. This is useful for long cached-prefix
+    # hits, which otherwise become one very large synchronous transfer.
+    SGLANG_DISAGGREGATION_KV_TRANSFER_CHUNK_SIZE = EnvInt(0)
     SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT = EnvInt(300)
     SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL = EnvFloat(5.0)
     SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE = EnvInt(2)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -363,6 +363,9 @@ class Envs:
     # 0 preserves the existing behavior. This is useful for long cached-prefix
     # hits, which otherwise become one very large synchronous transfer.
     SGLANG_DISAGGREGATION_KV_TRANSFER_CHUNK_SIZE = EnvInt(0)
+    # Emit five-second aggregate diagnostics for Mooncake prefill transfer
+    # queues, high-level send stages, and synchronous engine calls.
+    SGLANG_DISAGGREGATION_TRANSFER_DEBUG = EnvBool(False)
     SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT = EnvInt(300)
     SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL = EnvFloat(5.0)
     SGLANG_DISAGGREGATION_HEARTBEAT_MAX_FAILURE = EnvInt(2)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -912,6 +912,13 @@ class Envs:
     # cannot enable an unvalidated combination by accident. Flip to 1 once
     # numerical-equivalence regression has been verified on the target cluster.
     SGLANG_DSV4_ENABLE_DCP = EnvBool(False)
+    # Default DeepSeek V4 DCP decode path: each rank scores only the C4 indexer
+    # entries owned by its DCP shard, then gathers local top-k candidates and
+    # merges them into the global C4 sparse top-k. Set to 0 for fallback.
+    SGLANG_DSV4_DCP_SHARD_C4_INDEXER = EnvBool(True)
+    # Use one packed candidate collective for the sharded C4 top-k merge.
+    # Set to 0 to use the legacy unpacked merge.
+    SGLANG_DSV4_DCP_C4_PACKED_TOPK = EnvBool(True)
     # Default reasoning_effort for dsv4 chat encoder when request doesn't set it.
     # Accepts "", "max", "high" (empty string means unset); other values filtered to None.
     SGLANG_DSV4_REASONING_EFFORT = EnvStr("")

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -138,6 +138,10 @@ class AttentionBackend(ABC):
         """
         pass
 
+    def on_after_cuda_graph_capture(self):
+        """Hook immediately after a CUDA graph capture finishes."""
+        pass
+
     def get_verify_buffers_to_fill_after_draft(self):
         """
         Return buffers of verify attention kernels that needs to be filled after draft.

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -33,6 +33,11 @@ from sglang.kernels.ops.attention.dsv4_attn_metadata_kernels import (
     BuildPageTablePositions,
     ExpandPrefillCausally,
 )
+from sglang.srt.distributed.parallel_state import (
+    get_dcp_group,
+    get_dcp_rank,
+    get_dcp_world_size,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.dsv4.compressor_v2 import (
@@ -51,6 +56,7 @@ from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
     SparsePrefillChunkCache,
     SparsePrefillWorkspace,
 )
+from sglang.srt.layers.attention.utils import cp_lse_ag_out_rs
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_parallel
@@ -87,6 +93,17 @@ logger = logging.getLogger(__name__)
 SWA_WINDOW = 128
 C4_TOPK = 512
 PAGE_INDEX_ALIGNED_SIZE = 64
+
+
+def _expand_dcp_local_kv_mask(mask: torch.Tensor, target_len: int) -> torch.Tensor:
+    mask = mask.reshape(-1)
+    if mask.numel() == target_len:
+        return mask
+    if mask.numel() == 0:
+        return torch.zeros(target_len, device=mask.device, dtype=torch.bool)
+    if mask.numel() < target_len:
+        return F.pad(mask, (0, target_len - mask.numel()), value=False)
+    return mask[:target_len]
 
 
 def _get_logical_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
@@ -179,6 +196,9 @@ class DSV4AttnMetadata:
     c128_out_loc: Optional[torch.Tensor] = None
     c128_page_indices: Optional[torch.Tensor] = None
     c128_topk_lengths_clamp1: Optional[torch.Tensor] = None
+    dcp_swa_has_local_kv: Optional[torch.Tensor] = None
+    dcp_c128_has_local_kv: Optional[torch.Tensor] = None
+    dcp_has_local_kv: Optional[torch.Tensor] = None
 
     c1_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
     c4_flashmla_metadata: FlashMLASchedMeta = field(init=False, repr=False)
@@ -223,6 +243,9 @@ class DSV4AttnMetadata:
                 "c4_sparse_topk_lengths",
                 "c4_sparse_page_indices",
                 "c4_sparse_raw_indices",
+                "dcp_swa_has_local_kv",
+                "dcp_c128_has_local_kv",
+                "dcp_has_local_kv",
             ],
             assign_fields=[
                 # Recomputed by the recorded init_forward_metadata_in_graph op
@@ -248,6 +271,9 @@ class DSV4AttnMetadata:
             "c4_topk_lengths_raw",
             "c4_topk_lengths_clamp1",
             "c4_sparse_topk_lengths",
+            "dcp_swa_has_local_kv",
+            "dcp_c128_has_local_kv",
+            "dcp_has_local_kv",
         ]
         reference_assign_fields = [
             "page_table",
@@ -300,8 +326,74 @@ class DSV4AttnMetadata:
             compute_page_indices=True,
         )
 
+        self.apply_dcp_local_kv_indices()
         self.c128_page_indices = _pad_last_dim(self.c128_page_indices)
         self.swa_page_indices = _pad_last_dim(self.swa_page_indices)
+
+    @staticmethod
+    def _compact_dcp_local_indices(
+        indices: torch.Tensor,
+        dcp_world_size: int,
+        dcp_rank: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        valid_mask = indices >= 0
+        local_mask = valid_mask & ((indices % dcp_world_size) == dcp_rank)
+        physical_indices = torch.where(
+            local_mask, indices // dcp_world_size, torch.full_like(indices, -1)
+        )
+
+        col = torch.arange(indices.shape[-1], device=indices.device).view(
+            *([1] * (indices.dim() - 1)), -1
+        )
+        order_key = torch.where(local_mask, col, col + indices.shape[-1])
+        order = torch.argsort(order_key, dim=-1)
+        compacted = torch.gather(physical_indices, dim=-1, index=order)
+
+        local_lengths = local_mask.sum(dim=-1).to(torch.int32)
+        compact_mask = col < local_lengths.unsqueeze(-1)
+        compacted = torch.where(
+            compact_mask, compacted, torch.full_like(compacted, -1)
+        )
+        # Keep empty-row indices at -1 so FlashMLA masks them out, but avoid
+        # passing topk_length=0 to the graph-captured scheduler path. A dummy
+        # ``index=0`` would pollute rows where SWA is empty but an extra source
+        # is present; ``length=1,index=-1`` preserves the "no local KV" signal.
+        return compacted.to(torch.int32), local_lengths
+
+    def apply_dcp_local_kv_indices(self) -> None:
+        dcp_world_size = get_dcp_world_size()
+        if dcp_world_size == 1 or self.dcp_swa_has_local_kv is not None:
+            return
+
+        dcp_rank = get_dcp_rank()
+        self.swa_page_indices, swa_local_lengths = (
+            self._compact_dcp_local_indices(
+                self.swa_page_indices, dcp_world_size, dcp_rank,
+            )
+        )
+        self.dcp_swa_has_local_kv = swa_local_lengths > 0
+        self.swa_topk_lengths = torch.clamp(swa_local_lengths, min=1)
+        if self.c128_page_indices is not None:
+            self.c128_page_indices, c128_local_lengths = (
+                self._compact_dcp_local_indices(
+                    self.c128_page_indices, dcp_world_size, dcp_rank,
+                )
+            )
+            self.dcp_c128_has_local_kv = c128_local_lengths > 0
+            # Extra KV sources may be empty while SWA still has local KV for
+            # this row. Clamp only the length; empty rows retain index -1, so
+            # FlashMLA masks them instead of attending to a dummy KV.
+            self.c128_topk_lengths_clamp1 = torch.clamp(c128_local_lengths, min=1)
+        # Backward-compatible alias for existing metadata copy/replay paths.
+        # Forward must use the compress-ratio-specific mask below instead.
+        self.dcp_has_local_kv = self.dcp_swa_has_local_kv
+
+    def get_dcp_has_local_kv(self, compress_ratio: Literal[0, 4, 128]):
+        if self.dcp_swa_has_local_kv is None:
+            return self.dcp_has_local_kv
+        if compress_ratio == 128 and self.dcp_c128_has_local_kv is not None:
+            return self.dcp_swa_has_local_kv | self.dcp_c128_has_local_kv
+        return self.dcp_swa_has_local_kv
 
     _CP_REINDEX_FIELDS = [
         "seq_lens_casual",
@@ -313,6 +405,9 @@ class DSV4AttnMetadata:
         "c4_topk_lengths_clamp1",
         "c128_page_indices",
         "c128_topk_lengths_clamp1",
+        "dcp_swa_has_local_kv",
+        "dcp_c128_has_local_kv",
+        "dcp_has_local_kv",
     ]
     _CP_GLOBAL_FIELDS = [
         "raw_out_loc",
@@ -333,13 +428,17 @@ class DSV4AttnMetadata:
         expected_local_len = pre_global_len // cp_size
         for field_name in self._CP_REINDEX_FIELDS:
             val = getattr(self, field_name, None)
+            if val is None:
+                continue
             assert isinstance(
                 val, torch.Tensor
             ), f"CP reindex: {field_name} is {type(val)}, expected Tensor"
             setattr(self, field_name, val[idx].contiguous())
 
         for field_name in self._CP_REINDEX_FIELDS:
-            val = getattr(self, field_name)
+            val = getattr(self, field_name, None)
+            if val is None:
+                continue
             assert val.shape[0] == expected_local_len, (
                 f"apply_cp_reindex post-condition: {field_name}.shape[0]={val.shape[0]} "
                 f"!= expected_local_len={expected_local_len} (cp_size={cp_size})"
@@ -432,6 +531,7 @@ class DSV4RawVerifyMetadata:
 
     extend_seq_lens: Optional[torch.Tensor] = None
     seq_lens_cpu: Optional[List[int]] = None
+    active_bs: Optional[int] = None
     c128_compress_metadata: Optional[FusedCompressMetadata] = None
 
     extend_start_loc: Optional[torch.Tensor] = None
@@ -445,6 +545,7 @@ class DSV4RawVerifyMetadata:
 
         self.extend_seq_lens = other.extend_seq_lens
         self.seq_lens_cpu = other.seq_lens_cpu
+        self.active_bs = other.active_bs
         self.c128_compress_metadata = _copy_or_replace(
             self.c128_compress_metadata, other.c128_compress_metadata
         )
@@ -556,6 +657,13 @@ class DeepseekV4AttnBackend(
             DSV4RawVerifyMetadata,
             DSV4RawDecodeMetadata,
         ] = None
+        self._current_capture_raw: Optional[
+            Union[DSV4RawVerifyMetadata, DSV4RawDecodeMetadata]
+        ] = None
+        self._current_capture_bucket_bs: Optional[Tuple[_GraphBucket, int]] = None
+        self._cuda_graph_captured_full_metadata: Dict[
+            _GraphBucket, Dict[int, DSV4Metadata]
+        ] = {bucket: {} for bucket in _GraphBucket}
         self.online_c128_mtp = OnlineC128MTPController(self)
         self.sparse_prefill_workspace = SparsePrefillWorkspace(self.device)
         spec_alg = model_runner.spec_algorithm
@@ -618,6 +726,7 @@ class DeepseekV4AttnBackend(
         extend_seq_lens: torch.Tensor,
         use_prefill_cuda_graph: bool,
         online_c128_state_slot_offset: int,
+        online_c128_active_bs: Optional[int] = None,
     ) -> Optional[FusedCompressMetadata]:
         if not self.online_c128_mtp.enabled():
             return None
@@ -638,6 +747,7 @@ class DeepseekV4AttnBackend(
             extend_lens_cpu=extend_lens_cpu,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
             online_state_slot_offset=online_c128_state_slot_offset,
+            online_active_bs=online_c128_active_bs,
         )
 
     def init_forward_metadata_indexer(
@@ -801,6 +911,7 @@ class DeepseekV4AttnBackend(
         use_prefill_cuda_graph: bool = False,
         online_c128_state_slot_offset: int = 0,
         ragged_layout: Optional[RaggedVerifyLayout] = None,
+        online_c128_active_bs: Optional[int] = None,
     ) -> Union[DSV4Metadata, DSV4RawVerifyMetadata]:
         if envs.SGLANG_PREP_IN_CUDA_GRAPH.get():
             assert out_cache_loc is not None
@@ -832,6 +943,7 @@ class DeepseekV4AttnBackend(
                 out_cache_loc=out_cache_loc,
                 extend_seq_lens=extend_seq_lens,
                 seq_lens_cpu=seq_lens_cpu_list,
+                active_bs=online_c128_active_bs,
                 c128_compress_metadata=self._make_target_verify_c128_metadata(
                     req_pool_indices,
                     seq_lens,
@@ -839,6 +951,7 @@ class DeepseekV4AttnBackend(
                     extend_seq_lens,
                     use_prefill_cuda_graph,
                     online_c128_state_slot_offset,
+                    online_c128_active_bs,
                 ),
                 extend_start_loc=extend_start_loc,
                 verify_lens=verify_lens,
@@ -977,6 +1090,7 @@ class DeepseekV4AttnBackend(
                     qo_len=num_draft_tokens,
                     seq_lens=seq_lens,
                     req_pool_indices=req_pool_indices,
+                    padded_num_tokens=out_cache_loc.shape[0],
                 )
             )
         core_attn_metadata = self.make_core_attn_metadata(
@@ -1001,6 +1115,7 @@ class DeepseekV4AttnBackend(
             use_prefill_cuda_graph=True,
             num_q_tokens=num_q_tokens,
             online_state_slot_offset=online_c128_state_slot_offset,
+            online_active_bs=raw_metadata.active_bs,
         )
         c128_compress_metadata = raw_metadata.c128_compress_metadata
         if c128_compress_metadata is None:
@@ -1095,6 +1210,18 @@ class DeepseekV4AttnBackend(
             self.forward_metadata = self.make_forward_metadata_from_raw_decode(
                 raw_metadata=self.forward_metadata,
             )
+
+        # Keep the full metadata object whose tensor addresses are captured by
+        # the graph. Replay-side preparation updates this object in place; the
+        # raw metadata retained by the out-of-graph path is only an input to the
+        # conversion above and is not read by the captured kernels directly.
+        if (
+            torch.cuda.is_current_stream_capturing()
+            and self._current_capture_bucket_bs is not None
+            and isinstance(self.forward_metadata, DSV4Metadata)
+        ):
+            bucket, bs = self._current_capture_bucket_bs
+            self._cuda_graph_captured_full_metadata[bucket][bs] = self.forward_metadata
 
         # Compute the SWA KV-store write target once per forward and cache it on
         # the metadata for every layer's store. This is recorded inside the cuda
@@ -1217,10 +1344,15 @@ class DeepseekV4AttnBackend(
         if bucket == _GraphBucket.DECODE_OR_IDLE:
             assert out_cache_loc is not None
             assert len(out_cache_loc.shape) == 1, f"{out_cache_loc.shape=}"
+            assert len(out_cache_loc) <= bs, (
+                f"decode replay out_cache_loc is longer than graph batch: "
+                f"{len(out_cache_loc)=}, {bs=}"
+            )
             self.online_c128_mtp.prepare_forward(
                 actual_forward_mode,
                 req_pool_indices,
                 seq_lens,
+                verify_bs=_get_target_verify_bs(forward_batch),
             )
             out_cache_loc_padded = torch.nn.functional.pad(
                 out_cache_loc,
@@ -1297,12 +1429,14 @@ class DeepseekV4AttnBackend(
                 use_prefill_cuda_graph=True,
                 online_c128_state_slot_offset=online_c128_state_slot_offset,
                 ragged_layout=ragged_layout,
+                online_c128_active_bs=verify_bs,
             )
         elif bucket == _GraphBucket.DRAFT_EXTEND:
             self.online_c128_mtp.prepare_forward(
                 actual_forward_mode,
                 req_pool_indices,
                 seq_lens,
+                verify_bs=_get_target_verify_bs(forward_batch),
             )
             num_tokens_per_req = self.draft_extend_num_tokens_per_req
             if out_cache_loc is not None:
@@ -1331,6 +1465,7 @@ class DeepseekV4AttnBackend(
         if in_capture:
             # Preserve _current_capture_raw for on_after_cuda_graph_warmup
             metadata = self.forward_metadata
+            self._current_capture_bucket_bs = (bucket, bs)
             self._current_capture_raw = (
                 metadata
                 if isinstance(
@@ -1532,6 +1667,26 @@ class DeepseekV4AttnBackend(
             self.forward_metadata = temp_metadata
             return
         chosen_metadata.copy_(temp_metadata)
+        captured_full_metadata = self._cuda_graph_captured_full_metadata[bucket].get(
+            bs
+        )
+        if captured_full_metadata is not None:
+            if isinstance(temp_metadata, DSV4Metadata):
+                temp_full_metadata = temp_metadata
+            elif isinstance(temp_metadata, DSV4RawVerifyMetadata):
+                temp_full_metadata = self.make_forward_metadata_from_raw_verify(
+                    raw_metadata=temp_metadata,
+                    online_c128_state_slot_offset=(
+                        self.online_c128_mtp.state_slot_offset()
+                    ),
+                )
+            elif isinstance(temp_metadata, DSV4RawDecodeMetadata):
+                temp_full_metadata = self.make_forward_metadata_from_raw_decode(
+                    raw_metadata=temp_metadata,
+                )
+            else:
+                raise TypeError(f"unexpected {type(temp_metadata)=}")
+            captured_full_metadata.copy_(temp_full_metadata)
         self.forward_metadata = chosen_metadata
 
     def get_cuda_graph_seq_len_fill_value(self):
@@ -1588,6 +1743,8 @@ class DeepseekV4AttnBackend(
                 layer_id=layer_id,
                 swa_loc=swa_loc,
                 cache_k=swa_k,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
+                raw_loc=forward_batch.out_cache_loc,
             )
         else:
             swa_k_pack = quant_to_nope_fp8_rope_bf16_pack_triton(swa_k)
@@ -1595,6 +1752,8 @@ class DeepseekV4AttnBackend(
                 layer_id=layer_id,
                 swa_loc=swa_loc,
                 cache_nope_fp8_rope_bf16_pack=swa_k_pack,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
+                raw_loc=forward_batch.out_cache_loc,
             )
 
     def forward(
@@ -1666,10 +1825,32 @@ class DeepseekV4AttnBackend(
                     return x[: q.shape[0]]
                 return _pad_tensor_to_size(x, q.shape[0], value=value)
 
-            swa_page_indices = match_num_queries(swa_page_indices, value=0)
+            # If query rows outgrow the metadata rows (for example padded
+            # target-verify buckets), pad with FlashMLA's empty-row sentinel.
+            # SWA slot 0 is a valid local cache slot under DCP, so using 0 here
+            # would make synthetic rows attend to unrelated KV.
+            swa_page_indices = match_num_queries(swa_page_indices, value=-1)
             swa_topk_lengths = match_num_queries(swa_topk_lengths, value=1)
             extra_indices = match_num_queries(extra_indices, value=-1)
             extra_topk_lengths = match_num_queries(extra_topk_lengths, value=1)
+
+            c4_has_local_kv = None
+            if (
+                get_dcp_world_size() > 1
+                and compress_ratio == 4
+                and extra_indices is not None
+            ):
+                dcp_world_size = get_dcp_world_size()
+                dcp_rank = get_dcp_rank()
+                extra_indices, c4_local_lengths = (
+                    core_attn_metadata._compact_dcp_local_indices(
+                        extra_indices, dcp_world_size, dcp_rank
+                    )
+                )
+                # Same rule as C128: avoid topk_length=0 in FlashMLA while
+                # keeping empty-row indices at -1 so no dummy KV is attended.
+                extra_topk_lengths = torch.clamp(c4_local_lengths, min=1)
+                c4_has_local_kv = c4_local_lengths > 0
 
             if q.ndim == 3:
                 q = q.unsqueeze(1)
@@ -1679,7 +1860,6 @@ class DeepseekV4AttnBackend(
                 extra_indices = extra_indices.unsqueeze(1)
 
             assert attn_sink is not None
-
             flashmla_metadata = core_attn_metadata.get_flashmla_metadata(compress_ratio)
 
             assert (
@@ -1714,7 +1894,7 @@ class DeepseekV4AttnBackend(
                     flash_mla_with_kvcache_sm120,
                 )
 
-                o = flash_mla_with_kvcache_sm120(
+                flashmla_ret = flash_mla_with_kvcache_sm120(
                     q=q,
                     k_cache=swa_k_cache,
                     head_dim_v=self.head_dim_v,
@@ -1725,14 +1905,14 @@ class DeepseekV4AttnBackend(
                     extra_k_cache=extra_k_cache,
                     extra_indices_in_kvcache=extra_indices,
                     extra_topk_length=extra_topk_lengths,
-                )[0]
+                )
             else:
                 if _is_xpu:
                     from sgl_kernel import flash_mla_with_kvcache
                 else:
                     from sgl_kernel.flash_mla import flash_mla_with_kvcache
 
-                o = flash_mla_with_kvcache(
+                flashmla_ret = flash_mla_with_kvcache(
                     q=q,
                     k_cache=swa_k_cache,
                     head_dim_v=self.head_dim_v,
@@ -1747,9 +1927,63 @@ class DeepseekV4AttnBackend(
                     extra_k_cache=extra_k_cache,
                     extra_indices_in_kvcache=extra_indices,
                     extra_topk_length=extra_topk_lengths,
-                )[0]
+                )
 
-            o = o.squeeze(1)
+            o = flashmla_ret[0].squeeze(1)
+            dcp_has_local_kv = None
+            if get_dcp_world_size() > 1:
+                o_dtype = o.dtype
+                lse = flashmla_ret[1]
+                if lse.dim() == 3 and lse.shape[0] == 1:
+                    lse = lse.squeeze(0)
+                elif lse.dim() == 3 and lse.shape[1] == 1:
+                    lse = lse.squeeze(1)
+                elif lse.dim() == 3 and lse.shape[-1] == 1:
+                    lse = lse.squeeze(-1)
+                if lse.dim() > 2:
+                    token_dim = 0
+                    if lse.shape[0] != o.shape[0]:
+                        for dim, size in enumerate(lse.shape):
+                            if size == o.shape[0]:
+                                token_dim = dim
+                                break
+                    if token_dim != 0:
+                        lse = lse.movedim(token_dim, 0).contiguous()
+                    lse = lse.reshape(lse.shape[0], -1)
+                if (
+                    lse.dim() == 2
+                    and lse.shape[0] != o.shape[0]
+                    and lse.shape[1] == o.shape[0]
+                ):
+                    lse = lse.transpose(0, 1).contiguous()
+                if lse.dim() != 2 or lse.shape[:2] != o.shape[:2]:
+                    raise RuntimeError(
+                        "Unexpected FlashMLA output/LSE shapes for DCP merge: "
+                        f"output={tuple(o.shape)}, lse={tuple(lse.shape)}"
+                    )
+                dcp_has_local_kv = core_attn_metadata.get_dcp_has_local_kv(
+                    compress_ratio
+                )
+                if compress_ratio == 4 and c4_has_local_kv is not None:
+                    dcp_has_local_kv = dcp_has_local_kv | c4_has_local_kv
+                if get_dcp_rank() != 0 and dcp_has_local_kv is not None:
+                    token_len = o.shape[0]
+                    dcp_has_local_kv = _expand_dcp_local_kv_mask(
+                        dcp_has_local_kv, token_len
+                    )
+                    no_local_kv = ~dcp_has_local_kv
+                    lse = torch.where(
+                        no_local_kv[:, None],
+                        torch.full_like(lse, torch.finfo(lse.dtype).min),
+                        lse,
+                    )
+                    o = torch.where(
+                        no_local_kv[:, None, None],
+                        torch.zeros_like(o),
+                        o,
+                    )
+                o = cp_lse_ag_out_rs(o, lse, get_dcp_group()).to(o_dtype)
+
             return o
 
         raise NotImplementedError("ragged attention")
@@ -1913,6 +2147,7 @@ class DeepseekV4AttnBackend(
         qo_len: int,
         seq_lens: torch.Tensor,
         req_pool_indices: torch.Tensor,
+        padded_num_tokens: Optional[int] = None,
     ):
         seq_lens_casual = seq_lens[:, None] + torch.arange(
             -qo_len + 1, 1, **self.cuda_int32_kwargs
@@ -1922,6 +2157,19 @@ class DeepseekV4AttnBackend(
             bs, **self.cuda_int32_kwargs
         ).repeat_interleave(qo_len)
         req_pool_indices_repeated = req_pool_indices[idx_to_req_repeated]
+        num_tokens = seq_lens_casual.shape[0]
+        if padded_num_tokens is not None and padded_num_tokens > num_tokens:
+            pad_size = padded_num_tokens - num_tokens
+            seq_lens_casual = torch.nn.functional.pad(
+                seq_lens_casual,
+                (0, pad_size),
+                value=1,
+            )
+            req_pool_indices_repeated = torch.nn.functional.pad(
+                req_pool_indices_repeated,
+                (0, pad_size),
+                value=req_pool_indices_repeated[-1].item(),
+            )
         return seq_lens_casual, req_pool_indices_repeated
 
     def make_core_attn_metadata(
@@ -1993,6 +2241,7 @@ class DeepseekV4AttnBackend(
             core_attn_metadata.init_compression_metadata()
             core_attn_metadata.init_flashmla_related(is_prefill=is_prefill)
         else:
+            core_attn_metadata.apply_dcp_local_kv_indices()
             core_attn_metadata.c4_sparse_topk_lengths = None
             core_attn_metadata.c4_sparse_page_indices = None
             core_attn_metadata.c4_sparse_raw_indices = None
@@ -2087,14 +2336,16 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
         else:
             if self.speculative_num_steps == 1:
                 return
-            self.attn_backends[0].init_forward_metadata_out_graph(inner_fb)
-            temp_metadata = self.attn_backends[0].forward_metadata
-            for i in range(1, self.speculative_num_steps - 1):
-                self.attn_backends[i].replay_cuda_graph_metadata_from(
-                    bs=forward_batch.batch_size,
-                    temp_metadata=temp_metadata,
-                    bucket=_GraphBucket.DECODE_OR_IDLE,
-                )
+            per_step_out_cache_loc = per_step_draft_out_cache_loc(
+                inner_fb.out_cache_loc,
+                inner_fb.batch_size,
+                self.topk,
+                self.speculative_num_steps,
+            )
+            for i in range(self.speculative_num_steps - 1):
+                step_fb = SimpleNamespace(**vars(inner_fb))
+                step_fb.out_cache_loc = per_step_out_cache_loc[i]
+                self.attn_backends[i].init_forward_metadata_out_graph(step_fb)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         for i in range(self.speculative_num_steps - 1):

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -56,7 +56,11 @@ from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
     SparsePrefillChunkCache,
     SparsePrefillWorkspace,
 )
-from sglang.srt.layers.attention.utils import cp_lse_ag_out_rs
+from sglang.kernels.ops.attention.utils import (
+    cp_lse_a2a_out_rs,
+    cp_lse_ag_out_reduce_scatter,
+    cp_lse_ag_out_rs,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_parallel
@@ -1982,7 +1986,45 @@ class DeepseekV4AttnBackend(
                         torch.zeros_like(o),
                         o,
                     )
-                o = cp_lse_ag_out_rs(o, lse, get_dcp_group()).to(o_dtype)
+                if envs.SGLANG_DSV4_DCP_A2A_LSE_VERIFY.get():
+                    if torch.cuda.is_current_stream_capturing():
+                        raise RuntimeError(
+                            "SGLANG_DSV4_DCP_A2A_LSE_VERIFY requires "
+                            "--disable-cuda-graph"
+                        )
+                    ref_o, ref_lse = cp_lse_ag_out_rs(
+                        o, lse, get_dcp_group(), return_lse=True
+                    )
+                    a2a_o, a2a_lse = cp_lse_a2a_out_rs(
+                        o, lse, get_dcp_group(), return_lse=True
+                    )
+                    torch.testing.assert_close(
+                        a2a_lse,
+                        ref_lse,
+                        rtol=1e-6,
+                        atol=1e-6,
+                        msg=lambda msg: (
+                            f"DSV4 DCP A2A LSE mismatch at layer {layer_id}: {msg}"
+                        ),
+                    )
+                    torch.testing.assert_close(
+                        a2a_o,
+                        ref_o,
+                        rtol=2e-3,
+                        atol=2e-3,
+                        msg=lambda msg: (
+                            f"DSV4 DCP A2A output mismatch at layer {layer_id}: {msg}"
+                        ),
+                    )
+                    o = a2a_o.to(o_dtype)
+                elif envs.SGLANG_DSV4_DCP_A2A_LSE.get():
+                    o = cp_lse_a2a_out_rs(o, lse, get_dcp_group()).to(o_dtype)
+                elif envs.SGLANG_DSV4_DCP_AG_RS.get():
+                    o = cp_lse_ag_out_reduce_scatter(
+                        o, lse, get_dcp_group()
+                    ).to(o_dtype)
+                else:
+                    o = cp_lse_ag_out_rs(o, lse, get_dcp_group()).to(o_dtype)
 
             return o
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -1375,6 +1375,8 @@ class DeepseekV4HipRadixBackend(
                 layer_id=layer_id,
                 swa_loc=swa_loc,
                 cache_k=swa_k,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
+                raw_loc=forward_batch.out_cache_loc,
             )
         else:
             swa_k_pack = quant_to_nope_fp8_rope_bf16_pack_triton(swa_k)
@@ -1382,6 +1384,8 @@ class DeepseekV4HipRadixBackend(
                 layer_id=layer_id,
                 swa_loc=swa_loc,
                 cache_nope_fp8_rope_bf16_pack=swa_k_pack,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
+                raw_loc=forward_batch.out_cache_loc,
             )
 
     def forward(

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from sglang.srt.layers.rotary_embedding import RotaryEmbedding
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
-
 class FusedCompressMetadata(NamedTuple):
     write_loc: torch.Tensor
     extra_data: Optional[torch.Tensor]
@@ -183,10 +182,13 @@ class CompressorBackendMixin:
                 layer_id=layer_id,
                 loc=out_loc,
                 cache_k=new_compressed_kv,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
             )
         else:
             pack = quant_to_nope_fp8_rope_bf16_pack_triton(new_compressed_kv.bfloat16())
-            token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc, pack)
+            token_to_kv_pool.set_extra_key_buffer(
+                layer_id, out_loc, pack, dcp_kv_mask=forward_batch.dcp_kv_mask
+            )
 
     def forward_indexer_compressor(
         self,
@@ -215,6 +217,7 @@ class CompressorBackendMixin:
                 layer_id=layer_id,
                 loc=out_loc,
                 cache_k=new_compressed_kv,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
             )
         else:
             new_compressed_kv_fp8, new_compressed_kv_scale = act_quant(
@@ -225,6 +228,7 @@ class CompressorBackendMixin:
                 loc=out_loc,
                 index_k=new_compressed_kv_fp8,
                 index_k_scale=new_compressed_kv_scale,
+                dcp_kv_mask=forward_batch.dcp_kv_mask,
             )
 
 

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -20,13 +20,291 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
-
 CompressMetadata: TypeAlias = Union[CompressorDecodePlan, CompressorPrefillPlan]
 # NOTE: alias for backward compatibility
 FusedCompressMetadata: TypeAlias = CompressMetadata
 
 _is_hip = is_hip_runtime()
 
+def _dcp_write_enabled() -> bool:
+    from sglang.srt.distributed.parallel_state import get_dcp_group_no_assert
+
+    group = get_dcp_group_no_assert()
+    return group is not None and group.world_size > 1
+
+
+if _is_hip:
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _c128_compress_decode_kernel(
+        buf_ptr,
+        input_ptr,
+        ape_ptr,
+        out_ptr,
+        plan_ptr,
+        buf_stride_slot,
+        input_stride_b,
+        ape_stride_r,
+        out_stride_b,
+        bs,
+        HEAD_DIM: tl.constexpr,
+        BLOCK_D: tl.constexpr,
+        COMPRESS_RATIO: tl.constexpr,
+    ):
+        """Fused C128 decode: write to state buffer + online softmax-pool.
+
+        plan_ptr points to int32 view: [bs, 4] where each row is
+        {seq_len, write_loc, read_page_0, read_page_1}.
+        """
+        bid = tl.program_id(0)
+        if bid >= bs:
+            return
+
+        # Parse plan
+        plan_base = plan_ptr + bid * 4
+        seq_len = tl.load(plan_base).to(tl.int32)
+        write_loc = tl.load(plan_base + 1).to(tl.int32)
+        read_page_0 = tl.load(plan_base + 2).to(tl.int32)
+
+        d = tl.arange(0, BLOCK_D)
+        last_dim: tl.constexpr = HEAD_DIM * 2
+
+        # Step 1: Write kv_score_input to state buffer at write_loc
+        d_mask_full = d < last_dim
+        input_val = tl.load(
+            input_ptr + bid * input_stride_b + d, mask=d_mask_full, other=0.0
+        )
+        tl.store(buf_ptr + write_loc * buf_stride_slot + d, input_val, mask=d_mask_full)
+
+        # Step 2: Check boundary condition
+        d_mask_hd = d < HEAD_DIM
+        if seq_len % COMPRESS_RATIO != 0:
+            tl.store(
+                out_ptr + bid * out_stride_b + d,
+                tl.zeros([BLOCK_D], tl.float32),
+                mask=d_mask_hd,
+            )
+            return
+
+        # Step 3: Online softmax-pool over 128 slots in the page
+        page_base = read_page_0 * COMPRESS_RATIO * buf_stride_slot
+        m_prev = tl.full([BLOCK_D], float("-inf"), tl.float32)
+        kv_acc = tl.zeros([BLOCK_D], tl.float32)
+        w_acc = tl.zeros([BLOCK_D], tl.float32)
+
+        for k in tl.static_range(COMPRESS_RATIO):
+            slot_addr = page_base + k * buf_stride_slot
+            kv_val = tl.load(buf_ptr + slot_addr + d, mask=d_mask_hd, other=0.0).to(
+                tl.float32
+            )
+            sc_val = tl.load(
+                buf_ptr + slot_addr + HEAD_DIM + d, mask=d_mask_hd, other=0.0
+            ).to(tl.float32)
+            ape_val = tl.load(
+                ape_ptr + k * ape_stride_r + d, mask=d_mask_hd, other=0.0
+            ).to(tl.float32)
+            score_k = sc_val + ape_val
+
+            m_new = tl.maximum(m_prev, score_k)
+            exp_old = tl.where(m_prev == float("-inf"), 0.0, tl.exp(m_prev - m_new))
+            exp_cur = tl.where(score_k == float("-inf"), 0.0, tl.exp(score_k - m_new))
+            kv_acc = kv_acc * exp_old + exp_cur * kv_val
+            w_acc = w_acc * exp_old + exp_cur
+            m_prev = m_new
+
+        compressed = kv_acc / w_acc
+        tl.store(out_ptr + bid * out_stride_b + d, compressed, mask=d_mask_hd)
+
+    @triton.jit
+    def _c128_compress_prefill_write_kernel(
+        buf_ptr,
+        input_ptr,
+        plan_w_ptr,
+        buf_stride_slot,
+        input_stride_b,
+        num_w,
+        BLOCK_D: tl.constexpr,
+        LAST_DIM: tl.constexpr,
+    ):
+        """Prefill write phase: scatter kv_score_input tokens into state buffer."""
+        wid = tl.program_id(0)
+        if wid >= num_w:
+            return
+
+        # WritePlan: {ragged_id(u32), write_loc(i32)} = 8 bytes = 2 int32s
+        plan_base = plan_w_ptr + wid * 2
+        ragged_id = (tl.load(plan_base).to(tl.int32)) & 0xFFFF
+        write_loc = tl.load(plan_base + 1).to(tl.int32)
+
+        d = tl.arange(0, BLOCK_D)
+        d_mask = d < LAST_DIM
+
+        if write_loc >= 0:
+            input_val = tl.load(
+                input_ptr + ragged_id * input_stride_b + d, mask=d_mask, other=0.0
+            )
+            tl.store(buf_ptr + write_loc * buf_stride_slot + d, input_val, mask=d_mask)
+
+    @triton.jit
+    def _c128_compress_prefill_compress_kernel(
+        buf_ptr,
+        ape_ptr,
+        out_ptr,
+        plan_c_ptr,
+        buf_stride_slot,
+        ape_stride_r,
+        out_stride_b,
+        num_c,
+        HEAD_DIM: tl.constexpr,
+        BLOCK_D: tl.constexpr,
+        COMPRESS_RATIO: tl.constexpr,
+    ):
+        """Prefill compress phase: online softmax-pool for each compress plan entry."""
+        cid = tl.program_id(0)
+        if cid >= num_c:
+            return
+
+        # CompressPlan: {seq_len(u32), ragged_id(u16)|buffer_len(u16), read_page_0(i32), read_page_1(i32)}
+        plan_base = plan_c_ptr + cid * 4
+        read_page_0 = tl.load(plan_base + 2).to(tl.int32)
+
+        d = tl.arange(0, BLOCK_D)
+        d_mask_hd = d < HEAD_DIM
+
+        if read_page_0 < 0:
+            tl.store(
+                out_ptr + cid * out_stride_b + d,
+                tl.zeros([BLOCK_D], tl.float32),
+                mask=d_mask_hd,
+            )
+            return
+
+        page_base = read_page_0 * COMPRESS_RATIO * buf_stride_slot
+        m_prev = tl.full([BLOCK_D], float("-inf"), tl.float32)
+        kv_acc = tl.zeros([BLOCK_D], tl.float32)
+        w_acc = tl.zeros([BLOCK_D], tl.float32)
+
+        for k in tl.static_range(COMPRESS_RATIO):
+            slot_addr = page_base + k * buf_stride_slot
+            kv_val = tl.load(buf_ptr + slot_addr + d, mask=d_mask_hd, other=0.0).to(
+                tl.float32
+            )
+            sc_val = tl.load(
+                buf_ptr + slot_addr + HEAD_DIM + d, mask=d_mask_hd, other=0.0
+            ).to(tl.float32)
+            ape_val = tl.load(
+                ape_ptr + k * ape_stride_r + d, mask=d_mask_hd, other=0.0
+            ).to(tl.float32)
+            score_k = sc_val + ape_val
+
+            m_new = tl.maximum(m_prev, score_k)
+            exp_old = tl.where(m_prev == float("-inf"), 0.0, tl.exp(m_prev - m_new))
+            exp_cur = tl.where(score_k == float("-inf"), 0.0, tl.exp(score_k - m_new))
+            kv_acc = kv_acc * exp_old + exp_cur * kv_val
+            w_acc = w_acc * exp_old + exp_cur
+            m_prev = m_new
+
+        compressed = kv_acc / w_acc
+        tl.store(out_ptr + cid * out_stride_b + d, compressed, mask=d_mask_hd)
+
+
+def _compress_forward_c128_triton(
+    kv_score_buffer: torch.Tensor,
+    kv_score_input: torch.Tensor,
+    ape: torch.Tensor,
+    plan: Union[CompressorDecodePlan, CompressorPrefillPlan],
+    head_dim: int,
+) -> torch.Tensor:
+    """Triton C128 compress_forward for HIP (wave64).
+
+    Fuses write + online-softmax-pool into Triton kernels.
+    CUDA graph compatible.
+    """
+    num_total_slots = kv_score_buffer.shape[0] * kv_score_buffer.shape[1]
+    num_pages = kv_score_buffer.shape[0]
+    last_dim = kv_score_buffer.shape[-1]
+    compress_ratio = 128
+
+    buf_flat = kv_score_buffer.view(-1, last_dim)
+    buf_stride_slot = last_dim  # elements per slot
+
+    BLOCK_D = triton.next_power_of_2(last_dim)
+
+    if plan.is_decode:
+        # Decode path: single kernel does write + compress
+        plan_raw = plan[1].view(torch.int32)  # [bs, 4]
+        bs = plan_raw.shape[0]
+        out = torch.empty(
+            bs, head_dim, dtype=torch.float32, device=kv_score_input.device
+        )
+
+        if bs > 0 and num_total_slots > 0:
+            grid = (bs,)
+            _c128_compress_decode_kernel[grid](
+                buf_flat,
+                kv_score_input,
+                ape,
+                out,
+                plan_raw,
+                buf_stride_slot,
+                kv_score_input.stride(0),
+                ape.stride(0),
+                out.stride(0),
+                bs,
+                HEAD_DIM=head_dim,
+                BLOCK_D=triton.next_power_of_2(head_dim),
+                COMPRESS_RATIO=compress_ratio,
+                num_warps=8,
+            )
+        return out
+    else:
+        # Prefill path: separate write kernel + compress kernel
+        plan_c_raw = plan[1].view(torch.int32)  # [num_c, 4]
+        plan_w = plan[2]  # [num_w, 8] uint8
+        plan_w_raw = plan_w.view(torch.int32)  # [num_w, 2]
+        num_c = plan_c_raw.shape[0]
+        num_w = plan_w_raw.shape[0]
+
+        out = torch.empty(
+            num_c, head_dim, dtype=torch.float32, device=kv_score_input.device
+        )
+
+        # Phase 1: Write
+        if num_w > 0 and num_total_slots > 0:
+            grid_w = (num_w,)
+            _c128_compress_prefill_write_kernel[grid_w](
+                buf_flat,
+                kv_score_input,
+                plan_w_raw,
+                buf_stride_slot,
+                kv_score_input.stride(0),
+                num_w,
+                BLOCK_D=BLOCK_D,
+                LAST_DIM=last_dim,
+                num_warps=4,
+            )
+
+        # Phase 2: Compress
+        if num_c > 0 and num_pages > 0:
+            grid_c = (num_c,)
+            _c128_compress_prefill_compress_kernel[grid_c](
+                buf_flat,
+                ape,
+                out,
+                plan_c_raw,
+                buf_stride_slot,
+                ape.stride(0),
+                out.stride(0),
+                num_c,
+                HEAD_DIM=head_dim,
+                BLOCK_D=triton.next_power_of_2(head_dim),
+                COMPRESS_RATIO=compress_ratio,
+                num_warps=8,
+            )
+
+        return out
 
 def _use_online_compress(compress_ratio: int) -> bool:
     """Online state-pool path is c128-only."""
@@ -218,13 +496,17 @@ class CompressorBackendMixin:
             is_unified_kv_triton,
         )
 
-        if _is_hip and not envs.SGLANG_OPT_USE_JIT_NORM.get():
-            self._forward_unified_hip(
+        use_dcp_scatter_store = _dcp_write_enabled() and not is_unified_kv_triton()
+        if (
+            _is_hip and not envs.SGLANG_OPT_USE_JIT_NORM.get()
+        ) or use_dcp_scatter_store:
+            self._forward_unified_scatter_store(
                 token_to_kv_pool=token_to_kv_pool,
                 kv_score_input=kv_score_input,
                 state_pool=state_pool,
                 compressor=compressor,
                 layer_id=layer_id,
+                forward_batch=forward_batch,
             )
         else:
             out_loc = self._get_out_loc(compressor.ratio)
@@ -280,15 +562,16 @@ class CompressorBackendMixin:
                 or forward_batch.forward_mode,
             )
 
-    def _forward_unified_hip(
+    def _forward_unified_scatter_store(
         self,
         token_to_kv_pool: DeepSeekV4TokenToKVPool,
         kv_score_input: torch.Tensor,
         state_pool,
         compressor: Compressor,
         layer_id: int,
+        forward_batch: ForwardBatch,
     ) -> None:
-        """HIP-specific forward path using PyTorch/Triton fallbacks."""
+        """Fallback forward path that stores through DCP-aware KV-pool APIs."""
         from sglang.kernels.ops.attention.deepseek_v4_rope import (
             fused_norm_rope_inplace_triton,
         )
@@ -306,10 +589,14 @@ class CompressorBackendMixin:
         out_loc = self._get_out_loc(compress_ratio)
 
         # Step 1: compress_forward (always use JIT for both C4 and C128)
-        coff = 2 if is_overlap_compress(compress_ratio) else 1
-        last_dim = 2 * head_dim * coff
         kv_score_buffer = state_pool.kv_score_buffer.kv_score
-        kv_score_buffer = kv_score_buffer.view(-1, compress_ratio, last_dim)
+        is_online = _use_online_compress(compress_ratio)
+        if is_online:
+            kv_score_buffer = kv_score_buffer.view(-1, 1, head_dim * 3)
+        else:
+            coff = 2 if is_overlap_compress(compress_ratio) else 1
+            last_dim = 2 * head_dim * coff
+            kv_score_buffer = kv_score_buffer.view(-1, compress_ratio, last_dim)
 
         kv_compressed = compress_forward(
             kv_score_buffer=kv_score_buffer,
@@ -318,20 +605,17 @@ class CompressorBackendMixin:
             plan=plan,
             compress_ratio=compress_ratio,
             head_dim=head_dim,
-            is_online=False,
+            is_online=is_online,
         )
 
         if kv_compressed.shape[0] == 0:
             return
 
-        # For decode: zero out non-boundary tokens to prevent corrupting kvcache loc 0.
+        boundary_mask = None
         if plan.is_decode:
             plan_raw = plan[1].view(torch.int32)
             seq_lens_plan = plan_raw[:, 0].to(torch.int32)
-            is_boundary = (seq_lens_plan % compress_ratio == 0).unsqueeze(-1)
-            kv_compressed = torch.where(
-                is_boundary, kv_compressed, torch.zeros_like(kv_compressed)
-            )
+            boundary_mask = (seq_lens_plan % compress_ratio == 0).contiguous()
 
         # Step 2: norm + rope (Triton fallback for precision parity with V1)
         positions = _extract_positions_from_plan(plan, compress_ratio)
@@ -350,16 +634,23 @@ class CompressorBackendMixin:
             kv_compressed = rotate_activation(kv_compressed)
 
         # Step 4: store to kvcache
-        # For decode: store ALL tokens. Non-boundary tokens have out_loc=0 (safe).
+        # For decode: only store true compressed-boundary tokens. Slot 0 can be a
+        # real compressed cache slot, so non-boundary tokens must not write zeros
+        # there.
         # For prefill: plan_c already only contains valid entries.
+        write_mask = None
         if plan.is_decode:
             kv_to_store = kv_compressed
             out_loc_to_store = out_loc
+            write_mask = boundary_mask
         else:
             kv_to_store = kv_compressed
             plan_raw = plan[1].view(torch.int32)
+            valid_plan_mask = (plan_raw[:, 0].to(torch.int32) >= 0).contiguous()
             ragged_ids = plan_raw[:, 1].to(torch.int32) & 0xFFFF
-            out_loc_to_store = out_loc[ragged_ids.long()]
+            ragged_ids = ragged_ids.long().clamp(max=out_loc.shape[0] - 1)
+            out_loc_to_store = out_loc[ragged_ids]
+            write_mask = valid_plan_mask
 
         if kv_to_store.shape[0] == 0:
             return
@@ -371,12 +662,16 @@ class CompressorBackendMixin:
                     layer_id=layer_id,
                     loc=out_loc_to_store,
                     cache_k=kv_to_store,
+                    dcp_kv_mask=forward_batch.dcp_kv_mask,
+                    write_mask=write_mask,
                 )
             else:
                 token_to_kv_pool.set_extra_key_buffer_fused(
                     layer_id=layer_id,
                     loc=out_loc_to_store,
                     cache_k=kv_to_store,
+                    dcp_kv_mask=forward_batch.dcp_kv_mask,
+                    write_mask=write_mask,
                 )
         else:
             if is_indexer:
@@ -386,10 +681,18 @@ class CompressorBackendMixin:
                     loc=out_loc_to_store,
                     index_k=kv_fp8,
                     index_k_scale=kv_scale,
+                    dcp_kv_mask=forward_batch.dcp_kv_mask,
+                    write_mask=write_mask,
                 )
             else:
                 pack = quant_to_nope_fp8_rope_bf16_pack_triton(kv_to_store.bfloat16())
-                token_to_kv_pool.set_extra_key_buffer(layer_id, out_loc_to_store, pack)
+                token_to_kv_pool.set_extra_key_buffer(
+                    layer_id,
+                    out_loc_to_store,
+                    pack,
+                    dcp_kv_mask=forward_batch.dcp_kv_mask,
+                    write_mask=write_mask,
+                )
 
     # NOTE: alias for backward compatibility
     forward_indexer_compressor = forward_unified
@@ -414,6 +717,7 @@ def create_paged_compressor_data(
     use_prefill_cuda_graph: bool = False,
     num_q_tokens: Optional[int] = None,
     online_state_slot_offset: int = 0,
+    online_active_bs: Optional[int] = None,
 ) -> CompressMetadata:
     """Build the paged compress metadata (= the plan).
 
@@ -433,6 +737,7 @@ def create_paged_compressor_data(
             use_prefill_cuda_graph=use_prefill_cuda_graph,
             num_q_tokens=num_q_tokens,
             online_state_slot_offset=online_state_slot_offset,
+            online_active_bs=online_active_bs,
         )
 
     swa_page_size = token_to_kv_pool.swa_page_size
@@ -465,6 +770,7 @@ def create_paged_compressor_data(
             ring_size=ring_size,
             num_q_tokens=num_q_tokens,
             use_cuda_graph=use_prefill_cuda_graph,
+            active_bs=online_active_bs,
         )
     else:
         return CompressorDecodePlan.generate(
@@ -491,6 +797,7 @@ def _create_online_paged_compressor_data(
     use_prefill_cuda_graph: bool,
     num_q_tokens: Optional[int],
     online_state_slot_offset: int = 0,
+    online_active_bs: Optional[int] = None,
 ) -> CompressMetadata:
     req_pool_indices = req_pool_indices.to(torch.int64)
 
@@ -517,6 +824,7 @@ def _create_online_paged_compressor_data(
             num_q_tokens=int(num_q_tokens_planner),
             use_cuda_graph=use_prefill_cuda_graph,
             state_slot_offset=online_state_slot_offset,
+            active_bs=online_active_bs,
         )
     else:
         return CompressorDecodePlan.generate_online(

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -42,9 +42,8 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
-
 FP8_DTYPE = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
-
+FP8_MAX = torch.finfo(FP8_DTYPE).max
 
 IndexerQuery: TypeAlias = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
 

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -9,6 +9,8 @@ import torch.nn.functional as F
 from sglang.jit_kernel.dsv4 import (
     fused_q_indexer_rope_hadamard_fp4_quant,
     fused_q_indexer_rope_hadamard_quant,
+    merge_dcp_topk_candidates_512,
+    topk_candidates_512,
     topk_transform_512,
     topk_transform_512_v2,
 )
@@ -557,6 +559,217 @@ class C4IndexerBackendMixin:
             max_seqlen_k=plan.max_seqlen_k,
         )
 
+    def _try_forward_dcp_sharded_c4_indexer(
+        self,
+        *,
+        q: torch.Tensor,
+        q_indexer: torch.Tensor,
+        weights: torch.Tensor,
+        logits_fn: Any,
+        use_tilelang: bool,
+        use_aiter: bool,
+        c4_indexer: C4Indexer,
+        forward_batch: ForwardBatch,
+        token_to_kv_pool: DeepSeekV4TokenToKVPool,
+        indexer_metadata: PagedIndexerMetadata,
+        page_table: torch.Tensor,
+        c4_seq_lens: torch.Tensor,
+        local_page_table: Optional[torch.Tensor],
+        local_c4_seq_lens: Optional[torch.Tensor],
+        c4_sparse_page_indices: torch.Tensor,
+        raw_indices: Optional[torch.Tensor],
+    ) -> bool:
+        """Score interleaved logical C4-page shards and merge local top-k.
+
+        The P0 path keeps the indexer cache replicated, but each DCP rank sends
+        only logical pages ``rank, rank + world_size, ...`` to the existing
+        paged-MQA logits kernel. A C4 page contains 64 compressed items (256 raw
+        tokens), so shard boundaries preserve the compressor's 8-token window.
+        """
+
+        if not envs.SGLANG_DSV4_DCP_SHARD_C4_INDEXER.get():
+            return False
+        if c4_indexer.use_fp4_indexer:
+            return False
+        if is_hip():
+            return False
+        if self.hisparse_coordinator is not None:
+            return False
+        if not forward_batch.forward_mode.is_decode():
+            return False
+        if self.debug_use_external_c4_sparse_indices:
+            return False
+        if not isinstance(q_indexer, torch.Tensor):
+            return False
+        if q_indexer.dim() != 3 or q_indexer.shape[-1] != c4_indexer.head_dim:
+            return False
+        if local_page_table is None or local_c4_seq_lens is None:
+            return False
+
+        from sglang.srt.distributed.parallel_state import get_dcp_group_no_assert
+
+        dcp_group = get_dcp_group_no_assert()
+        if dcp_group is None or dcp_group.world_size <= 1:
+            return False
+        if (
+            indexer_metadata.dcp_world_size != dcp_group.world_size
+            or indexer_metadata.dcp_rank != dcp_group.rank_in_group
+        ):
+            return False
+
+        batch_size = q_indexer.shape[0]
+        if batch_size == 0:
+            c4_sparse_page_indices.fill_(-1)
+            if raw_indices is not None:
+                raw_indices.fill_(-1)
+            return True
+
+        c4_page_size = indexer_metadata.c4_page_size
+        topk = c4_sparse_page_indices.shape[1]
+        if topk == 0:
+            return True
+
+        device = q_indexer.device
+        world_size = dcp_group.world_size
+        rank = dcp_group.rank_in_group
+        max_global_seq_len = indexer_metadata.max_c4_seq_len
+        max_global_pages = (max_global_seq_len + c4_page_size - 1) // c4_page_size
+        max_local_pages = max(
+            0, (max_global_pages + world_size - 1 - rank) // world_size
+        )
+        local_page_table = local_page_table[:, :max_local_pages]
+        local_seq_lens = local_c4_seq_lens.view(-1).to(torch.int32).contiguous()
+
+        if local_page_table.shape[1] == 0:
+            # A short request can leave a high DCP rank with no logical page.
+            # Keep all ranks in the candidate collectives without invoking the
+            # paged-MQA kernel on an empty page table.
+            local_page_table = page_table[:, :1].contiguous()
+            local_logits = torch.full(
+                (batch_size, c4_page_size),
+                float("-inf"),
+                dtype=torch.float32,
+                device=device,
+            )
+        else:
+            c4_indexer_kv_cache = token_to_kv_pool.get_index_k_with_scale_buffer(
+                layer_id=c4_indexer.layer_id,
+            )
+            assert c4_indexer_kv_cache.dim() == 2
+            c4_indexer_kv_cache = c4_indexer_kv_cache.view(
+                c4_indexer_kv_cache.shape[0],
+                c4_page_size,
+                1,
+                c4_indexer.head_dim + 4,
+            )
+            local_seq_lens_for_kernel = local_seq_lens
+            if not use_tilelang and not use_aiter:
+                local_seq_lens_for_kernel = local_seq_lens_for_kernel.unsqueeze(-1)
+            local_logits = logits_fn(
+                q,
+                c4_indexer_kv_cache,
+                weights,
+                local_seq_lens_for_kernel,
+                local_page_table,
+                indexer_metadata.dcp_deep_gemm_metadata,
+                local_page_table.shape[1] * c4_page_size,
+                False,
+            )
+
+        if envs.SGLANG_DSV4_DCP_C4_PACKED_TOPK.get():
+            local_candidates = indexer_metadata.dcp_local_topk_candidates
+            gathered_candidates = indexer_metadata.dcp_gathered_topk_candidates
+            assert local_candidates is not None
+            assert gathered_candidates is not None
+            local_candidates = local_candidates[:batch_size]
+            gathered_candidates = gathered_candidates[: world_size * batch_size]
+            topk_candidates_512(
+                local_logits,
+                local_seq_lens,
+                local_candidates,
+                c4_page_size,
+                world_size,
+                rank,
+            )
+            dcp_group.all_gather_into_tensor(
+                gathered_candidates, local_candidates
+            )
+            merge_dcp_topk_candidates_512(
+                gathered_candidates,
+                c4_seq_lens.view(-1).to(torch.int32).contiguous(),
+                page_table,
+                c4_sparse_page_indices,
+                c4_page_size,
+                world_size,
+                raw_indices,
+            )
+            return True
+
+        local_raw = (
+            raw_indices
+            if raw_indices is not None
+            else torch.empty_like(c4_sparse_page_indices)
+        )
+        topk_transform_512(
+            local_logits,
+            local_seq_lens,
+            local_page_table,
+            c4_sparse_page_indices,
+            c4_page_size,
+            local_raw,
+        )
+
+        local_raw_i64 = local_raw.to(torch.int64)
+        local_scores = torch.gather(
+            local_logits, 1, local_raw_i64.clamp(min=0)
+        ).masked_fill(local_raw < 0, float("-inf"))
+
+        page_bits = (c4_page_size - 1).bit_length()
+        page_mask = c4_page_size - 1
+        global_raw = (
+            ((local_raw_i64 >> page_bits) * world_size + rank) << page_bits
+        ) | (local_raw_i64 & page_mask)
+        global_raw = global_raw.to(torch.int32).masked_fill(local_raw < 0, -1)
+
+        gathered_scores = dcp_group.all_gather(local_scores.contiguous(), dim=1)
+        gathered_raw = dcp_group.all_gather(global_raw.contiguous(), dim=1)
+        merged_scores, merged_pos = torch.topk(
+            gathered_scores, k=topk, dim=1, largest=True, sorted=False
+        )
+        merged_raw = torch.gather(gathered_raw, 1, merged_pos)
+        valid_merged = (merged_scores != float("-inf")) & (merged_raw >= 0)
+        merged_raw = merged_raw.masked_fill(~valid_merged, -1)
+
+        final_raw = merged_raw.to(torch.int32)
+        # Match topk_transform_512 semantics: when the compressed history is
+        # no longer than TOPK, return the complete raw range in order.
+        seq_lens = c4_seq_lens.view(-1).to(device=device, dtype=torch.int64)
+        needs_sequential = seq_lens <= topk
+        arange_key = f"dcp_c4_topk_{topk}_{device}"
+        if arange_key not in _arange_cache:
+            _arange_cache[arange_key] = torch.arange(
+                topk, device=device, dtype=torch.int32
+            )
+        topk_positions = _arange_cache[arange_key]
+        topk_positions = topk_positions.unsqueeze(0).expand(batch_size, -1)
+        sequential_valid = topk_positions.to(torch.int64) < seq_lens.unsqueeze(1)
+        sequential_raw = topk_positions.masked_fill(~sequential_valid, -1)
+        final_raw = torch.where(
+            needs_sequential.unsqueeze(1), sequential_raw, final_raw
+        )
+        if raw_indices is not None:
+            raw_indices.copy_(final_raw)
+
+        raw_for_gather = final_raw.clamp(min=0).to(torch.int64)
+        page_ids = raw_for_gather >> page_bits
+        page_offsets = raw_for_gather & page_mask
+        page_ids = torch.clamp(page_ids, max=page_table.shape[1] - 1)
+        final_pages = torch.gather(page_table, 1, page_ids)
+        final_slots = (final_pages << page_bits) | page_offsets.to(torch.int32)
+        final_slots = final_slots.masked_fill(final_raw < 0, -1)
+        c4_sparse_page_indices.copy_(final_slots)
+        return True
+
     def forward_c4_indexer(
         self,
         x: torch.Tensor,
@@ -666,12 +879,70 @@ class C4IndexerBackendMixin:
         c4_sparse_page_indices = match_num_queries(
             core_metadata.c4_sparse_page_indices, value=-1
         )
+
+        indexer_capturer = get_global_indexer_capturer()
+        capture_enabled = indexer_capturer is not None
+
+        hisparse_coordinator = self.hisparse_coordinator
+        hisparse_decode = (
+            hisparse_coordinator is not None and forward_batch.forward_mode.is_decode()
+        )
+
+        raw_indices = None
+        if capture_enabled:
+            raw_indices = torch.empty_like(c4_sparse_page_indices)
+        elif hisparse_decode:
+            raw_indices = hisparse_coordinator.raw_indices_buffer[
+                : c4_sparse_page_indices.size(0)
+            ]
+        elif core_metadata.c4_sparse_raw_indices is not None:
+            raw_indices = match_num_queries(
+                core_metadata.c4_sparse_raw_indices, value=-1
+            )
+
         _use_tilelang = (
             envs.SGLANG_OPT_USE_TILELANG_INDEXER.get() and not use_fp4_indexer
         )
         _use_aiter = envs.SGLANG_OPT_USE_AITER_INDEXER.get() and not use_fp4_indexer
         if _c4sl.dim() == 1 and not _use_tilelang and not _use_aiter:
             _c4sl = _c4sl.unsqueeze(-1)
+
+        local_page_table = indexer_metadata.dcp_local_page_table
+        if local_page_table is not None:
+            local_page_table = match_num_queries(local_page_table, value=0)
+        local_c4_seq_lens = indexer_metadata.dcp_local_c4_seq_lens
+        if local_c4_seq_lens is not None:
+            local_c4_seq_lens = match_num_queries(
+                local_c4_seq_lens,
+                value=1 if indexer_metadata.dcp_rank == 0 else 0,
+            )
+
+        if self._try_forward_dcp_sharded_c4_indexer(
+            q=q,
+            q_indexer=q_indexer,
+            weights=weights,
+            logits_fn=fn,
+            use_tilelang=_use_tilelang,
+            use_aiter=_use_aiter,
+            c4_indexer=c4_indexer,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+            indexer_metadata=indexer_metadata,
+            page_table=page_table,
+            c4_seq_lens=c4_seq_lens,
+            local_page_table=local_page_table,
+            local_c4_seq_lens=local_c4_seq_lens,
+            c4_sparse_page_indices=c4_sparse_page_indices,
+            raw_indices=raw_indices,
+        ):
+            assert indexer_metadata.page_table is core_metadata.page_table
+            if capture_enabled:
+                compress_layer_id = token_to_kv_pool.layer_mapping[
+                    c4_indexer.layer_id
+                ].compress_layer_id
+                indexer_capturer.capture(compress_layer_id, raw_indices)
+            return
+
         nonpaged_plan = self._get_nonpaged_indexer_plan(
             c4_indexer=c4_indexer,
             forward_batch=forward_batch,
@@ -712,24 +983,6 @@ class C4IndexerBackendMixin:
         assert indexer_metadata.page_table is core_metadata.page_table
         if self.debug_use_external_c4_sparse_indices:
             return
-
-        indexer_capturer = get_global_indexer_capturer()
-        capture_enabled = indexer_capturer is not None
-
-        hisparse_coordinator = self.hisparse_coordinator
-        hisparse_decode = (
-            hisparse_coordinator is not None and forward_batch.forward_mode.is_decode()
-        )
-
-        raw_indices = None
-        if capture_enabled:
-            raw_indices = torch.empty_like(c4_sparse_page_indices)
-        elif hisparse_decode:
-            raw_indices = hisparse_coordinator.raw_indices_buffer[
-                : c4_sparse_page_indices.size(0)
-            ]
-        elif core_metadata.c4_sparse_raw_indices is not None:
-            raw_indices = core_metadata.c4_sparse_raw_indices
 
         if envs.SGLANG_TOPK_TRANSFORM_512_TORCH.get():
             topk_transform_512_pytorch_vectorized(

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -12,6 +12,52 @@ from sglang.srt.utils import is_hip, is_xpu
 if TYPE_CHECKING:
     pass
 
+_TOPK_V2_MAX_SUPPORTED_LENGTH = 262144
+
+
+def _maybe_copy_flashmla_sched_meta(dst, src) -> bool:
+    if not (
+        hasattr(dst, "have_initialized")
+        and hasattr(src, "have_initialized")
+        and hasattr(dst, "tile_scheduler_metadata")
+        and hasattr(src, "tile_scheduler_metadata")
+        and hasattr(dst, "num_splits")
+        and hasattr(src, "num_splits")
+    ):
+        return False
+
+    if dst is None or src is None:
+        return False
+
+    # CUDA graphs capture the initialized FlashMLA metadata tensors by pointer.
+    # Replay preparation often builds a fresh, uninitialized metadata object;
+    # replacing the captured object would drop the tensors still referenced by
+    # the graph. Keep the captured object alive in that case.
+    if getattr(dst, "have_initialized", False) and not getattr(
+        src, "have_initialized", False
+    ):
+        return True
+
+    if not getattr(dst, "have_initialized", False) or not getattr(
+        src, "have_initialized", False
+    ):
+        return False
+
+    for field_name in ("tile_scheduler_metadata", "num_splits"):
+        src_val = getattr(src, field_name)
+        dst_val = getattr(dst, field_name)
+        if src_val is None and dst_val is None:
+            continue
+        if src_val is None or dst_val is None or not hasattr(dst_val, "copy_"):
+            return False
+        if tuple(src_val.shape) != tuple(dst_val.shape):
+            return False
+        dst_val.copy_(src_val)
+
+    dst.have_initialized = src.have_initialized
+    dst.config = src.config
+    return True
+
 
 """
 Some comments on the common terms used in DeepSeekV4Backend:
@@ -81,7 +127,10 @@ def copy_metadata(
             setattr(dst, field_name, src_val)
 
     for field_name in assign_fields:
-        setattr(dst, field_name, getattr(src, field_name))
+        src_val = getattr(src, field_name)
+        dst_val = getattr(dst, field_name)
+        if not _maybe_copy_flashmla_sched_meta(dst_val, src_val):
+            setattr(dst, field_name, src_val)
 
     provided_fields = check_eq_fields + copy_fields + assign_fields
     provided_fields_unique = set(provided_fields)
@@ -168,7 +217,23 @@ class PagedIndexerMetadata:
 
     @property
     def max_c4_seq_len(self) -> int:
-        return self.page_table.shape[1] * self.c4_page_size
+        if self.c4_seq_lens.numel() == 0:
+            return self.c4_page_size
+
+        # During CUDA graph capture, ``.item()`` forces a device->host sync,
+        # which is illegal on a capturing stream. The captured logits buffer
+        # must also be sized for the worst case so replay shapes stay valid.
+        # Fall back to the static max-capacity bound in that case.
+        if torch.cuda.is_current_stream_capturing():
+            return self.page_table.shape[1] * self.c4_page_size
+
+        # CUDA graph/raw metadata may keep a max-capacity page table. The indexer
+        # should only materialize logits up to the active compressed length.
+        max_c4_seq_len = int(self.c4_seq_lens.max().item())
+        max_c4_pages = max(
+            1, (max_c4_seq_len + self.c4_page_size - 1) // self.c4_page_size
+        )
+        return min(max_c4_pages, self.page_table.shape[1]) * self.c4_page_size
 
     def copy_(self, other: PagedIndexerMetadata):
         if is_hip():

--- a/python/sglang/srt/layers/attention/dsv4/metadata.py
+++ b/python/sglang/srt/layers/attention/dsv4/metadata.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     pass
 
 _TOPK_V2_MAX_SUPPORTED_LENGTH = 262144
+_C4_TOPK = 512
 
 
 def _maybe_copy_flashmla_sched_meta(dst, src) -> bool:
@@ -97,6 +98,33 @@ Some other notes:
 _LARGE_INDEXER_QUERY_THRESHOLD = 11673
 
 
+def get_dcp_sharded_c4_seq_lens(
+    c4_seq_lens: torch.Tensor,
+    c4_page_size: int,
+    dcp_world_size: int,
+    dcp_rank: int,
+) -> torch.Tensor:
+    """Return lengths after interleaving logical C4 pages across DCP ranks."""
+
+    assert c4_page_size > 0
+    assert dcp_world_size > 0
+    assert 0 <= dcp_rank < dcp_world_size
+
+    shape = c4_seq_lens.shape
+    seq_lens = c4_seq_lens.reshape(-1).to(torch.int64)
+    full_pages = seq_lens // c4_page_size
+    tail = seq_lens % c4_page_size
+
+    # Count full logical pages p where p % world_size == rank.
+    local_full_pages = torch.clamp(
+        (full_pages + dcp_world_size - 1 - dcp_rank) // dcp_world_size,
+        min=0,
+    )
+    owns_tail = (tail > 0) & ((full_pages % dcp_world_size) == dcp_rank)
+    local_tail = torch.where(owns_tail, tail, torch.zeros_like(tail))
+    return (local_full_pages * c4_page_size + local_tail).to(torch.int32).view(shape)
+
+
 def copy_metadata(
     *,
     src,
@@ -104,8 +132,10 @@ def copy_metadata(
     check_eq_fields: List[str],
     copy_fields: List[str],
     assign_fields: Optional[List[str]] = None,
+    preserve_fields: Optional[List[str]] = None,
 ):
     assign_fields = assign_fields or []
+    preserve_fields = preserve_fields or []
 
     for field_name in check_eq_fields:
         src_val = getattr(src, field_name)
@@ -132,7 +162,31 @@ def copy_metadata(
         if not _maybe_copy_flashmla_sched_meta(dst_val, src_val):
             setattr(dst, field_name, src_val)
 
-    provided_fields = check_eq_fields + copy_fields + assign_fields
+    # CUDA graphs retain workspace addresses captured in kernel arguments. The
+    # replay metadata may own equivalent scratch tensors, but replacing or
+    # copying them is unnecessary and can invalidate the captured contract.
+    for field_name in preserve_fields:
+        src_val = getattr(src, field_name)
+        dst_val = getattr(dst, field_name)
+        if src_val is None or dst_val is None:
+            assert (
+                src_val is None and dst_val is None
+            ), f"{field_name=} {src_val=} {dst_val=}"
+            continue
+        assert isinstance(src_val, torch.Tensor) and isinstance(
+            dst_val, torch.Tensor
+        ), f"{field_name=} must contain matching tensors"
+        assert (
+            src_val.shape == dst_val.shape
+        ), f"{field_name=} {src_val.shape=} {dst_val.shape=}"
+        assert (
+            src_val.dtype == dst_val.dtype
+        ), f"{field_name=} {src_val.dtype=} {dst_val.dtype=}"
+        assert (
+            src_val.device == dst_val.device
+        ), f"{field_name=} {src_val.device=} {dst_val.device=}"
+
+    provided_fields = check_eq_fields + copy_fields + assign_fields + preserve_fields
     provided_fields_unique = set(provided_fields)
     assert len(provided_fields) == len(
         provided_fields_unique
@@ -163,40 +217,90 @@ class PagedIndexerMetadata:
     c4_seq_lens: torch.Tensor
     use_prefill_cuda_graph: bool = False
     deep_gemm_metadata: Any = field(init=False, repr=False)
+    dcp_world_size: int = field(init=False, repr=False, default=1)
+    dcp_rank: int = field(init=False, repr=False, default=0)
+    dcp_local_page_table: Optional[torch.Tensor] = field(
+        init=False, repr=False, default=None
+    )
+    dcp_local_c4_seq_lens: Optional[torch.Tensor] = field(
+        init=False, repr=False, default=None
+    )
+    dcp_deep_gemm_metadata: Any = field(init=False, repr=False, default=None)
+    dcp_local_topk_candidates: Optional[torch.Tensor] = field(
+        init=False, repr=False, default=None
+    )
+    dcp_gathered_topk_candidates: Optional[torch.Tensor] = field(
+        init=False, repr=False, default=None
+    )
     topk_metadata: torch.Tensor = field(init=False, repr=False)
     nonpaged_plan: Optional[NonPagedIndexerPlan] = field(
         init=False, repr=False, default=None
     )
 
-    def __post_init__(self):
+    def _make_deep_gemm_metadata(self, c4_seq_lens: torch.Tensor):
         if (
             envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
             or is_xpu()
             or envs.SGLANG_OPT_USE_AITER_INDEXER.get()
         ):
-            self.deep_gemm_metadata = None
+            return None
+
+        import deep_gemm
+
+        use_jit_indexer = (
+            envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.get()
+            or c4_seq_lens.numel() > _LARGE_INDEXER_QUERY_THRESHOLD
+        )
+        if use_jit_indexer:
+            from sglang.jit_kernel.dsv4 import get_paged_mqa_logits_metadata
         else:
-            import deep_gemm
+            from deep_gemm import get_paged_mqa_logits_metadata
 
-            use_jit_indexer = (
-                envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.get()
-                or self.c4_seq_lens.numel() > _LARGE_INDEXER_QUERY_THRESHOLD
-            )
-            if use_jit_indexer:
-                from sglang.jit_kernel.dsv4 import get_paged_mqa_logits_metadata
-            else:
-                from deep_gemm import get_paged_mqa_logits_metadata
+        _c4 = c4_seq_lens.to(torch.int32)
+        if _c4.dim() == 1:
+            _c4 = _c4.unsqueeze(-1)
+        metadata = get_paged_mqa_logits_metadata(
+            _c4,
+            self.c4_page_size,
+            deep_gemm.get_num_sms(),
+        )
+        assert isinstance(metadata, torch.Tensor)
+        return metadata
 
-            _c4 = self.c4_seq_lens.to(torch.int32)
-            if _c4.dim() == 1:
-                _c4 = _c4.unsqueeze(-1)
-            self.deep_gemm_metadata = get_paged_mqa_logits_metadata(
-                _c4,
-                self.c4_page_size,
-                deep_gemm.get_num_sms(),
-            )
+    def __post_init__(self):
+        self.deep_gemm_metadata = self._make_deep_gemm_metadata(self.c4_seq_lens)
 
-            assert isinstance(self.deep_gemm_metadata, torch.Tensor)
+        if envs.SGLANG_DSV4_DCP_SHARD_C4_INDEXER.get() and not is_hip():
+            from sglang.srt.distributed.parallel_state import get_dcp_group_no_assert
+
+            dcp_group = get_dcp_group_no_assert()
+            if dcp_group is not None and dcp_group.world_size > 1:
+                self.dcp_world_size = dcp_group.world_size
+                self.dcp_rank = dcp_group.rank_in_group
+                self.dcp_local_page_table = self.page_table[
+                    :, self.dcp_rank :: self.dcp_world_size
+                ].contiguous()
+                self.dcp_local_c4_seq_lens = get_dcp_sharded_c4_seq_lens(
+                    self.c4_seq_lens,
+                    self.c4_page_size,
+                    self.dcp_world_size,
+                    self.dcp_rank,
+                )
+                self.dcp_deep_gemm_metadata = self._make_deep_gemm_metadata(
+                    self.dcp_local_c4_seq_lens
+                )
+                if envs.SGLANG_DSV4_DCP_C4_PACKED_TOPK.get():
+                    batch_size = self.page_table.shape[0]
+                    self.dcp_local_topk_candidates = torch.empty(
+                        (batch_size, _C4_TOPK),
+                        dtype=torch.int64,
+                        device=self.page_table.device,
+                    )
+                    self.dcp_gathered_topk_candidates = torch.empty(
+                        (self.dcp_world_size * batch_size, _C4_TOPK),
+                        dtype=torch.int64,
+                        device=self.page_table.device,
+                    )
 
         from sglang.jit_kernel.dsv4 import plan_topk_v2
 
@@ -242,13 +346,27 @@ class PagedIndexerMetadata:
         else:
             copy_fields = ["page_table", "c4_seq_lens", "deep_gemm_metadata"]
             assign_fields = ["nonpaged_plan"]
-        copy_fields += ["topk_metadata"]
+        copy_fields += [
+            "dcp_local_page_table",
+            "dcp_local_c4_seq_lens",
+            "dcp_deep_gemm_metadata",
+            "topk_metadata",
+        ]
         copy_metadata(
             src=other,
             dst=self,
-            check_eq_fields=["page_size", "use_prefill_cuda_graph"],
+            check_eq_fields=[
+                "page_size",
+                "use_prefill_cuda_graph",
+                "dcp_world_size",
+                "dcp_rank",
+            ],
             copy_fields=copy_fields,
             assign_fields=assign_fields,
+            preserve_fields=[
+                "dcp_local_topk_candidates",
+                "dcp_gathered_topk_candidates",
+            ],
         )
         self.nonpaged_plan = None
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1388,10 +1388,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         for tokenized_obj in tokenized_objs:
             tokenized_obj.wrap_pickle_fields()
 
+        rids = [tokenized_obj.rid for tokenized_obj in tokenized_objs]
         if isinstance(tokenized_objs[0], TokenizedGenerateReqInput):
-            batch_req = BatchTokenizedGenerateReqInput(batch=tokenized_objs)
+            batch_req = BatchTokenizedGenerateReqInput(batch=tokenized_objs, rids=rids)
         else:
-            batch_req = BatchTokenizedEmbeddingReqInput(batch=tokenized_objs)
+            batch_req = BatchTokenizedEmbeddingReqInput(batch=tokenized_objs, rids=rids)
 
         self._dispatch_to_scheduler(batch_req)
         for tokenized_obj, time_stat in zip(tokenized_objs, time_stats):
@@ -3293,3 +3294,5 @@ def stamp_http_worker_ipc(obj: Any, ipc_name: str) -> None:
             req.http_worker_ipc = ipc_name
     elif isinstance(obj, BaseBatchReq):
         obj.http_worker_ipcs = [ipc_name] * len(obj.rids)
+        for request in getattr(obj, "batch", ()):
+            request.http_worker_ipc = ipc_name

--- a/python/sglang/srt/mem_cache/allocator/__init__.py
+++ b/python/sglang/srt/mem_cache/allocator/__init__.py
@@ -1,6 +1,7 @@
 """Token-to-KV-slot allocators. One file per allocation strategy."""
 
 from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.dcp import DcpTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.paged import (
     PagedTokenToKVPoolAllocator,
     alloc_extend_naive,
@@ -9,6 +10,7 @@ from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
 
 __all__ = [
     "BaseTokenToKVPoolAllocator",
+    "DcpTokenToKVPoolAllocator",
     "PagedTokenToKVPoolAllocator",
     "TokenToKVPoolAllocator",
     "alloc_extend_naive",

--- a/python/sglang/srt/mem_cache/allocator/dcp.py
+++ b/python/sglang/srt/mem_cache/allocator/dcp.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.memory_pool import KVCache
+
+
+class DcpTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
+    """Logical paged allocator for decode-context-parallel KV storage.
+
+    DCP keeps request metadata in a cluster-wide logical token-index space.
+    KV writers map logical token index ``i`` to rank ``i % dcp_world_size`` and
+    local physical offset ``i // dcp_world_size`` when writing the per-rank pool.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        device: str,
+        kvcache: "KVCache",
+        need_sort: bool,
+        dcp_rank: int,
+        dcp_world_size: int,
+    ):
+        assert dcp_world_size >= 1
+        assert size % dcp_world_size == 0, (
+            f"DCP logical size {size} must be divisible by dcp_world_size "
+            f"{dcp_world_size}"
+        )
+        self.size = size
+        self.page_size = page_size
+        self.dtype = dtype
+        self.device = device
+        self._kvcache = kvcache
+        self.need_sort = need_sort
+        self.dcp_rank = dcp_rank
+        self.dcp_world_size = dcp_world_size
+        self.real_allocator = PagedTokenToKVPoolAllocator(
+            size, page_size, dtype, device, kvcache, need_sort
+        )
+
+    @property
+    def free_pages(self):
+        return self.real_allocator.free_pages
+
+    @free_pages.setter
+    def free_pages(self, value):
+        self.real_allocator.free_pages = value
+
+    @property
+    def release_pages(self):
+        return self.real_allocator.release_pages
+
+    @release_pages.setter
+    def release_pages(self, value):
+        self.real_allocator.release_pages = value
+
+    @property
+    def is_not_in_free_group(self):
+        return self.real_allocator.is_not_in_free_group
+
+    @is_not_in_free_group.setter
+    def is_not_in_free_group(self, value):
+        self.real_allocator.is_not_in_free_group = value
+
+    @property
+    def free_group(self):
+        return self.real_allocator.free_group
+
+    @free_group.setter
+    def free_group(self, value):
+        self.real_allocator.free_group = value
+
+    @property
+    def num_pages(self):
+        return self.real_allocator.num_pages
+
+    @property
+    def size_full(self):
+        return self.size
+
+    def alloc(self, need_size: int):
+        return self.real_allocator.alloc(need_size)
+
+    def alloc_extend(self, *args, **kwargs):
+        return self.real_allocator.alloc_extend(*args, **kwargs)
+
+    def alloc_decode(self, *args, **kwargs):
+        return self.real_allocator.alloc_decode(*args, **kwargs)
+
+    def free(self, free_index: torch.Tensor):
+        return self.real_allocator.free(free_index)
+
+    def clear(self):
+        return self.real_allocator.clear()
+
+    def available_size(self):
+        return self.real_allocator.available_size()
+
+    def debug_print(self) -> str:
+        return self.real_allocator.debug_print()
+
+    def free_group_begin(self):
+        self.real_allocator.free_group_begin()
+
+    def free_group_end(self):
+        self.real_allocator.free_group_end()
+
+    def merge_and_sort_free(self):
+        self.real_allocator.merge_and_sort_free()
+
+    def backup_state(self):
+        return self.real_allocator.backup_state()
+
+    def restore_state(self, state):
+        self.real_allocator.restore_state(state)
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        return self.real_allocator.get_cpu_copy(indices, mamba_indices=mamba_indices)
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        return self.real_allocator.load_cpu_copy(
+            kv_cache_cpu, indices, mamba_indices=mamba_indices
+        )
+
+    def filter_local_indices(self, indices: torch.Tensor) -> torch.Tensor:
+        local_mask = indices % self.dcp_world_size == self.dcp_rank
+        return indices[local_mask] // self.dcp_world_size

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -1,6 +1,7 @@
 import torch
 
 from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.dcp import DcpTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
@@ -29,6 +30,8 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         device: str,
         kvcache: BaseSWAKVPool,
         need_sort: bool,
+        dcp_rank: int = 0,
+        dcp_world_size: int = 1,
     ):
         assert isinstance(kvcache, BaseSWAKVPool)
         self._size_full = size
@@ -56,26 +59,44 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
                 need_sort,
             )
         else:
-            if _is_npu:
-                PagedTokenToKVPoolAllocatorClass = NPUPagedTokenToKVPoolAllocator
+            if dcp_world_size > 1:
+                # DCP keeps allocator bookkeeping in logical token-index space.
+                # KV writers map logical locs to rank-local storage.
+                def _make_dcp_allocator(pool_size, kv_pool):
+                    return DcpTokenToKVPoolAllocator(
+                        pool_size,
+                        page_size,
+                        dtype,
+                        device,
+                        kv_pool,
+                        need_sort,
+                        dcp_rank=dcp_rank,
+                        dcp_world_size=dcp_world_size,
+                    )
+
+                self.full_attn_allocator = _make_dcp_allocator(size, full_kv_pool)
+                self.swa_attn_allocator = _make_dcp_allocator(size_swa, swa_kv_pool)
             else:
-                PagedTokenToKVPoolAllocatorClass = PagedTokenToKVPoolAllocator
-            self.full_attn_allocator = PagedTokenToKVPoolAllocatorClass(
-                size,
-                page_size,
-                dtype,
-                device,
-                full_kv_pool,
-                need_sort,
-            )
-            self.swa_attn_allocator = PagedTokenToKVPoolAllocatorClass(
-                size_swa,
-                page_size,
-                dtype,
-                device,
-                swa_kv_pool,
-                need_sort,
-            )
+                if _is_npu:
+                    PagedTokenToKVPoolAllocatorClass = NPUPagedTokenToKVPoolAllocator
+                else:
+                    PagedTokenToKVPoolAllocatorClass = PagedTokenToKVPoolAllocator
+                self.full_attn_allocator = PagedTokenToKVPoolAllocatorClass(
+                    size,
+                    page_size,
+                    dtype,
+                    device,
+                    full_kv_pool,
+                    need_sort,
+                )
+                self.swa_attn_allocator = PagedTokenToKVPoolAllocatorClass(
+                    size_swa,
+                    page_size,
+                    dtype,
+                    device,
+                    swa_kv_pool,
+                    need_sort,
+                )
         # Note: append one more item of value -1 in the end so -1 maps to -1.
         # It is needed for the last_loc in alloc_extend, where the first full_last_loc
         # is -1, and we need to map it to swa_last_loc -1 as well.
@@ -345,6 +366,12 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_swa_index_mapping[full_indices] = swa_indices
 
     def free_swa(self, free_index: torch.Tensor):
+        if free_index.numel() == 0:
+            return
+
+        free_index = free_index[
+            (free_index >= 0) & (free_index < self.full_to_swa_index_mapping.shape[0])
+        ]
         if free_index.numel() == 0:
             return
 

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -32,8 +32,13 @@ MAMBA_STATE_PER_REQ_NO_CACHE = 1
 logger = logging.getLogger(__name__)
 
 
-def kv_to_page_indices(kv_indices: torch.Tensor, page_size: int) -> np.ndarray:
-    return (kv_indices[::page_size] // page_size).cpu().numpy()
+def kv_to_page_indices(
+    kv_indices: torch.Tensor | np.ndarray, page_size: int
+) -> np.ndarray:
+    page_indices = kv_indices[::page_size] // page_size
+    if isinstance(page_indices, torch.Tensor):
+        return page_indices.cpu().numpy()
+    return np.asarray(page_indices)
 
 
 def kv_to_page_num(num_kv_indices: int, page_size: int):

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.runtime_context import get_server_args
+from sglang.srt.platforms import current_platform
 from sglang.srt.utils import ceil_div, is_hip
 
 logger = logging.getLogger(__name__)
@@ -128,12 +129,18 @@ class DeepSeekV4SingleKVPool(KVCache):
         layer_id: int,
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
     ):
         dsv4_index_buf_accessor.SetKAndS.execute(
             pool=self,
             buf=self.kv_buffer[layer_id],
             loc=loc,
             nope_fp8_rope_bf16_pack=cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
         )
 
     def set_key_buffer_fused(
@@ -150,6 +157,34 @@ class DeepSeekV4SingleKVPool(KVCache):
             type="flashmla",
         )
 
+    def set_key_buffer_fused_fallback_triton(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
+    ) -> None:
+        """DCP fallback path: quantize the bf16 ``cache_k`` to a NopeFp8RopeBf16
+        pack on-device, then write through the Triton kernel which honors
+        ``dcp_world_size``/``dcp_rank``. Used when ``dcp_size > 1`` because the
+        fused C++ flashmla store kernel is not yet DCP-aware.
+        """
+        from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
+            quant_to_nope_fp8_rope_bf16_pack_triton,
+        )
+
+        pack = quant_to_nope_fp8_rope_bf16_pack_triton(cache_k.bfloat16())
+        self.set_key_buffer(
+            layer_id,
+            loc,
+            pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
+
     def get_key_buffer(self, layer_id: int):
         if self.store_dtype != self.dtype:
             return self.kv_buffer[layer_id - self.start_layer].view(self.dtype)
@@ -164,6 +199,124 @@ class DeepSeekV4SingleKVPool(KVCache):
 
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError("Use get_key_buffer instead.")
+
+    def _value_bytes_per_token(self) -> int:
+        return (
+            self.qk_nope_head_dim
+            + self.qk_rope_head_dim * self.rope_storage_dtype.itemsize
+        )
+
+    def _scale_bytes_per_token(self) -> int:
+        return self.qk_nope_head_dim // self.quantize_block_size + self.scale_pad
+
+    def _copy_token_rows_to_cpu(self, buf: torch.Tensor, indices: torch.Tensor):
+        value_bytes = self._value_bytes_per_token()
+        scale_bytes = self._scale_bytes_per_token()
+        pages = (indices // self.page_size).to(torch.long)
+        offsets = (indices % self.page_size).to(torch.long)
+
+        value_byte_offsets = torch.arange(value_bytes, device=buf.device)
+        value_offsets = offsets[:, None] * value_bytes + value_byte_offsets[None, :]
+        values_cpu = buf[pages[:, None], value_offsets].to("cpu", non_blocking=True)
+
+        scale_byte_offsets = torch.arange(scale_bytes, device=buf.device)
+        scale_base = self.page_size * value_bytes
+        scale_offsets = (
+            scale_base
+            + offsets[:, None] * scale_bytes
+            + scale_byte_offsets[None, :]
+        )
+        scales_cpu = buf[pages[:, None], scale_offsets].to("cpu", non_blocking=True)
+        return values_cpu, scales_cpu
+
+    def _load_token_rows_from_cpu(
+        self,
+        buf: torch.Tensor,
+        indices: torch.Tensor,
+        values_cpu: torch.Tensor,
+        scales_cpu: torch.Tensor,
+    ) -> None:
+        value_bytes = self._value_bytes_per_token()
+        scale_bytes = self._scale_bytes_per_token()
+        pages = (indices // self.page_size).to(torch.long)
+        offsets = (indices % self.page_size).to(torch.long)
+
+        value_byte_offsets = torch.arange(value_bytes, device=buf.device)
+        value_offsets = offsets[:, None] * value_bytes + value_byte_offsets[None, :]
+        values = values_cpu.to(buf.device, non_blocking=True)
+        buf[pages[:, None], value_offsets] = values
+
+        scale_byte_offsets = torch.arange(scale_bytes, device=buf.device)
+        scale_base = self.page_size * value_bytes
+        scale_offsets = (
+            scale_base
+            + offsets[:, None] * scale_bytes
+            + scale_byte_offsets[None, :]
+        )
+        scales = scales_cpu.to(buf.device, non_blocking=True)
+        buf[pages[:, None], scale_offsets] = scales
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        """Move packed DSV4 token rows between cache slots."""
+        if self.layer_num == 0 or tgt_loc.numel() == 0:
+            return
+
+        tgt_loc = tgt_loc.view(-1).long()
+        src_loc = src_loc.view(-1).long()
+
+        value_bytes = self._value_bytes_per_token()
+        scale_bytes = self._scale_bytes_per_token()
+        value_byte_offsets = torch.arange(value_bytes, device=self.device)
+        scale_byte_offsets = torch.arange(scale_bytes, device=self.device)
+        scale_base = self.page_size * value_bytes
+
+        pages_t = tgt_loc // self.page_size
+        offsets_t = tgt_loc % self.page_size
+        pages_s = src_loc // self.page_size
+        offsets_s = src_loc % self.page_size
+
+        value_offsets_t = offsets_t[:, None] * value_bytes + value_byte_offsets[None, :]
+        value_offsets_s = offsets_s[:, None] * value_bytes + value_byte_offsets[None, :]
+        scale_offsets_t = (
+            scale_base + offsets_t[:, None] * scale_bytes + scale_byte_offsets[None, :]
+        )
+        scale_offsets_s = (
+            scale_base + offsets_s[:, None] * scale_bytes + scale_byte_offsets[None, :]
+        )
+
+        for buf in self.kv_buffer:
+            values = buf[pages_s[:, None], value_offsets_s].clone()
+            scales = buf[pages_s[:, None], scale_offsets_s].clone()
+            buf[pages_t[:, None], value_offsets_t] = values
+            buf[pages_t[:, None], scale_offsets_t] = scales
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        kv_cache_cpu = []
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            layer_chunks = []
+            buf = self.kv_buffer[layer_id]
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                layer_chunks.append(self._copy_token_rows_to_cpu(buf, chunk_indices))
+            kv_cache_cpu.append(layer_chunks)
+        current_platform.synchronize()
+        return kv_cache_cpu
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            buf = self.kv_buffer[layer_id]
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                values_cpu, scales_cpu = kv_cache_cpu[layer_id][i // chunk_size]
+                assert values_cpu.shape[0] == scales_cpu.shape[0] == len(chunk_indices)
+                self._load_token_rows_from_cpu(
+                    buf, chunk_indices, values_cpu, scales_cpu
+                )
+        current_platform.synchronize()
 
 
 class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
@@ -229,9 +382,19 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         layer_id: int,
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
     ):
         loc = self.translate_loc_to_hisparse_device(loc)
-        super().set_key_buffer(layer_id, loc, cache_nope_fp8_rope_bf16_pack)
+        super().set_key_buffer(
+            layer_id,
+            loc,
+            cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
 
     def set_key_buffer_fused(
         self,
@@ -241,6 +404,25 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
     ) -> None:
         loc = self.translate_loc_to_hisparse_device(loc)
         return super().set_key_buffer_fused(layer_id, loc, cache_k)
+
+    def set_key_buffer_fused_fallback_triton(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
+    ) -> None:
+        loc = self.translate_loc_to_hisparse_device(loc)
+        return super().set_key_buffer_fused_fallback_triton(
+            layer_id,
+            loc,
+            cache_k,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
+        )
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         raise NotImplementedError("HiSparseC4DevicePool does not support get_cpu_copy")
@@ -303,6 +485,42 @@ class DeepSeekV4IndexerPool(KVCache):
                     for _ in range(self.layer_num)
                 ]
 
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        """Move C4 indexer key+scale rows between cache slots."""
+        if self.layer_num == 0 or tgt_loc.numel() == 0:
+            return
+
+        tgt_loc = tgt_loc.view(-1).long()
+        src_loc = src_loc.view(-1).long()
+
+        k_bytes = (
+            self.index_head_dim // 2 if self.use_fp4_indexer else self.index_head_dim
+        )
+        scale_bytes = 4
+        k_offsets = torch.arange(k_bytes, device=self.device)
+        scale_offsets = torch.arange(scale_bytes, device=self.device)
+        scale_base = self.page_size * k_bytes
+
+        pages_t = tgt_loc // self.page_size
+        offsets_t = tgt_loc % self.page_size
+        pages_s = src_loc // self.page_size
+        offsets_s = src_loc % self.page_size
+
+        k_offsets_t = offsets_t[:, None] * k_bytes + k_offsets[None, :]
+        k_offsets_s = offsets_s[:, None] * k_bytes + k_offsets[None, :]
+        scale_offsets_t = (
+            scale_base + offsets_t[:, None] * scale_bytes + scale_offsets[None, :]
+        )
+        scale_offsets_s = (
+            scale_base + offsets_s[:, None] * scale_bytes + scale_offsets[None, :]
+        )
+
+        for buf in self.index_k_with_scale_buffer:
+            keys = buf[pages_s[:, None], k_offsets_s].clone()
+            scales = buf[pages_s[:, None], scale_offsets_s].clone()
+            buf[pages_t[:, None], k_offsets_t] = keys
+            buf[pages_t[:, None], scale_offsets_t] = scales
+
     def get_kv_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError()
 
@@ -342,10 +560,18 @@ class DeepSeekV4IndexerPool(KVCache):
         loc: torch.Tensor,
         index_k: torch.Tensor,
         index_k_scale: torch.Tensor,
+        dcp_world_size: int = 1,
+        dcp_rank: int = 0,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
         buf = self.index_k_with_scale_buffer[layer_id - self.start_layer]
         index_buf_accessor.SetKAndS.execute(
-            pool=self, buf=buf, loc=loc, index_k=index_k, index_k_scale=index_k_scale
+            pool=self,
+            buf=buf,
+            loc=loc,
+            index_k=index_k,
+            index_k_scale=index_k_scale,
+            write_mask=write_mask,
         )
 
     def set_index_fused(
@@ -378,6 +604,84 @@ class DeepSeekV4IndexerPool(KVCache):
             loc=loc,
             page_size=self.page_size,
         )
+
+    def _scale_bytes_per_token(self) -> int:
+        return (self.index_head_dim // self.quant_block_size) * 4
+
+    def _copy_token_rows_to_cpu(self, buf: torch.Tensor, indices: torch.Tensor):
+        value_bytes = self.index_head_dim
+        scale_bytes = self._scale_bytes_per_token()
+        pages = (indices // self.page_size).to(torch.long)
+        offsets = (indices % self.page_size).to(torch.long)
+
+        value_byte_offsets = torch.arange(value_bytes, device=buf.device)
+        value_offsets = offsets[:, None] * value_bytes + value_byte_offsets[None, :]
+        values_cpu = buf[pages[:, None], value_offsets].to("cpu", non_blocking=True)
+
+        scale_byte_offsets = torch.arange(scale_bytes, device=buf.device)
+        scale_base = self.page_size * value_bytes
+        scale_offsets = (
+            scale_base
+            + offsets[:, None] * scale_bytes
+            + scale_byte_offsets[None, :]
+        )
+        scales_cpu = buf[pages[:, None], scale_offsets].to("cpu", non_blocking=True)
+        return values_cpu, scales_cpu
+
+    def _load_token_rows_from_cpu(
+        self,
+        buf: torch.Tensor,
+        indices: torch.Tensor,
+        values_cpu: torch.Tensor,
+        scales_cpu: torch.Tensor,
+    ) -> None:
+        value_bytes = self.index_head_dim
+        scale_bytes = self._scale_bytes_per_token()
+        pages = (indices // self.page_size).to(torch.long)
+        offsets = (indices % self.page_size).to(torch.long)
+
+        value_byte_offsets = torch.arange(value_bytes, device=buf.device)
+        value_offsets = offsets[:, None] * value_bytes + value_byte_offsets[None, :]
+        values = values_cpu.to(buf.device, non_blocking=True)
+        buf[pages[:, None], value_offsets] = values
+
+        scale_byte_offsets = torch.arange(scale_bytes, device=buf.device)
+        scale_base = self.page_size * value_bytes
+        scale_offsets = (
+            scale_base
+            + offsets[:, None] * scale_bytes
+            + scale_byte_offsets[None, :]
+        )
+        scales = scales_cpu.to(buf.device, non_blocking=True)
+        buf[pages[:, None], scale_offsets] = scales
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        kv_cache_cpu = []
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            layer_chunks = []
+            buf = self.index_k_with_scale_buffer[layer_id]
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                layer_chunks.append(self._copy_token_rows_to_cpu(buf, chunk_indices))
+            kv_cache_cpu.append(layer_chunks)
+        current_platform.synchronize()
+        return kv_cache_cpu
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            buf = self.index_k_with_scale_buffer[layer_id]
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                values_cpu, scales_cpu = kv_cache_cpu[layer_id][i // chunk_size]
+                assert values_cpu.shape[0] == scales_cpu.shape[0] == len(chunk_indices)
+                self._load_token_rows_from_cpu(
+                    buf, chunk_indices, values_cpu, scales_cpu
+                )
+        current_platform.synchronize()
 
 
 class DeepSeekV4LayerItem(NamedTuple):
@@ -479,6 +783,8 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         end_layer: Optional[int] = None,
         enable_hisparse: bool = False,
         online_mtp_max_draft_tokens: int = 0,
+        c4_indexer_size: Optional[int] = None,
+        c4_indexer_state_pool_size: Optional[int] = None,
         num_req_slots: Optional[int] = None,
     ):
         super().__init__(
@@ -491,13 +797,17 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             start_layer,
             end_layer,
         )
-        c4_logical_size = c128_size * 32
+        c4_logical_size = (
+            c4_indexer_size if c4_indexer_size is not None else c128_size * 32
+        )
 
         logger.info(
             "Initialize DeepSeekV4TokenToKVPool with "
             f"{max_num_reqs=} {swa_size=} {c4_size=} "
             f"{c4_logical_size=} {c128_size=} "
-            f"{c4_state_pool_size=} {c128_state_pool_size=}"
+            f"{c4_state_pool_size=} "
+            f"{c4_indexer_state_pool_size=} "
+            f"{c128_state_pool_size=}"
         )
 
         self.max_num_reqs = max_num_reqs
@@ -511,6 +821,11 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.c4_logical_size = c4_logical_size
         self.c128_size = c128_size
         self.c4_state_pool_size = c4_state_pool_size
+        self.c4_indexer_state_pool_size = (
+            c4_indexer_state_pool_size
+            if c4_indexer_state_pool_size is not None
+            else c4_state_pool_size
+        )
         c128_ring_size = self.get_ring_size(128)
         if ONLINE_C128:
             # Request-scoped online C128 state is indexed by req_pool_idx.
@@ -533,6 +848,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             self.online_c128_mtp_pending_seq_lens = torch.empty(
                 self.online_c128_state_num_req_slots, dtype=torch.int64, device=device
             )
+            self.online_c128_mtp_pending_seq_lens.fill_(-1)
 
         # Determine this PP stage's absolute layer range
         if (
@@ -668,6 +984,130 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     def translate_loc_from_full_to_swa(self, kv_indices: torch.Tensor):
         assert self.full_to_swa_index_mapping is not None
         return self.full_to_swa_index_mapping[kv_indices]
+
+    def _localize_dcp_move_locs(
+        self, tgt_loc: torch.Tensor, src_loc: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        dcp_world_size, dcp_rank = self._dcp_world_rank()
+        if dcp_world_size == 1 or tgt_loc.numel() == 0:
+            return tgt_loc, src_loc
+
+        local_mask = (tgt_loc % dcp_world_size == dcp_rank) & (
+            src_loc % dcp_world_size == dcp_rank
+        )
+        if not torch.any(local_mask):
+            return tgt_loc.new_empty((0,)), src_loc.new_empty((0,))
+        return (
+            tgt_loc[local_mask] // dcp_world_size,
+            src_loc[local_mask] // dcp_world_size,
+        )
+
+    @staticmethod
+    def _compressed_move_locs_from_full(
+        tgt_loc: torch.Tensor, src_loc: torch.Tensor, compress_ratio: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if tgt_loc.numel() == 0:
+            return tgt_loc, src_loc
+        mask = ((tgt_loc + 1) % compress_ratio == 0) & (
+            (src_loc + 1) % compress_ratio == 0
+        )
+        return (
+            (tgt_loc[mask] // compress_ratio).to(tgt_loc.dtype),
+            (src_loc[mask] // compress_ratio).to(src_loc.dtype),
+        )
+
+    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
+        """Move accepted speculative DSV4 KV rows into their committed slots."""
+        if tgt_loc.numel() == 0:
+            return
+
+        tgt_loc = tgt_loc.view(-1).long()
+        src_loc = src_loc.view(-1).long()
+
+        if self._unified_kv:
+            raise NotImplementedError("DSV4 unified KV move is not supported yet.")
+
+        tgt_swa = self.translate_loc_from_full_to_swa(tgt_loc)
+        src_swa = self.translate_loc_from_full_to_swa(src_loc)
+        tgt_swa_local, src_swa_local = self._localize_dcp_move_locs(tgt_swa, src_swa)
+        self.swa_kv_pool.move_kv_cache(tgt_swa_local, src_swa_local)
+
+        tgt_c4, src_c4 = self._compressed_move_locs_from_full(tgt_loc, src_loc, 4)
+        if tgt_c4.numel() and src_c4.numel():
+            # C4 indexer cache is replicated in global c4-index space.
+            self.c4_indexer_kv_pool.move_kv_cache(tgt_c4, src_c4)
+            tgt_c4_local, src_c4_local = self._localize_dcp_move_locs(tgt_c4, src_c4)
+            self.c4_kv_pool.move_kv_cache(tgt_c4_local, src_c4_local)
+
+        tgt_c128, src_c128 = self._compressed_move_locs_from_full(tgt_loc, src_loc, 128)
+        if tgt_c128.numel() and src_c128.numel():
+            tgt_c128_local, src_c128_local = self._localize_dcp_move_locs(
+                tgt_c128, src_c128
+            )
+            self.c128_kv_pool.move_kv_cache(tgt_c128_local, src_c128_local)
+
+    def move_accepted_kv_cache(
+        self,
+        tgt_loc: torch.Tensor,
+        src_loc: torch.Tensor,
+        accepted_seq_lens: torch.Tensor,
+    ):
+        """Move speculative accepted rows using logical seq-len boundaries.
+
+        DSV4 compressed KV is written when the logical sequence length hits a
+        compression boundary. The physical full-cache slot number is allocator
+        state and must not be used to infer C4/C128 boundaries.
+        """
+        if tgt_loc.numel() == 0:
+            return
+
+        tgt_loc = tgt_loc.view(-1).long()
+        src_loc = src_loc.view(-1).long()
+        accepted_seq_lens = accepted_seq_lens.view(-1).to(device=tgt_loc.device)
+
+        if self._unified_kv:
+            raise NotImplementedError("DSV4 unified KV move is not supported yet.")
+
+        tgt_swa = self.translate_loc_from_full_to_swa(tgt_loc)
+        src_swa = self.translate_loc_from_full_to_swa(src_loc)
+        tgt_swa_local, src_swa_local = self._localize_dcp_move_locs(tgt_swa, src_swa)
+        self.swa_kv_pool.move_kv_cache(tgt_swa_local, src_swa_local)
+
+        tgt_c4, src_c4 = self._compressed_move_locs_from_boundary_mask(
+            tgt_loc, src_loc, accepted_seq_lens, 4
+        )
+        if tgt_c4.numel() and src_c4.numel():
+            self.c4_indexer_kv_pool.move_kv_cache(tgt_c4, src_c4)
+            tgt_c4_local, src_c4_local = self._localize_dcp_move_locs(tgt_c4, src_c4)
+            self.c4_kv_pool.move_kv_cache(tgt_c4_local, src_c4_local)
+
+        tgt_c128, src_c128 = self._compressed_move_locs_from_boundary_mask(
+            tgt_loc, src_loc, accepted_seq_lens, 128
+        )
+        if tgt_c128.numel() and src_c128.numel():
+            tgt_c128_local, src_c128_local = self._localize_dcp_move_locs(
+                tgt_c128, src_c128
+            )
+            self.c128_kv_pool.move_kv_cache(tgt_c128_local, src_c128_local)
+
+    @staticmethod
+    def _compressed_move_locs_from_boundary_mask(
+        tgt_loc: torch.Tensor,
+        src_loc: torch.Tensor,
+        accepted_seq_lens: torch.Tensor,
+        compress_ratio: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if tgt_loc.numel() == 0:
+            return tgt_loc, src_loc
+        token_len = min(tgt_loc.numel(), src_loc.numel(), accepted_seq_lens.numel())
+        tgt_loc = tgt_loc[:token_len]
+        src_loc = src_loc[:token_len]
+        accepted_seq_lens = accepted_seq_lens[:token_len]
+        mask = accepted_seq_lens % compress_ratio == 0
+        return (
+            (tgt_loc[mask] // compress_ratio).to(tgt_loc.dtype),
+            (src_loc[mask] // compress_ratio).to(src_loc.dtype),
+        )
 
     def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs: List[int] = []
@@ -919,6 +1359,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
     def _init_paged_compress_states(self, enable_memory_saver: bool):
         c4_state_pool_size = self.c4_state_pool_size
+        c4_indexer_state_pool_size = self.c4_indexer_state_pool_size
         c128_state_pool_size = self.c128_state_pool_size
         total_L = len(self.compression_ratios)
         self.compress_state_pools: List[Optional[CompressStatePool]] = [None] * total_L
@@ -1009,16 +1450,25 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
 
             state = pool.kv_score_buffer.kv_score
             if ONLINE_C128:
-                row = state[req_pool_idx]
-                head_dim = row.shape[-1] // 3
-                row[:head_dim].fill_(float("-inf"))
-                row[head_dim:].zero_()
+                rows = [req_pool_idx]
+                if pool.online_mtp_max_draft_tokens > 0:
+                    rows = [
+                        req_pool_idx + i * pool.online_mtp_state_slot_offset
+                        for i in range(pool.online_mtp_max_draft_tokens + 1)
+                    ]
+                rows = torch.as_tensor(rows, dtype=torch.long, device=state.device)
+                head_dim = state.shape[-1] // 3
+                state[rows, :head_dim] = float("-inf")
+                state[rows, head_dim:] = 0
             else:
                 start = req_pool_idx * pool.ring_size
                 rows = state[start : start + pool.ring_size]
                 half = rows.shape[-1] // 2
                 rows[:, :half].zero_()
                 rows[:, half:].fill_(float("-inf"))
+
+        if self.online_c128_mtp_pending_seq_lens is not None:
+            self.online_c128_mtp_pending_seq_lens[req_pool_idx] = -1
 
     def clear_unaccepted_c128_draft_states(
         self,
@@ -1064,14 +1514,52 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         self.wait_layer_transfer(layer_id)
         return self.swa_kv_pool.get_key_buffer(self._swa_local_layer_id(layer_id))
 
+    def _dcp_world_rank(self) -> Tuple[int, int]:
+        """Resolve current DCP (decode context parallel) world size and rank.
+
+        Imported lazily so non-DCP setups don't pay an import cost. Returns
+        ``(world_size, rank)``; when DCP is disabled the group is ``None``
+        and we fall back to ``(1, 0)`` which makes the Triton kernel a no-op
+        on the dcp dimension.
+        """
+        from sglang.srt.distributed.parallel_state import get_dcp_group_no_assert
+
+        group = get_dcp_group_no_assert()
+        if group is None or group.world_size == 1:
+            return 1, 0
+        return group.world_size, group.rank_in_group
+
+    def _dcp_write_context(self) -> Tuple[int, int, bool]:
+        dcp_world_size, dcp_rank = self._dcp_world_rank()
+        return dcp_world_size, dcp_rank, dcp_world_size > 1
+
+    @staticmethod
+    def _dcp_loc_write_mask(loc: torch.Tensor) -> torch.Tensor:
+        # Keep only the validity part here: full-cache loc 0 is the allocator's
+        # dummy/padding slot and must not be persisted as KV. Callers that write
+        # translated locations (for example SWA ring slots) must pass the raw
+        # full-cache loc instead, because translated slot 0 can be valid.
+        return (loc > 0).contiguous()
+
     def set_swa_key_buffer(
         self,
         layer_id: int,
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+        if dcp_enabled or dcp_kv_mask is not None:
+            write_mask = self._dcp_loc_write_mask(loc)
+        else:
+            write_mask = None
         self.swa_kv_pool.set_key_buffer(
-            self._swa_local_layer_id(layer_id), loc, cache_nope_fp8_rope_bf16_pack
+            self._swa_local_layer_id(layer_id),
+            loc,
+            cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
         )
 
     def get_extra_key_page_size(self, layer_id: int) -> int:
@@ -1090,11 +1578,19 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, _ = self._dcp_write_context()
         _, compress_layer_id, compress_kv_pool = self.layer_mapping[layer_id]
         assert compress_kv_pool is not None
         compress_kv_pool.set_key_buffer(
-            compress_layer_id, loc, cache_nope_fp8_rope_bf16_pack
+            compress_layer_id,
+            loc,
+            cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=(write_mask.contiguous() if write_mask is not None else None),
         )
 
     def get_index_k_page_size(self) -> int:
@@ -1131,11 +1627,20 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         loc: torch.Tensor,
         index_k: torch.Tensor,
         index_k_scale: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
         assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
+        # The c4 indexer is a scoring cache used by paged_mqa_logits with the
+        # global c4 page_table, and its topk result is later localized for DCP
+        # attention. Keep this cache replicated in global c4-index space.
         self.c4_indexer_kv_pool.set_index_k_scale_buffer(
-            compress_layer_id, loc, index_k, index_k_scale
+            compress_layer_id,
+            loc,
+            index_k,
+            index_k_scale,
+            write_mask=write_mask.contiguous() if write_mask is not None else None,
         )
 
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:
@@ -1155,9 +1660,23 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         swa_loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        raw_loc: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+        if dcp_enabled or dcp_kv_mask is not None:
+            write_mask = self._dcp_loc_write_mask(
+                raw_loc if raw_loc is not None else swa_loc
+            )
+        else:
+            write_mask = None
         self.swa_kv_pool.set_key_buffer(
-            self._swa_local_layer_id(layer_id), swa_loc, cache_nope_fp8_rope_bf16_pack
+            self._swa_local_layer_id(layer_id),
+            swa_loc,
+            cache_nope_fp8_rope_bf16_pack,
+            dcp_world_size=dcp_world_size,
+            dcp_rank=dcp_rank,
+            write_mask=write_mask,
         )
 
     def get_swa_key_buffer_radix(self, layer_id: int) -> torch.Tensor:
@@ -1169,7 +1688,21 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         swa_loc: torch.Tensor,
         cache_k: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        raw_loc: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+        if dcp_enabled or dcp_kv_mask is not None:
+            return self.swa_kv_pool.set_key_buffer_fused_fallback_triton(
+                self._swa_local_layer_id(layer_id),
+                swa_loc,
+                cache_k,
+                dcp_world_size=dcp_world_size,
+                dcp_rank=dcp_rank,
+                write_mask=self._dcp_loc_write_mask(
+                    raw_loc if raw_loc is not None else swa_loc
+                ),
+            )
         return self.swa_kv_pool.set_key_buffer_fused(
             self._swa_local_layer_id(layer_id), swa_loc, cache_k
         )
@@ -1183,7 +1716,25 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         eps: float,
         freqs_cis: torch.Tensor,
         positions: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        raw_loc: Optional[torch.Tensor] = None,
     ) -> None:
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+        if dcp_enabled or dcp_kv_mask is not None:
+            from sglang.jit_kernel.dsv4 import fused_norm_rope_inplace
+
+            kv = kv.contiguous()
+            fused_norm_rope_inplace(kv, kv_weight, eps, freqs_cis, positions)
+            return self.swa_kv_pool.set_key_buffer_fused_fallback_triton(
+                self._swa_local_layer_id(layer_id),
+                swa_loc,
+                kv,
+                dcp_world_size=dcp_world_size,
+                dcp_rank=dcp_rank,
+                write_mask=self._dcp_loc_write_mask(
+                    raw_loc if raw_loc is not None else swa_loc
+                ),
+            )
         fused_k_norm_rope_flashmla(
             kv=kv,
             kv_weight=kv_weight,
@@ -1200,9 +1751,24 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         loc: torch.Tensor,
         cache_k: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
-        _, compress_layer_id, compress_kv_pool = self.layer_mapping[layer_id]
+        compress_ratio, compress_layer_id, compress_kv_pool = self.layer_mapping[
+            layer_id
+        ]
         assert compress_kv_pool is not None
+        dcp_world_size, dcp_rank, dcp_enabled = self._dcp_write_context()
+
+        if dcp_enabled or dcp_kv_mask is not None or write_mask is not None:
+            return compress_kv_pool.set_key_buffer_fused_fallback_triton(
+                compress_layer_id,
+                loc,
+                cache_k,
+                dcp_world_size=dcp_world_size,
+                dcp_rank=dcp_rank,
+                write_mask=write_mask.contiguous() if write_mask is not None else None,
+            )
         return compress_kv_pool.set_key_buffer_fused(compress_layer_id, loc, cache_k)
 
     def set_index_k_fused(
@@ -1210,9 +1776,24 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         layer_id: int,
         loc: torch.Tensor,
         cache_k: torch.Tensor,
+        dcp_kv_mask: Optional[torch.Tensor] = None,
+        write_mask: Optional[torch.Tensor] = None,
     ) -> None:
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
         assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
+        if write_mask is not None:
+            from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
+
+            index_k, index_k_scale = act_quant(cache_k)
+            return self.c4_indexer_kv_pool.set_index_k_scale_buffer(
+                compress_layer_id,
+                loc,
+                index_k,
+                index_k_scale,
+                write_mask=write_mask.contiguous(),
+            )
+        # See set_index_k_scale_buffer: the indexer KV must stay global because
+        # the logits path reads it through the global c4 page_table.
         return self.c4_indexer_kv_pool.set_index_fused(compress_layer_id, loc, cache_k)
 
     def set_index_k_fp4(
@@ -1224,3 +1805,190 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         compress_ratio, compress_layer_id, _ = self.layer_mapping[layer_id]
         assert compress_ratio == 4, f"only c4 has indexer, got {compress_ratio = }"
         return self.c4_indexer_kv_pool.set_index_fp4(compress_layer_id, loc, cache_k)
+
+    def _compressed_indices_from_full_indices(
+        self, indices: torch.Tensor, compress_ratio: int
+    ) -> torch.Tensor:
+        if len(indices) == 0:
+            return indices
+        positions = torch.arange(
+            1, len(indices) + 1, dtype=torch.long, device=indices.device
+        )
+        mask = (positions % compress_ratio) == 0
+        return (indices[mask] // compress_ratio).to(indices.dtype)
+
+    def _copy_state_pool_to_cpu(
+        self, pool: Optional[CompressStatePool], indices: torch.Tensor
+    ):
+        if (
+            pool is None
+            or self.full_to_swa_index_mapping is None
+            or len(indices) == 0
+        ):
+            return None
+        swa_indices = self.full_to_swa_index_mapping[indices]
+        mask = swa_indices >= 0
+        if not torch.any(mask):
+            return None
+        state_locs = pool.translate_from_swa_loc_to_state_loc(swa_indices[mask])
+        bank_offsets = [0]
+        if pool.online_mtp_max_draft_tokens > 0:
+            bank_offsets = [
+                i * pool.online_mtp_state_slot_offset
+                for i in range(pool.online_mtp_max_draft_tokens + 1)
+            ]
+        cpu_banks = [
+            pool.kv_score_buffer.kv_score[state_locs + offset].to(
+                "cpu", non_blocking=True
+            )
+            for offset in bank_offsets
+        ]
+        return {
+            "mask": mask.cpu(),
+            "bank_offsets": bank_offsets,
+            "kv_score": cpu_banks,
+        }
+
+    def _load_state_pool_from_cpu(
+        self,
+        pool: Optional[CompressStatePool],
+        state_cpu,
+        indices: torch.Tensor,
+    ) -> None:
+        if (
+            pool is None
+            or state_cpu is None
+            or self.full_to_swa_index_mapping is None
+            or len(indices) == 0
+        ):
+            return
+        old_mask = state_cpu["mask"].to(indices.device)
+        if not torch.any(old_mask):
+            return
+        swa_indices = self.full_to_swa_index_mapping[indices]
+        new_mask = swa_indices >= 0
+        row_mask = new_mask[old_mask]
+        if not torch.any(row_mask):
+            return
+        state_locs = pool.translate_from_swa_loc_to_state_loc(
+            swa_indices[old_mask][row_mask]
+        )
+        for bank_cpu, offset in zip(
+            state_cpu["kv_score"], state_cpu["bank_offsets"]
+        ):
+            pool.kv_score_buffer.kv_score[state_locs + offset] = bank_cpu[
+                row_mask.cpu()
+            ].to(pool.kv_score_buffer.kv_score.device, non_blocking=True)
+        pool.kv_score_buffer[-1].clear()
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        swa_cpu = None
+        swa_mask = None
+        if self.full_to_swa_index_mapping is not None and len(indices) > 0:
+            swa_indices = self.full_to_swa_index_mapping[indices]
+            swa_mask = swa_indices >= 0
+            if torch.any(swa_mask):
+                swa_cpu = self.swa_kv_pool.get_cpu_copy(swa_indices[swa_mask])
+                swa_mask = swa_mask.cpu()
+
+        c4_indices = self._compressed_indices_from_full_indices(indices, 4)
+        c128_indices = self._compressed_indices_from_full_indices(indices, 128)
+        c4_cpu = (
+            self.c4_kv_pool.get_cpu_copy(c4_indices)
+            if len(c4_indices) > 0
+            else None
+        )
+        c128_cpu = (
+            self.c128_kv_pool.get_cpu_copy(c128_indices)
+            if len(c128_indices) > 0
+            else None
+        )
+        c4_indexer_cpu = (
+            self.c4_indexer_kv_pool.get_cpu_copy(c4_indices)
+            if len(c4_indices) > 0
+            else None
+        )
+        state_cpu = [
+            self._copy_state_pool_to_cpu(pool, indices)
+            for pool in self.compress_state_pools
+        ]
+        indexer_state_cpu = [
+            self._copy_state_pool_to_cpu(pool, indices)
+            for pool in self.indexer_compress_state_pools
+        ]
+        current_platform.synchronize()
+        return {
+            "swa": swa_cpu,
+            "swa_mask": swa_mask,
+            "c4": c4_cpu,
+            "c4_indices_len": len(c4_indices),
+            "c128": c128_cpu,
+            "c128_indices_len": len(c128_indices),
+            "c4_indexer": c4_indexer_cpu,
+            "state": state_cpu,
+            "indexer_state": indexer_state_cpu,
+        }
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        swa_cpu = kv_cache_cpu["swa"]
+        if swa_cpu is not None and self.full_to_swa_index_mapping is not None:
+            swa_indices = self.full_to_swa_index_mapping[indices]
+            new_swa_mask = swa_indices >= 0
+            old_swa_mask = kv_cache_cpu.get("swa_mask")
+            if old_swa_mask is not None:
+                old_swa_mask = old_swa_mask.to(indices.device)
+                row_mask = new_swa_mask[old_swa_mask].cpu()
+                swa_indices = swa_indices[old_swa_mask][row_mask.to(indices.device)]
+            else:
+                row_mask = new_swa_mask.cpu()
+                swa_indices = swa_indices[new_swa_mask]
+            if swa_indices.numel() > 0:
+                swa_cpu = self._filter_layer_chunks(swa_cpu, row_mask)
+                self.swa_kv_pool.load_cpu_copy(swa_cpu, swa_indices)
+
+        c4_indices = self._compressed_indices_from_full_indices(indices, 4)
+        c128_indices = self._compressed_indices_from_full_indices(indices, 128)
+        if kv_cache_cpu["c4"] is not None and len(c4_indices) > 0:
+            c4_indices = c4_indices[: kv_cache_cpu["c4_indices_len"]]
+            self.c4_kv_pool.load_cpu_copy(kv_cache_cpu["c4"], c4_indices)
+        if kv_cache_cpu["c4_indexer"] is not None and len(c4_indices) > 0:
+            c4_indices = c4_indices[: kv_cache_cpu["c4_indices_len"]]
+            self.c4_indexer_kv_pool.load_cpu_copy(
+                kv_cache_cpu["c4_indexer"], c4_indices
+            )
+        if kv_cache_cpu["c128"] is not None and len(c128_indices) > 0:
+            c128_indices = c128_indices[: kv_cache_cpu["c128_indices_len"]]
+            self.c128_kv_pool.load_cpu_copy(kv_cache_cpu["c128"], c128_indices)
+
+        for pool, state_cpu in zip(self.compress_state_pools, kv_cache_cpu["state"]):
+            self._load_state_pool_from_cpu(pool, state_cpu, indices)
+        for pool, state_cpu in zip(
+            self.indexer_compress_state_pools, kv_cache_cpu["indexer_state"]
+        ):
+            self._load_state_pool_from_cpu(pool, state_cpu, indices)
+        current_platform.synchronize()
+
+    def _filter_layer_chunks(self, kv_cpu, row_mask: torch.Tensor):
+        if kv_cpu is None:
+            return None
+        if row_mask is None or bool(torch.all(row_mask).item()):
+            return kv_cpu
+        chunk_size = self.cpu_offloading_chunk_size
+        filtered = []
+        for layer_chunks in kv_cpu:
+            if len(layer_chunks) == 0:
+                filtered.append([])
+                continue
+            values_cpu = torch.cat([chunk[0] for chunk in layer_chunks], dim=0)
+            scales_cpu = torch.cat([chunk[1] for chunk in layer_chunks], dim=0)
+            values_cpu = values_cpu[row_mask]
+            scales_cpu = scales_cpu[row_mask]
+            filtered_layer = []
+            for i in range(0, len(values_cpu), chunk_size):
+                filtered_layer.append(
+                    (values_cpu[i : i + chunk_size], scales_cpu[i : i + chunk_size])
+                )
+            filtered.append(filtered_layer)
+        return filtered

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -837,6 +837,17 @@ class KVCacheConfigurator:
         if not _is_npu:
             assert swa_page_size == 256, "In paged swa mode, page_size must be 256."
 
+        (
+            physical_swa_tokens,
+            physical_c4_tokens,
+            physical_c128_tokens,
+            c4_indexer_tokens,
+        ) = self._get_dsv4_physical_pool_sizes(
+            swa_max_total_num_tokens=swa_max_total_num_tokens,
+            c4_max_total_num_tokens=c4_max_total_num_tokens,
+            c128_max_total_num_tokens=c128_max_total_num_tokens,
+        )
+
         if self.is_draft_worker:
             from sglang.srt.models.deepseek_v4_nextn import (
                 COMPRESS_RATIO_NEXTN_LAYER,
@@ -885,9 +896,11 @@ class KVCacheConfigurator:
             # SWA ring is indexed by req_pool_idx; PD decode inflates req_to_token
             # past max_running_requests (pre-alloc), so size to the real capacity.
             num_req_slots=req_to_token_pool.req_to_token.shape[0],
-            swa_size=swa_max_total_num_tokens,
-            c4_size=c4_max_total_num_tokens,
-            c128_size=c128_max_total_num_tokens,
+            swa_size=physical_swa_tokens,
+            c4_size=physical_c4_tokens,
+            c128_size=physical_c128_tokens,
+            # The C4 indexer cache remains replicated in global C4 space.
+            c4_indexer_size=c4_indexer_tokens,
             c4_state_pool_size=c4_state_pool_size,
             c128_state_pool_size=c128_state_pool_size,
             page_size=self.server_args.page_size,
@@ -911,6 +924,36 @@ class KVCacheConfigurator:
             ),
         )
         return token_to_kv_pool
+
+    def _get_dsv4_physical_pool_sizes(
+        self,
+        *,
+        swa_max_total_num_tokens: Optional[int],
+        c4_max_total_num_tokens: int,
+        c128_max_total_num_tokens: int,
+    ) -> tuple[int, int, int, int]:
+        assert swa_max_total_num_tokens is not None
+
+        # The pool configurator reports logical, cluster-wide capacities.
+        # DSV4 writers map logical locations to rank-local offsets under DCP,
+        # so the physical sequence-addressed buffers only need one DCP shard.
+        dcp_size = max(int(getattr(self.server_args, "dcp_size", 1)), 1)
+        physical_swa_tokens = swa_max_total_num_tokens // dcp_size
+        physical_c4_tokens = (
+            c4_max_total_num_tokens
+            if self.server_args.enable_hisparse
+            else c4_max_total_num_tokens // dcp_size
+        )
+        physical_c128_tokens = c128_max_total_num_tokens // dcp_size
+
+        # The C4 indexer cache remains replicated in global C4 space.
+        c4_indexer_tokens = c128_max_total_num_tokens * 32
+        return (
+            physical_swa_tokens,
+            physical_c4_tokens,
+            physical_c128_tokens,
+            c4_indexer_tokens,
+        )
 
     def _build_oot_dsa_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
         PoolCls = current_platform.get_dsa_kv_pool_cls()

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -643,6 +643,17 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if skip_attn_backend_init:
             self.mark_forward_metadata_ready()
 
+    # For Decode Context Parallel (DCP).
+    # Bool tensor of shape [num_tokens]; True at position i means the slot
+    # ``out_cache_loc[i]`` belongs to the current dcp rank and the writer
+    # kernel should actually persist this token's KV. Filled in ``init_new``
+    # only when ``model_runner.dcp_size > 1``; ``None`` otherwise.
+    dcp_kv_mask: Optional[torch.Tensor] = None
+
+    # Debug-only escape hatch for isolating CUDA graph issues on a specific
+    # forward without changing its semantic forward mode.
+    disable_cuda_graph_for_debug: bool = False
+
     @classmethod
     def init_new(
         cls,
@@ -898,11 +909,33 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if (
             getattr(model_runner, "dcp_size", 1) > 1
             and ret.out_cache_loc is not None
-            and is_hip()
         ):
-            ret.dcp_kv_mask = (
-                ret.positions % model_runner.dcp_size == model_runner.dcp_rank
-            )
+            dcp_positions = ret.positions
+            if (
+                dcp_positions is not None
+                and dcp_positions.numel() != ret.out_cache_loc.numel()
+                and ret.forward_mode.is_target_verify()
+            ):
+                bs = len(batch.seq_lens)
+                num_verify_tokens = ret.out_cache_loc.numel() // bs
+                if num_verify_tokens * bs == ret.out_cache_loc.numel():
+                    offsets = torch.arange(
+                        num_verify_tokens,
+                        dtype=batch.seq_lens.dtype,
+                        device=device,
+                    )
+                    dcp_positions = (
+                        batch.seq_lens[:, None] + offsets[None, :]
+                    ).reshape(-1)
+            if (
+                dcp_positions is not None
+                and dcp_positions.numel() == ret.out_cache_loc.numel()
+            ):
+                ret.dcp_kv_mask = (
+                    dcp_positions % model_runner.dcp_size == model_runner.dcp_rank
+                )
+            else:
+                ret.dcp_kv_mask = None
 
         return ret
 
@@ -1395,6 +1428,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if self.encoder_lens is not None:
             self.encoder_lens = self._pad_tensor_to_size(self.encoder_lens, bs)
         self.positions = self._pad_tensor_to_size(self.positions, num_tokens)
+        if self.dcp_kv_mask is not None:
+            self.dcp_kv_mask = self._pad_tensor_to_size(self.dcp_kv_mask, num_tokens)
         if self.mamba_track_indices is not None:
             self.mamba_track_indices = self._pad_tensor_to_size(
                 self.mamba_track_indices, bs
@@ -1494,6 +1529,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 logits_output.hidden_states = logits_output.hidden_states[:num_tokens]
             elif self.forward_mode.is_target_verify():  # verify
                 num_tokens = bs * self.spec_info.draft_token_num
+                if self.dcp_kv_mask is not None:
+                    self.dcp_kv_mask = self.dcp_kv_mask[:num_tokens]
                 if logits_output.next_token_logits is not None:
                     logits_output.next_token_logits = logits_output.next_token_logits[
                         :num_tokens

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -549,6 +549,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             )
         self.swa_page_size = cfg.window_size
         self.swa_ratio = kvc.server_args.swa_full_tokens_ratio
+        self.dcp_size = max(int(getattr(kvc.server_args, "dcp_size", 1)), 1)
         self.is_speculative = kvc.server_args.speculative_algorithm is not None
         self.online_c128_mtp_max_draft_tokens = (
             kvc.server_args.max_speculative_num_draft_tokens or 0
@@ -562,7 +563,8 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.disaggregation_decode_extra_slots = (
             kvc.server_args.disaggregation_decode_extra_slots or 0
         )
-        if kvc.server_args.enable_hisparse:
+        self.enable_hisparse = kvc.server_args.enable_hisparse
+        if self.enable_hisparse:
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
             self.c4_shrink_factor = parse_hisparse_config(
@@ -581,7 +583,10 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.num_layers_ca4 = sum(1 for r in self.compression_ratios if r == 4)
         self.num_layers_ca128 = sum(1 for r in self.compression_ratios if r == 128)
 
-        self.bytes_per_full_token = self._get_bytes_per_full_token()
+        (
+            self.sharded_bytes_per_full_token,
+            self.replicated_bytes_per_full_token,
+        ) = self._get_bytes_per_full_token_components()
         if self.is_speculative:
             # Reserve memory for the speculative draft worker by inflating
             # per-token bytes by (target+draft)/target. Equivalent to dflash's
@@ -589,7 +594,18 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T).
             draft_layers = 1
             target_layers = self.num_layers_total
-            self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers
+            speculative_scale = (target_layers + draft_layers) / target_layers
+            self.sharded_bytes_per_full_token *= speculative_scale
+            self.replicated_bytes_per_full_token *= speculative_scale
+
+        # DCP shards sequence-addressed SWA/C4/C128 KV pools across ranks.
+        # Compression state and the C4 indexer cache are still rank-local
+        # replicas, so solve capacity from the per-rank cost of one logical
+        # token rather than multiplying the DCP=1 capacity blindly.
+        self.bytes_per_full_token = (
+            self.sharded_bytes_per_full_token / self.dcp_size
+            + self.replicated_bytes_per_full_token
+        )
 
         # Online c128 keeps a single in-progress (max, sum, kv) state per index
         # and assumes a strict forward-only schedule. Speculative decode (MTP)
@@ -621,7 +637,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                     "DSV4 compressed attention: online c128 enabled (ring_size=1)"
                 )
 
-    def _get_bytes_per_full_token(self) -> float:
+    def _get_bytes_per_full_token_components(self) -> tuple[float, float]:
         kv_bytes = self.qk_nope_head_dim + self.qk_rope_head_dim * 2 + 8
 
         quant_block_size = 128
@@ -650,11 +666,17 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         c128_state_ratio = 0
 
         c4_frac = 1 / (4 * self.c4_shrink_factor)
-        return (
-            self.swa_ratio * kv_bytes * self.num_layers_total
-            + c4_frac * kv_bytes * self.num_layers_ca4
-            + 1 / 128 * kv_bytes * self.num_layers_ca128
-            + 1 / 4 * indexer_bytes * self.num_layers_ca4
+        c4_kv_bytes = c4_frac * kv_bytes * self.num_layers_ca4
+        sharded_bytes = self.swa_ratio * kv_bytes * self.num_layers_total + (
+            1 / 128 * kv_bytes * self.num_layers_ca128
+        )
+        if not self.enable_hisparse:
+            sharded_bytes += c4_kv_bytes
+
+        replicated_bytes = (
+            # DCP can shard C4 indexer scoring work, but its cache storage is
+            # still addressed in the global C4 page space on every rank.
+            1 / 4 * indexer_bytes * self.num_layers_ca4
             + self.swa_ratio * c4_state_ratio * c4_state_bytes * self.num_layers_ca4
             + c128_state_ratio * c128_state_bytes * self.num_layers_ca128
             + self.swa_ratio
@@ -662,6 +684,11 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             * c4_indexer_state_bytes
             * self.num_layers_ca4
         )
+        # HiSparse still allocates every logical C4 device page on each rank.
+        if self.enable_hisparse:
+            replicated_bytes += c4_kv_bytes
+
+        return sharded_bytes, replicated_bytes
 
     def _compute_dsv4_sizes(self, full_token: int, page_size: int) -> _DSV4PoolSizes:
         full_token = full_token // page_size * page_size
@@ -774,6 +801,11 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         logger.info(
             f"DSV4 memory calculation: "
             f"bytes_per_full_token={self.bytes_per_full_token:.2f}, "
+            f"sharded_bytes_per_full_token="
+            f"{self.sharded_bytes_per_full_token:.2f}, "
+            f"replicated_bytes_per_full_token="
+            f"{self.replicated_bytes_per_full_token:.2f}, "
+            f"dcp_size={self.dcp_size}, "
             f"available_bytes={available_bytes / (1 << 30):.2f} GB, "
             f"c128_state_fixed={c128_state_fixed_bytes / (1 << 30):.2f} GB, "
             f"full_token={sizes.full_max_total_num_tokens}"

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -55,6 +55,7 @@ class MemoryPoolConfig:
     c4_max_total_num_tokens: int = 0
     c128_max_total_num_tokens: int = 0
     c4_state_pool_size: int = 0
+    c4_indexer_state_pool_size: int = 0
     c128_state_pool_size: int = 0
 
     mem_fraction_static: Optional[float] = None
@@ -518,6 +519,7 @@ class _DSV4PoolSizes:
     c4_max_total_num_tokens: int
     c128_max_total_num_tokens: int
     c4_state_pool_size: int
+    c4_indexer_state_pool_size: int
     c128_state_pool_size: int
 
 
@@ -664,12 +666,14 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
     def _compute_dsv4_sizes(self, full_token: int, page_size: int) -> _DSV4PoolSizes:
         full_token = full_token // page_size * page_size
         swa_tokens = int(full_token * self.swa_ratio) // page_size * page_size
+        c4_state_pool_size = swa_tokens // self.swa_page_size * self.c4_ring_size
         return _DSV4PoolSizes(
             full_max_total_num_tokens=full_token,
             swa_max_total_num_tokens=swa_tokens,
             c4_max_total_num_tokens=full_token // (4 * self.c4_shrink_factor),
             c128_max_total_num_tokens=full_token // 128,
-            c4_state_pool_size=swa_tokens // self.swa_page_size * self.c4_ring_size,
+            c4_state_pool_size=c4_state_pool_size,
+            c4_indexer_state_pool_size=c4_state_pool_size,
             c128_state_pool_size=0,
         )
 
@@ -721,6 +725,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             f"c4={sizes.c4_max_total_num_tokens}, "
             f"c128={sizes.c128_max_total_num_tokens}, "
             f"c4_state={sizes.c4_state_pool_size}, "
+            f"c4_indexer_state={sizes.c4_indexer_state_pool_size}, "
             f"c128_state={sizes.c128_state_pool_size}"
         )
         return MemoryPoolConfig(
@@ -730,6 +735,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             c4_max_total_num_tokens=sizes.c4_max_total_num_tokens,
             c128_max_total_num_tokens=sizes.c128_max_total_num_tokens,
             c4_state_pool_size=sizes.c4_state_pool_size,
+            c4_indexer_state_pool_size=sizes.c4_indexer_state_pool_size,
             c128_state_pool_size=sizes.c128_state_pool_size,
         )
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2309,14 +2309,6 @@ class DeepseekV4Model(nn.Module):
                     if key.startswith("pd_aux_hidden_states_")
                 )
             ]
-            if hidden_states.shape[0] != positions.shape[0]:
-                rids = getattr(forward_batch, "rids", None)
-                raise RuntimeError(
-                    "PP proxy hidden token count does not match current positions: "
-                    f"pp_rank={self.pp_group.rank_in_group}, "
-                    f"hidden_tokens={hidden_states.shape[0]}, "
-                    f"position_tokens={positions.shape[0]}, rids={rids}"
-                )
             # Unflatten 2D PP IPC tensor back to 3D mHC shape.
             if hidden_states.ndim == 2:
                 hidden_states = hidden_states.view(
@@ -2342,6 +2334,21 @@ class DeepseekV4Model(nn.Module):
             positions = cp_split_and_rebuild_position(forward_batch, positions)
             input_ids = cp_round_robin_input_ids(input_ids)
             input_ids_global = input_ids
+
+        # The first PP rank applies prefill-CP sharding before sending hidden
+        # states downstream. Later PP ranks must apply the same sharding to
+        # positions before comparing token counts with the received PP tensor.
+        if (
+            not self.pp_group.is_first_rank
+            and hidden_states.shape[0] != positions.shape[0]
+        ):
+            rids = getattr(forward_batch, "rids", None)
+            raise RuntimeError(
+                "PP proxy hidden token count does not match current positions: "
+                f"pp_rank={self.pp_group.rank_in_group}, "
+                f"hidden_tokens={hidden_states.shape[0]}, "
+                f"position_tokens={positions.shape[0]}, rids={rids}"
+            )
 
         # Reset Compressor's per-step freqs_cis cache from any previous step.
         for _attr in ("freqs_cis_c4", "freqs_cis_c128"):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -38,6 +38,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
 from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.distributed import (
+    get_dcp_group_no_assert,
     get_pp_group,
     get_tp_group,
 )
@@ -64,7 +65,6 @@ from sglang.srt.layers.dp_attention import (
     _tbo_event,
     attn_tp_all_gather,
     attn_tp_all_reduce,
-    dp_gather_partial,
     dp_gather_replicate,
     dp_reduce_scatter_tensor,
     dp_reduce_scatterv_async,
@@ -192,6 +192,7 @@ def _get_mhc_ops() -> MhcOps:
 
 
 logger = logging.getLogger(__name__)
+
 
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
 _MHC_POST_MULT_VALUE = 2.0
@@ -343,7 +344,10 @@ def deepseek_v4_attention_with_output(
     key_value = key_value[:real_num_tokens]
 
     original_out_cache_loc = forward_batch.out_cache_loc
+    original_dcp_kv_mask = forward_batch.dcp_kv_mask
     forward_batch.out_cache_loc = original_out_cache_loc[:real_num_tokens]
+    if original_dcp_kv_mask is not None:
+        forward_batch.dcp_kv_mask = original_dcp_kv_mask[:real_num_tokens]
 
     attn_backend = get_attn_backend()
     try:
@@ -359,6 +363,7 @@ def deepseek_v4_attention_with_output(
         )
     finally:
         forward_batch.out_cache_loc = original_out_cache_loc
+        forward_batch.dcp_kv_mask = original_dcp_kv_mask
 
     assert (
         output[:real_num_tokens].numel() == ret.numel()
@@ -695,6 +700,8 @@ class MQALayer(MqaAttentionBase):
             eps=self.eps,
             freqs_cis=self.freqs_cis,
             positions=positions,
+            dcp_kv_mask=forward_batch.dcp_kv_mask,
+            raw_loc=forward_batch.out_cache_loc,
         )
 
     def _compute_kv_bf16(
@@ -1165,6 +1172,29 @@ class MQALayer(MqaAttentionBase):
                 x_quant=x_quant,
             )
 
+        attn_q_base = q_out if q_out is not None else q
+        dcp_group = get_dcp_group_no_assert()
+        use_dcp = dcp_group is not None and dcp_group.world_size > 1
+        if use_dcp:
+            # DCP shards KV tokens across ranks, but every rank must evaluate
+            # attention for the same full set of query heads before the backend
+            # LSE-merge/reduce-scatter step. ``q_padded`` only has this rank's
+            # TP slice initialized, so gather local heads from the DCP group.
+            q_for_attn = dcp_group.all_gather(attn_q_base.contiguous(), dim=1)
+            attn_sink_for_attn = dcp_group.all_gather(
+                self._attn_sink_local[: self.n_local_heads].contiguous(), dim=0
+            )
+            if dcp_group.rank_in_group != 0:
+                # The sink is a global virtual KV item. Folding it into every
+                # DCP shard would count it multiple times during LSE merge.
+                attn_sink_for_attn = torch.full_like(
+                    attn_sink_for_attn,
+                    torch.finfo(attn_sink_for_attn.dtype).min,
+                )
+        else:
+            q_for_attn = q_padded if q_padded is not None else attn_q_base
+            attn_sink_for_attn = self._attn_sink_local
+
         # The cache write is always fused / already done by _forward_prepare* --
         # tell the backend to skip its own store_cache. When `kv is None`
         # (no DSA-CP), pass `q` as a sentinel for the `k is v` assert; the
@@ -1176,17 +1206,17 @@ class MQALayer(MqaAttentionBase):
 
         if is_unified_kv_triton():
             o = attn_backend.forward(
-                q=q_out if q_out is not None else q,
+                q=q_for_attn,
                 k=attn_k,
                 v=attn_k,
                 layer=self.attn_mqa,
                 forward_batch=forward_batch,
                 compress_ratio=self.compress_ratio,
-                attn_sink=self.attn_sink,
+                attn_sink=attn_sink_for_attn,
                 save_kv_cache=kv is not None,
             )
         else:
-            attn_q = q_padded if q_padded is not None else q
+            attn_q = q_for_attn
             save_kv_cache = False
             if forward_batch.forward_mode.is_extend() and is_in_breakable_cuda_graph():
                 o = attn_q.new_empty(
@@ -1198,7 +1228,7 @@ class MQALayer(MqaAttentionBase):
                     o,
                     self.attn_mqa.layer_id,
                     self.compress_ratio,
-                    self._attn_sink_local,
+                    attn_sink_for_attn,
                     save_kv_cache,
                 )
             else:
@@ -1209,10 +1239,17 @@ class MQALayer(MqaAttentionBase):
                     layer=self.attn_mqa,
                     forward_batch=forward_batch,
                     compress_ratio=self.compress_ratio,
-                    attn_sink=self._attn_sink_local,
+                    attn_sink=attn_sink_for_attn,
                     save_kv_cache=save_kv_cache,
                 )
             o = o[:, tp_slice, :]
+        if positions.shape[0] != o.shape[0]:
+            if o.shape[0] < positions.shape[0]:
+                raise RuntimeError(
+                    "DSV4 attention returned fewer tokens than requested: "
+                    f"output={o.shape[0]}, positions={positions.shape[0]}"
+                )
+            o = o[: positions.shape[0]]
         if _is_npu:
             v4_rope_inplace_npu(
                 o[..., -self.qk_rope_head_dim :],

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3095,9 +3095,9 @@ class ServerArgs:
         handle_pd_disaggregation(self)
 
     def _handle_dcp_validation(self):
-        # Decode context parallel (DCP) is currently implemented and validated
-        # only on AMD HIP/ROCm. Reject invalid or unverified configurations
-        # early instead of letting them fail deeper in model initialization.
+        # Decode context parallel (DCP) is implemented on AMD HIP/ROCm and
+        # CUDA. Reject invalid sizes or unsupported platforms early instead of
+        # letting them fail deeper in model initialization.
         if self.dcp_size < 1:
             raise ValueError(
                 "Decode context parallel size (--dcp-size / "
@@ -3106,24 +3106,14 @@ class ServerArgs:
             )
         if not self.dcp_size > 1:
             return
-        if is_hip():
+        if is_hip() or is_cuda():
             return
-        elif is_cuda():
-            if self.speculative_algorithm is not None:
-                raise ValueError(
-                    "Decode context parallel (--dcp-size / "
-                    "--decode-context-parallel-size > 1) on CUDA platform "
-                    "does not support any speculative algorithm, but got "
-                    f"dcp_size={self.dcp_size} on a CUDA platform with "
-                    "speculative decoding enabled."
-                )
-        else:
-            raise ValueError(
-                "Decode context parallel (--dcp-size / "
-                "--decode-context-parallel-size > 1) is currently only "
-                f"supported on the AMD HIP platform, but got dcp_size="
-                f"{self.dcp_size} on a non-HIP platform."
-            )
+        raise ValueError(
+            "Decode context parallel (--dcp-size / "
+            "--decode-context-parallel-size > 1) is currently only "
+            "supported on AMD HIP or CUDA platforms, but got dcp_size="
+            f"{self.dcp_size} on a non-HIP/CUDA platform."
+        )
 
     def _handle_load_balance_method(self):
         if self.disaggregation_mode not in ("null", "prefill", "decode"):
@@ -7376,6 +7366,30 @@ class ServerArgs:
             assert (
                 self.disable_overlap_schedule and self.speculative_algorithm is None
             ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+
+        if self.dcp_size > 1:
+            assert (
+                self.tp_size % self.dcp_size == 0
+            ), f"tp_size ({self.tp_size}) must be divisible by dcp_size ({self.dcp_size})"
+            assert (
+                self.pp_size == 1
+            ), "Decode context parallelism is not compatible with pipeline parallelism"
+            # DCP + PD disaggregation: only the mooncake transfer backend
+            # has been adapted to the per-rank physical offset remap
+            # (token-level RDMA path). Other backends still address GPU
+            # buffers using the cluster-wide global loc and would silently
+            # corrupt the transferred KV cache. Backends without DCP
+            # support also bail out at runtime via
+            # ``CommonKVManager._check_dcp_compat``; this assertion is the
+            # earlier, friendlier failure.
+            if self.disaggregation_mode != "null":
+                assert self.disaggregation_transfer_backend == "mooncake", (
+                    "Decode context parallelism (--dcp-size > 1) with PD "
+                    "disaggregation only supports "
+                    "--disaggregation-transfer-backend=mooncake right now "
+                    f"(got {self.disaggregation_transfer_backend!r}). Use "
+                    "--dcp-size 1 or switch to mooncake."
+                )
 
         assert not (
             self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -71,6 +71,7 @@ class EagleDraftInputBuffers(ForwardInputBuffers):
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
     dsa_seed_topk: Optional[torch.Tensor] = None
+    dcp_kv_mask: Optional[torch.Tensor] = None
 
 
 class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
@@ -189,6 +190,11 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             extend_seq_lens = torch.ones((self.max_bs,), dtype=torch.int32)
             topk_p = torch.zeros((self.max_bs, self.topk), dtype=torch.float32)
             topk_index = torch.zeros((self.max_bs, self.topk), dtype=torch.int64)
+            dcp_kv_mask = (
+                torch.zeros((self.max_num_token,), dtype=torch.bool)
+                if getattr(self.model_runner, "dcp_size", 1) > 1
+                else None
+            )
             draft_probs = (
                 torch.zeros(
                     (self.max_bs, self.model_runner.model_config.vocab_size),
@@ -261,6 +267,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
             dsa_seed_topk=dsa_seed_topk,
+            dcp_kv_mask=dcp_kv_mask,
         )
         self.buffers.share_buffers()
 
@@ -359,6 +366,11 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
         draft_probs = (
             buffers.draft_probs[:num_seqs] if buffers.draft_probs is not None else None
         )
+        dcp_kv_mask = (
+            buffers.dcp_kv_mask[:num_tokens]
+            if buffers.dcp_kv_mask is not None
+            else None
+        )
 
         if self.require_mlp_tp_gather:
             global_num_tokens_cpu = [num_tokens] * self.attn_dp_size
@@ -434,6 +446,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             sampling_info=sampling_info,
             rids_int=rids_int,
             bootstrap_room_ids_int=bootstrap_room_ids_int,
+            dcp_kv_mask=dcp_kv_mask,
             capture_hidden_mode=(
                 spec_info.capture_hidden_mode if spec_info else CaptureHiddenMode.NULL
             ),
@@ -504,6 +517,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
 
         raw_bs = forward_batch.batch_size
         raw_num_token = raw_bs * self.captured_req_width
+        raw_out_cache_loc = forward_batch.out_cache_loc
 
         # Pad to nearest captured shape
         if self.require_mlp_tp_gather:
@@ -535,6 +549,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             if buffers.dsa_seed_topk is not None:
                 buffers.dsa_seed_topk.zero_()
             buffers.req_pool_indices.zero_()
+            if buffers.dcp_kv_mask is not None:
+                buffers.dcp_kv_mask.zero_()
 
         num_tokens = bs * self.captured_req_width
 
@@ -599,6 +615,11 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
                 buffers.dsa_seed_topk[:raw_bs].copy_(seed)
             else:
                 buffers.dsa_seed_topk[:raw_bs].zero_()
+        if buffers.dcp_kv_mask is not None:
+            if forward_batch.dcp_kv_mask is not None:
+                buffers.dcp_kv_mask[:raw_num_token].copy_(forward_batch.dcp_kv_mask)
+            else:
+                buffers.dcp_kv_mask[:raw_num_token].zero_()
         # Only rejection sampling reads temperatures (renorm_draft_probs); skip
         # the copy otherwise to keep the non-RS path free of extra work.
         if (
@@ -626,6 +647,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             forward_batch.seq_lens = buffers.seq_lens[:bs]
             forward_batch.req_pool_indices = buffers.req_pool_indices[:bs]
             forward_batch.positions = buffers.positions[:num_tokens]
+            if buffers.dcp_kv_mask is not None:
+                forward_batch.dcp_kv_mask = buffers.dcp_kv_mask[:num_tokens]
             if raw_seq_lens_sum is not None:
                 forward_batch.seq_lens_sum = (
                     raw_seq_lens_sum + (bs - raw_bs) * self.seq_len_fill_value
@@ -646,20 +669,31 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             buffers.seq_lens_cpu[:raw_bs].copy_(forward_batch.seq_lens_cpu)
             forward_batch.seq_lens_cpu = buffers.seq_lens_cpu[:bs]
 
-        # forward_batch.batch_size was overwritten to bs above when padding.
-        self.draft_attn_backend.init_forward_metadata_out_graph(forward_batch)
-        self.raw_bs = raw_bs
-        self.bs = bs
+        # Metadata and the captured graph must read the padded static buffer.
+        # Padding the batch dimension expands the all-step flat buffer to
+        # bs * topk * num_steps entries.
+        forward_batch.out_cache_loc = buffers.out_cache_loc[
+            : num_tokens * self.speculative_num_steps
+        ]
+        try:
+            # forward_batch.batch_size was overwritten to bs above when padding.
+            self.draft_attn_backend.init_forward_metadata_out_graph(forward_batch)
+            self.raw_bs = raw_bs
+            self.bs = bs
 
-        # Replay via backend
-        shape_key = self._make_graph_key(bs)
-        timer_ctx = (
-            self.model_runner.device_timer.wrap(metadata={"category": "eagle_draft"})
-            if self.model_runner.device_timer
-            else contextlib.nullcontext()
-        )
-        with timer_ctx:
-            out = self._replay_graph(shape_key, forward_batch)
+            # Replay via backend
+            shape_key = self._make_graph_key(bs)
+            timer_ctx = (
+                self.model_runner.device_timer.wrap(
+                    metadata={"category": "eagle_draft"}
+                )
+                if self.model_runner.device_timer
+                else contextlib.nullcontext()
+            )
+            with timer_ctx:
+                out = self._replay_graph(shape_key, forward_batch)
+        finally:
+            forward_batch.out_cache_loc = raw_out_cache_loc
         if self.buffers.dsa_seed_topk is not None:
             forward_batch.spec_info.dsa_topk_indices = None
 
@@ -669,6 +703,8 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             forward_batch.positions = buffers.positions[:raw_num_token]
             forward_batch.seq_lens = buffers.seq_lens[:raw_bs]
             forward_batch.req_pool_indices = buffers.req_pool_indices[:raw_bs]
+            if buffers.dcp_kv_mask is not None:
+                forward_batch.dcp_kv_mask = buffers.dcp_kv_mask[:raw_num_token]
             if buffers.rids_int is not None and forward_batch.rids_int is not None:
                 forward_batch.rids_int = buffers.rids_int[:raw_bs]
             if (

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -73,6 +73,7 @@ class EagleDraftExtendInputBuffers(ForwardInputBuffers):
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
     dsa_seed_topk_capture: Optional[torch.Tensor] = None
+    dcp_kv_mask: Optional[torch.Tensor] = None
 
 
 class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
@@ -194,6 +195,11 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             num_accept_tokens = torch.full(
                 (self.max_bs,), self.captured_req_width, dtype=torch.int32
             )
+            dcp_kv_mask = (
+                torch.zeros((self.max_num_token,), dtype=torch.bool)
+                if getattr(self.model_runner, "dcp_size", 1) > 1
+                else None
+            )
 
             if self.require_gathered_buffer:
                 if self.require_mlp_tp_gather:
@@ -266,6 +272,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
             dsa_seed_topk_capture=dsa_seed_topk_capture,
+            dcp_kv_mask=dcp_kv_mask,
         )
         self.buffers.share_buffers()
 
@@ -346,6 +353,11 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         num_correct_drafts = buffers.num_correct_drafts[:bs]
         num_accept_tokens = buffers.num_accept_tokens[:bs]
         next_token_logits_buffer = buffers.next_token_logits_buffer[:num_tokens]
+        dcp_kv_mask = (
+            buffers.dcp_kv_mask[:num_tokens]
+            if buffers.dcp_kv_mask is not None
+            else None
+        )
 
         # pruned_states = num_tokens (all tokens)
         num_tokens_for_logprob = num_tokens
@@ -406,6 +418,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
             capture_hidden_mode=CaptureHiddenMode.LAST,
+            dcp_kv_mask=dcp_kv_mask,
         )
 
         if self.buffers.dsa_seed_topk_capture is not None:
@@ -510,6 +523,8 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             buffers.num_correct_drafts.fill_(self.captured_req_width)
             buffers.num_accept_tokens.fill_(self.captured_req_width)
             buffers.extend_seq_lens.fill_(self.captured_req_width)
+            if buffers.dcp_kv_mask is not None:
+                buffers.dcp_kv_mask.zero_()
 
         # Batch the small per-field device copies into a grouped foreach copy
         # (one foreach call per dtype pair) to cut launch overhead. hidden_states
@@ -543,6 +558,13 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
 
         # hidden_states is large + contiguous: copy_() uses the cudaMemcpyAsync
         # DMA engine; foreach would force the ~3x slower compute-kernel copy.
+        if (
+            buffers.dcp_kv_mask is not None
+            and forward_batch.dcp_kv_mask is not None
+        ):
+            buffers.dcp_kv_mask[:num_tokens].copy_(forward_batch.dcp_kv_mask)
+        elif buffers.dcp_kv_mask is not None:
+            buffers.dcp_kv_mask[:num_tokens].zero_()
         if (
             buffers.hidden_states is not None
             and forward_batch.spec_info.hidden_states is not None
@@ -603,6 +625,11 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             out_cache_loc=buffers.out_cache_loc[:num_tokens],
             out_cache_loc_dsv4=getattr(forward_batch, "out_cache_loc_dsv4", None),
             spec_info=forward_batch.spec_info,
+            dcp_kv_mask=(
+                buffers.dcp_kv_mask[:num_tokens]
+                if buffers.dcp_kv_mask is not None
+                else None
+            ),
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -106,6 +106,7 @@ class MultiLayerEagleDraftExtendInputBuffers(ForwardInputBuffers):
     next_token_logits_buffer: torch.Tensor
     global_num_tokens_gpu: Optional[torch.Tensor]
     global_num_tokens_for_logprob_gpu: Optional[torch.Tensor]
+    dcp_kv_mask: Optional[torch.Tensor]
 
 
 class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
@@ -246,6 +247,11 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         mrope_positions = buffers.mrope_positions[:, :num_tokens]
         hidden_states = buffers.hidden_states[:num_tokens]
         next_token_logits_buffer = buffers.next_token_logits_buffer[:num_tokens]
+        dcp_kv_mask = (
+            buffers.dcp_kv_mask[:num_tokens]
+            if buffers.dcp_kv_mask is not None
+            else None
+        )
 
         if self.require_mlp_tp_gather:
             global_num_tokens_cpu = [num_tokens] * self.dp_size
@@ -318,6 +324,7 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             extend_num_tokens=self.captured_req_width * bs,
             num_token_non_padded_cpu=self.captured_req_width * bs,
             return_hidden_states_before_norm=True,
+            dcp_kv_mask=dcp_kv_mask,
         )
         return forward_batch
 
@@ -434,6 +441,11 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             # per-step write target; out_cache_loc is frozen at prepare() time.
             out_cache_loc=buffers.out_cache_loc[:num_tokens],
             spec_info=spec_info,
+            dcp_kv_mask=(
+                buffers.dcp_kv_mask[:num_tokens]
+                if buffers.dcp_kv_mask is not None
+                else None
+            ),
         )
         self.eagle_worker.draft_extend_attn_backend_list[
             self.step
@@ -584,6 +596,11 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
             next_token_logits_buffer = torch.zeros(
                 (max_num_token, vocab_size), dtype=torch.float
             )
+            dcp_kv_mask = (
+                torch.zeros((max_num_token,), dtype=torch.bool)
+                if getattr(model_runner, "dcp_size", 1) > 1
+                else None
+            )
 
             if self.require_gathered_buffer:
                 if self.require_mlp_tp_gather:
@@ -618,6 +635,7 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
             next_token_logits_buffer=next_token_logits_buffer,
             global_num_tokens_gpu=global_num_tokens_gpu,
             global_num_tokens_for_logprob_gpu=global_num_tokens_for_logprob_gpu,
+            dcp_kv_mask=dcp_kv_mask,
         )
 
     def _prepare_extra(self, forward_batch: ForwardBatch) -> None:
@@ -663,6 +681,12 @@ class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
         buffers.num_accept_tokens[:raw_bs].copy_(
             forward_batch.spec_info.num_accept_tokens
         )
+
+        if buffers.dcp_kv_mask is not None:
+            if forward_batch.dcp_kv_mask is not None:
+                buffers.dcp_kv_mask[:num_tokens].copy_(forward_batch.dcp_kv_mask)
+            else:
+                buffers.dcp_kv_mask[:num_tokens].zero_()
 
         # Refresh the host mirror only when published; hand replay None
         # otherwise so no consumer reads a stale buffer.

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -650,9 +650,17 @@ def move_accept_tokens_to_target_kvcache(
         accept_out_cache_loc,
         size,
     )
-    token_to_kv_pool_allocator.get_kvcache().move_kv_cache(
-        tgt_cache_loc, accept_out_cache_loc
-    )
+    kvcache = token_to_kv_pool_allocator.get_kvcache()
+    move_accepted_kv_cache = getattr(kvcache, "move_accepted_kv_cache", None)
+    if move_accepted_kv_cache is not None:
+        accept_offsets = torch.arange(
+            accept_index.shape[1], dtype=batch.seq_lens.dtype, device=device
+        )
+        accepted_seq_lens = batch.seq_lens[:, None] + accept_offsets[None, :] + 1
+        accepted_seq_lens = accepted_seq_lens[accept_index != -1]
+        move_accepted_kv_cache(tgt_cache_loc, accept_out_cache_loc, accepted_seq_lens)
+    else:
+        kvcache.move_kv_cache(tgt_cache_loc, accept_out_cache_loc)
 
 
 def prepare_mamba_track_for_verify(batch: ScheduleBatch) -> None:


### PR DESCRIPTION
## Summary

- Add opt-in Mooncake transfer timing, block-distribution, and throughput diagnostics.
- Aggregate transfer statistics while reducing noisy per-block logs in normal operation.

This is PR 5/5 in the DSV4 DCP series and depends on #667. Merge after #667.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->