### PR TITLE
[HiCache][DSV4] Reconcile EIC load-back length across PP stages

### DIFF
--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -154,6 +154,10 @@ class EICHiRadixCache(RadixCache):
         self.tp_group = params.tp_cache_group
         self.tp_size = self.tp_group.size()
         self.rank = self.tp_group.rank()
+        # PP stages store each layer-shard's KV under a distinct EIC namespace
+        # (deploy_key embeds pp_rank), so per-stage load-back can succeed/fail
+        # independently. loading_check reconciles the admitted length across PP.
+        self.pp_group = params.pp_cache_group
         self.kv_cache = params.token_to_kv_pool_allocator.get_kvcache()
         self.sliding_window_size = params.sliding_window_size
         self.load_cache_event = threading.Event()
@@ -463,6 +467,18 @@ class EICHiRadixCache(RadixCache):
                 f"queue size {queue_size.item()}"
             )
 
+    def _pp_reduce_min(self, tensor):
+        # PP stages store their layers' KV in distinct EIC namespaces, so
+        # per-stage load-back completes independently. MIN across PP keeps the
+        # radix tree (and thus the admitted extend_len) identical on every stage.
+        if (
+            self.pp_group is not None
+            and torch.distributed.get_world_size(group=self.pp_group) > 1
+        ):
+            torch.distributed.all_reduce(
+                tensor, op=torch.distributed.ReduceOp.MIN, group=self.pp_group
+            )
+
     def loading_check(self):
         if len(self.ongoing_load_back) == 0:
             return
@@ -477,12 +493,20 @@ class EICHiRadixCache(RadixCache):
                 op=torch.distributed.ReduceOp.MIN,
                 group=self.tp_group,
             )
+        self._pp_reduce_min(queue_size)
         ack_list = []
         complete_tokens = []
         for _ in range(queue_size.item()):
             ack_id, complete_token = self.cache_controller.ack_load_queue.get_nowait()
             ack_list.append(ack_id)
             complete_tokens.append(complete_token)
+        # Load thread is a single FIFO consumer, so ack order is identical on
+        # every rank; complete_token is CP-reduced in the controller, MIN it
+        # across PP too so every stage truncates each node to the same length.
+        if ack_list:
+            ct = torch.tensor(complete_tokens, dtype=torch.int64)
+            self._pp_reduce_min(ct)
+            complete_tokens = ct.tolist()
         for ack_id, complete_token in zip(ack_list, complete_tokens):
             start_node, end_node, total_token_num = self.ongoing_load_back[ack_id]
             self.dec_lock_ref(end_node)
@@ -1248,6 +1272,11 @@ class EICPagedHiRadixCache(EICHiRadixCache):
                 group=self.tp_group,
             )
             eic_prefix_lens = eic_prefix_len_tensor.tolist()
+        # MIN across PP so the load-back decision is identical on every stage,
+        # else loading_check's PP reduce deadlocks on a divergent req set.
+        eic_prefix_len_tensor = torch.tensor(eic_prefix_lens, dtype=torch.int64)
+        self._pp_reduce_min(eic_prefix_len_tensor)
+        eic_prefix_lens = eic_prefix_len_tensor.tolist()
         for i, (last_node, req, local_prefix_len, local_evict_len) in enumerate(
             fetch_list
         ):

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -186,5 +186,45 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(sorted(freed.tolist()), [512, 768])
 
 
+    def test_loading_check_reduces_load_back_across_pp(self):
+        # PP stages store their layers' KV in distinct EIC namespaces, so a
+        # shared node can load back a different token count per stage. Without a
+        # PP-group MIN on both the drain count and complete_token, the radix
+        # tree truncates differently per stage and the admitted extend_len
+        # diverges -> fused_q_norm_rope batch_size crash. Assert both are
+        # reduced over pp_group with MIN.
+        from sglang.srt.mem_cache.eic_hiradix_cache import EICPagedHiRadixCache
+
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.tp_group = None  # TP reduces (group=None) are ignored by the test
+        cache.pp_group = object()
+        node = SimpleNamespace()
+        cache.ongoing_load_back = {0: (node, node, 64)}  # start==end: loop is a no-op
+        q = Queue()
+        q.put((0, 64))
+        cache.cache_controller = SimpleNamespace(ack_load_queue=q)
+        cache.dec_lock_ref = lambda n: None
+
+        pp_reduces = []
+
+        def fake_all_reduce(tensor, op=None, group=None):
+            self.assertEqual(op, torch.distributed.ReduceOp.MIN)
+            if group is cache.pp_group:
+                pp_reduces.append(tensor.numel())
+
+        with mock.patch.object(
+            torch.distributed, "get_world_size", return_value=2
+        ), mock.patch.object(
+            torch.distributed, "all_reduce", side_effect=fake_all_reduce
+        ):
+            EICPagedHiRadixCache.loading_check(cache)
+
+        # Both the drain count and the complete_token vector are MIN-reduced
+        # over the PP group (each numel==1 for this single-ack case).
+        self.assertEqual(
+            pp_reduces, [1, 1], "expected drain-count + complete_token PP reduces"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Under PD-disaggregated prefill with NSA context-parallel (`pp_size=2, tp_size=4, attn_cp_size=4, enable_nsa_prefill_context_parallel`) and EIC HiCache L2, prefill crashes in `fused_q_norm_rope`:

```
tvm.error.InternalError: ... main_norm_rope.cuh:183
- Root cause: Size mismatch for shape#0('batch_size'): expected 1024 but got 4032
```

It fires right after a partial EIC mget failure (`eic mget ... failed, fail count N`), always on a non-first PP rank, and the mismatched length varies run to run with the EIC hit rate.

## Root cause

Each PP stage stores its own layers' KV under a **distinct EIC namespace** — `deploy_key` embeds `pp_rank`. So for one request, PP0's and PP1's mget hit different keys and fail **independently**: PP0 loads back N tokens, PP1 loads back M≠N.

EIC's load-back consensus only spans `self.tp_group` (which, with `attn_cp_size == tp_size`, already covers attn_CP but **not PP**). So the two PP stages truncate the radix tree to different lengths → `set_extend_input_len` diverges → `positions` length diverges. Meanwhile the CP-split hidden states forwarded down the PP pipe are already 1024-long, so `len(positions) != q.shape[0]` and the kernel asserts.

Fixing only the CP-split gate would be wrong: PP requires every stage to process the identical token count, so divergent extend lengths corrupt the forward regardless of CP. The invariant is that all ranks jointly running one forward must agree on `(prefix_len, extend_len)`.

## Fix

Add PP-group `MIN` reduction at the two points where EIC load-back state is decided, mirroring the existing `tp_group` reduce:

- **`match_from_remote`** — MIN the EIC exists result across PP, so the load-back *decision* (`host_hit_length` → whether a req enters the load-back path) is identical on every stage. This is also what prevents `loading_check`'s PP collective from deadlocking on a divergent request set.
- **`loading_check`** — MIN the ack drain count and the per-node `complete_token` across PP, so every stage truncates the radix tree to the same length. The load thread is a single FIFO consumer, so ack order is identical on every rank, making the per-position `complete_token` MIN valid.

The PP handle (`pp_cache_group`) is already wired into `CacheInitParams`; EIC just wasn't using it.

## Test

`test/registered/unit/mem_cache/test_eic_hicache_regression.py::test_loading_check_pp_reduces_count_and_complete_tokens` (CPU-CI) asserts both the drain count and the `complete_token` vector are reduced across the PP group.

Full `test_eic_hicache_regression.py` (8 tests) passes in the DSV4 EIC image (`v0.5.15.post1.iaas.dev.202607231210-deepseek-v4-cu130`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->