### PR TITLE
[HiCache][DSV4] PP-consistent EIC admission: two-phase L2 verdicts + piggybacked L3 prefetch reconciliation

### DIFF
--- a/python/sglang/srt/distributed/communication_tags.py
+++ b/python/sglang/srt/distributed/communication_tags.py
@@ -7,3 +7,6 @@ class P2PTag(IntEnum):
 
     DEFAULT = 0
     HIRADIX_PP_SYNC = int.from_bytes(b"PpHi", byteorder="big")
+    # EIC load-back admission verdicts (own tag: must never share a FIFO slot
+    # with the num_ready stream above).
+    HIRADIX_PP_VERDICT = int.from_bytes(b"PpVd", byteorder="big")

--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -263,6 +263,8 @@ class EICCacheController(HiCacheController):
     def _completed_prefix(mask, step, limit):
         # Short mask = backend bailed out early, so the tail is a miss; all(mask)
         # would read it as a full hit.
+        if len(mask) * step >= limit and all(mask):
+            return limit
         completed = 0
         for ret in mask:
             if not ret:

--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -237,9 +237,14 @@ class EICCacheController(HiCacheController):
         """
         Write the KV cache to host memory.
         """
-        ret = self.mem_pool_host.assign_flat_data(
-            operation.host_indices, operation.data, operation.device_indices
-        )
+        try:
+            ret = self.mem_pool_host.assign_flat_data(
+                operation.host_indices, operation.data, operation.device_indices
+            )
+        except Exception as e:
+            # Must still ack: otherwise the node stays writing forever.
+            logger.exception(f"Write to eic raised, node: {operation.node_id}: {e}")
+            ret = False
         if not ret:
             logger.error(f"Failed to write to host memory {operation.node_id}")
         result = 0 if ret else 1
@@ -274,19 +279,24 @@ class EICCacheController(HiCacheController):
         """
         Load the KV cache from host memory to device memory.
         """
-        mask = self.mem_pool_host.get_flat_data(
-            operation.host_indices, operation.device_indices
-        )
+        try:
+            mask = self.mem_pool_host.get_flat_data(
+                operation.host_indices, operation.device_indices
+            )
+        except Exception as e:
+            # Must still ack: a skipped ack strands the request until abort.
+            logger.exception(f"Load from eic raised, node: {operation.node_id}: {e}")
+            mask = []
+        # Short mask = backend bailed out early, so the tail is a miss; all(mask)
+        # would read it as a full hit.
         completed_tokens = 0
-        if not all(mask):
+        for ret in mask:
+            if not ret:
+                break
+            completed_tokens += 1
+        completed_tokens = min(completed_tokens, len(operation.host_indices))
+        if completed_tokens < len(operation.host_indices):
             logger.warning(f"Failed to load from eic, node: {operation.node_id}")
-            for ret in mask:
-                if ret:
-                    completed_tokens += 1
-                else:
-                    break
-        else:
-            completed_tokens = len(operation.host_indices)
 
         if self.tp_world_size > 1:
             temp_tensor = torch.tensor(
@@ -319,9 +329,13 @@ class EICCacheController(HiCacheController):
         while self.write_wait_event.is_set():
             time.sleep(0.01)
         logger.debug(f"write device indices: {operation.device_indices}")
-        ret = self.mem_pool_host.assign_page_data(
-            operation.content_hash, operation.data, operation.device_indices
-        )
+        try:
+            ret = self.mem_pool_host.assign_page_data(
+                operation.content_hash, operation.data, operation.device_indices
+            )
+        except Exception as e:
+            logger.exception(f"Write to eic raised, node: {operation.node_id}: {e}")
+            ret = False
         if not ret:
             logger.error(f"Failed to write to host memory {operation.node_id}")
         result = 0 if ret else 1
@@ -343,19 +357,21 @@ class EICCacheController(HiCacheController):
         assert len(operation.host_indices) == self.page_size * len(
             operation.content_hash
         )
-        mask = self.mem_pool_host.get_page_data(
-            operation.content_hash, operation.device_indices
-        )
+        try:
+            mask = self.mem_pool_host.get_page_data(
+                operation.content_hash, operation.device_indices
+            )
+        except Exception as e:
+            logger.exception(f"Load from eic raised, node: {operation.node_id}: {e}")
+            mask = []
         completed_tokens = 0
-        if not all(mask):
+        for ret in mask:
+            if not ret:
+                break
+            completed_tokens += self.page_size
+        completed_tokens = min(completed_tokens, len(operation.host_indices))
+        if completed_tokens < len(operation.host_indices):
             logger.debug(f"Failed to load from eic, node: {operation.node_id}")
-            for ret in mask:
-                if ret:
-                    completed_tokens += self.page_size
-                else:
-                    break
-        else:
-            completed_tokens = len(operation.host_indices)
 
         if self.tp_world_size > 1:
             temp_tensor = torch.tensor(

--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -259,6 +259,17 @@ class EICCacheController(HiCacheController):
         ret = result == 0
         self.ack_write_queue.put((operation.node_id, ret))
 
+    @staticmethod
+    def _completed_prefix(mask, step, limit):
+        # Short mask = backend bailed out early, so the tail is a miss; all(mask)
+        # would read it as a full hit.
+        completed = 0
+        for ret in mask:
+            if not ret:
+                break
+            completed += step
+        return min(completed, limit)
+
     def batch_torch_cat(self, data_list: List[torch.Tensor], split_dim: int):
         """
         Batch torch.cat to avoid OOM.
@@ -287,14 +298,7 @@ class EICCacheController(HiCacheController):
             # Must still ack: a skipped ack strands the request until abort.
             logger.exception(f"Load from eic raised, node: {operation.node_id}: {e}")
             mask = []
-        # Short mask = backend bailed out early, so the tail is a miss; all(mask)
-        # would read it as a full hit.
-        completed_tokens = 0
-        for ret in mask:
-            if not ret:
-                break
-            completed_tokens += 1
-        completed_tokens = min(completed_tokens, len(operation.host_indices))
+        completed_tokens = self._completed_prefix(mask, 1, len(operation.host_indices))
         if completed_tokens < len(operation.host_indices):
             logger.warning(f"Failed to load from eic, node: {operation.node_id}")
 
@@ -364,12 +368,9 @@ class EICCacheController(HiCacheController):
         except Exception as e:
             logger.exception(f"Load from eic raised, node: {operation.node_id}: {e}")
             mask = []
-        completed_tokens = 0
-        for ret in mask:
-            if not ret:
-                break
-            completed_tokens += self.page_size
-        completed_tokens = min(completed_tokens, len(operation.host_indices))
+        completed_tokens = self._completed_prefix(
+            mask, self.page_size, len(operation.host_indices)
+        )
         if completed_tokens < len(operation.host_indices):
             logger.debug(f"Failed to load from eic, node: {operation.node_id}")
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -781,6 +781,8 @@ class Req(ReqDllmMixin):
         self.mamba_host_hit_length = 0
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0
+        # Tokens the EIC admission gate loaded back into prefix_indices
+        self.eic_loaded_len = 0
         # The node to lock until for swa radix tree lock ref
         self.swa_uuid_for_lock: Optional[int] = None
         # Whether the prefill-time SWA tree lock has been released early

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -943,7 +943,7 @@ class PrefillAdder:
             eic_prefix_len = 0
             if self.enable_eic_cache:
                 # Load-back already resolved by the async admission gate.
-                eic_prefix_len = getattr(req, "_eic_loaded_len", 0)
+                eic_prefix_len = req.eic_loaded_len
             elif req.needs_host_load_back():
                 new_indices, req.last_node = self.tree_cache.init_load_back(
                     InitLoadBackParams(

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -945,11 +945,7 @@ class PrefillAdder:
                         req=req,
                     )
                 )
-                logger.debug(
-                    f"req {req.rid} init load back, last node:{req.last_node.id}, prefix len:{len(req.prefix_indices)}"
-                )
                 if self.enable_eic_cache:
-                    loading_check_start_ts = time.perf_counter()
                     while not self.tree_cache.loading_complete(req.last_node):
                         time.sleep(0.001)
                     load_sucess = req.last_node.value is not None
@@ -961,9 +957,6 @@ class PrefillAdder:
                             last_gpu_node = last_gpu_node.parent
                         assert complete_token_num >= 0
                         req.last_node = last_gpu_node
-                        logger.error(
-                            f"req {req.rid} after load back failed, last node:{last_gpu_node.id}, complete_token_num:{complete_token_num}"
-                        )
                         if complete_token_num > 0:
                             new_indices = new_indices[:complete_token_num]
                         else:
@@ -972,13 +965,6 @@ class PrefillAdder:
                                 dtype=torch.int64,
                                 device=req.prefix_indices.device,
                             )
-                    loading_check_end_ts = time.perf_counter()
-                    logger.debug(
-                        f"batch_prefill loading check time {loading_check_end_ts - loading_check_start_ts}"
-                    )
-                logger.debug(
-                    f"after eic sync, req {req.rid} last node:{req.last_node.id}, prefix len:{len(req.prefix_indices)}"
-                )
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))
                 prefix_len = len(req.prefix_indices)

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 import logging
 import os
 import random
-import time
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from enum import Enum, auto
@@ -897,7 +896,12 @@ class PrefillAdder:
         total_tokens = req.extend_input_len + max_new + self.page_size
 
         # adjusting the input_tokens based on host_hit_length and page_size
-        real_input_tokens = req.extend_input_len - req.host_hit_length
+        if self.enable_eic_cache:
+            # Load-back already folded into prefix_indices by the admission gate,
+            # so extend_input_len is exactly the recompute; do not re-subtract.
+            real_input_tokens = req.extend_input_len
+        else:
+            real_input_tokens = req.extend_input_len - req.host_hit_length
         real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
 
@@ -937,7 +941,10 @@ class PrefillAdder:
                     chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
 
             eic_prefix_len = 0
-            if req.needs_host_load_back():
+            if self.enable_eic_cache:
+                # Load-back already resolved by the async admission gate.
+                eic_prefix_len = getattr(req, "_eic_loaded_len", 0)
+            elif req.needs_host_load_back():
                 new_indices, req.last_node = self.tree_cache.init_load_back(
                     InitLoadBackParams(
                         best_match_node=req.best_match_node,
@@ -945,26 +952,6 @@ class PrefillAdder:
                         req=req,
                     )
                 )
-                if self.enable_eic_cache:
-                    while not self.tree_cache.loading_complete(req.last_node):
-                        time.sleep(0.001)
-                    load_sucess = req.last_node.value is not None
-                    complete_token_num = len(new_indices)
-                    if not load_sucess:
-                        last_gpu_node = req.last_node
-                        while last_gpu_node.evicted:
-                            complete_token_num -= len(last_gpu_node.key)
-                            last_gpu_node = last_gpu_node.parent
-                        assert complete_token_num >= 0
-                        req.last_node = last_gpu_node
-                        if complete_token_num > 0:
-                            new_indices = new_indices[:complete_token_num]
-                        else:
-                            new_indices = torch.empty(
-                                (0,),
-                                dtype=torch.int64,
-                                device=req.prefix_indices.device,
-                            )
                 req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
                 req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))
                 prefix_len = len(req.prefix_indices)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2112,6 +2112,9 @@ class Scheduler(
                     self.tree_cache.release_aborted_request(candidate_req.rid)
                 elif self.enable_hierarchical_cache:
                     self.tree_cache.terminate_prefetch(candidate_req.rid)
+                if self.enable_eic_cache:
+                    # Release any in-flight EIC load-admit lock/state (deferring req).
+                    self.tree_cache.release_load_admit(candidate_req.rid)
                 self.waiting_queue.pop(idx)
                 req_to_abort = candidate_req
                 message = "The request is aborted by a higher priority request."
@@ -2142,6 +2145,8 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
+                if self.enable_eic_cache:
+                    self.tree_cache.release_load_admit(req.rid)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
                         finished_reason={
@@ -2550,7 +2555,27 @@ class Scheduler(
                     req.rid
                 )
 
-            req.init_next_round_input(self.tree_cache)
+            # EIC host load-back admits asynchronously via check_load_back_progress;
+            # a deferring req keeps its frozen match (re-matching a mutated tree would
+            # double-count) until its load resolves.
+            tc = self.tree_cache
+            deferring_load_back = (
+                self.enable_eic_cache and req.rid in tc.ongoing_load_admit
+            )
+            if not deferring_load_back:
+                req.init_next_round_input(tc)
+            # PP>1: EIC host load-back is disabled. Its cross-PP length reconciliation
+            # needs PP0 to RECEIVE a peer report in the scheduler thread, which
+            # deadlocks the out-of-phase pipeline in this gloo build (PP0 is the
+            # pipeline's output receiver). Admission falls to the PP-uniform device
+            # match; full host-load-back-under-PP is the pipeline-piggyback follow-up.
+            if self.enable_eic_cache and tc.pp_size <= 1 and (
+                deferring_load_back
+                or req.needs_host_load_back()
+            ):
+                if not tc.check_load_back_progress(req):
+                    continue
+
             res = adder.add_one_req(
                 req,
                 has_chunked_req=(self.chunked_req is not None),
@@ -3156,6 +3181,11 @@ class Scheduler(
                 tc = self.tree_cache
                 idle &= len(tc.ongoing_write_through) == 0
                 idle &= len(tc.ongoing_load_back) == 0
+                # EIC in-flight cross-PP admits. Gate ONLY on ongoing_load_admit:
+                # it is the PP-symmetric per-req marker (every stage registers on
+                # first encounter, all finalize at the verdict step). pending_report
+                # /_reports are rank0-only bookkeeping and would desync idle per rank.
+                idle &= len(getattr(tc, "ongoing_load_admit", ())) == 0
                 if tc.enable_storage:
                     idle &= len(tc.ongoing_prefetch) == 0
                     idle &= len(tc.ongoing_backup) == 0
@@ -3410,6 +3440,8 @@ class Scheduler(
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
+            if self.enable_eic_cache:
+                self.tree_cache.release_load_admit(req.rid)
             self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2433,6 +2433,13 @@ class Scheduler(
         if self.enable_hierarchical_cache:
             self.tree_cache.check_hicache_events()
 
+        if isinstance(self.tree_cache, EICPagedHiRadixCache):
+            # EIC remote prefetch. Must run here -- before the PP-divergent
+            # early-returns and calc_priority below -- so every PP stage calls
+            # it in lockstep (its PP all_reduce would otherwise hang) and sees
+            # the waiting queue in FIFO order (a clean per-stage prefix).
+            self.tree_cache.match_from_remote(self.waiting_queue)
+
         if self.enable_priority_preemption or self.is_hybrid_swa:
             # Reset batch_is_full to try preemption with a prefill adder.
             self.running_batch.batch_is_full = False
@@ -2511,10 +2518,6 @@ class Scheduler(
                     self.waiting_queue,
                     self.running_batch.reqs,
                 )
-
-        if isinstance(self.tree_cache, EICPagedHiRadixCache):
-            # for batch exists from EIC cache
-            self.tree_cache.match_from_remote(self.waiting_queue)
 
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2564,14 +2564,14 @@ class Scheduler(
             )
             if not deferring_load_back:
                 req.init_next_round_input(tc)
-            # PP>1: EIC host load-back is disabled. Its cross-PP length reconciliation
-            # needs PP0 to RECEIVE a peer report in the scheduler thread, which
-            # deadlocks the out-of-phase pipeline in this gloo build (PP0 is the
-            # pipeline's output receiver). Admission falls to the PP-uniform device
-            # match; full host-load-back-under-PP is the pipeline-piggyback follow-up.
-            if self.enable_eic_cache and tc.pp_size <= 1 and (
+            # PP>1 gates EVERY candidate (not only needs_host_load_back): host
+            # metadata is per-stage (EIC write acks fail per namespace), so the
+            # needs flag itself can diverge across stages; gating all candidates
+            # keeps the cross-PP report keysets symmetric, keyed by rid.
+            if self.enable_eic_cache and (
                 deferring_load_back
                 or req.needs_host_load_back()
+                or tc.pp_size > 1
             ):
                 if not tc.check_load_back_progress(req):
                     continue

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -2,6 +2,7 @@ import hashlib
 import heapq
 import logging
 import os
+import pickle
 import threading
 import time
 from functools import partial
@@ -18,7 +19,6 @@ from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.mem_cache.base_prefix_cache import (
     EvictParams,
     EvictResult,
-    InitLoadBackParams,
     InsertParams,
     MatchPrefixParams,
     MatchResult,
@@ -148,6 +148,13 @@ def nsa_pool_transfer(
 
 class EICHiRadixCache(RadixCache):
 
+    # PP verdict protocol knobs (see the __init__ comment block).
+    _KIND_SPAN, _KIND_FINAL = 0, 1
+    _VERDICT_CAP = 64  # verdict rows per DAG round; overflow waits a round
+    _EPOCH_CAP = 65536  # rid->epoch entries; eviction horizon >> stale lifetime
+    _TOMBSTONE_TTL = 4096  # rounds a released rid keeps dropping stragglers
+    _GC_AGE = 8192  # rounds before orphaned rank0 report entries are dropped
+
     def __init__(
         self,
         params: CacheInitParams,
@@ -162,12 +169,42 @@ class EICHiRadixCache(RadixCache):
         self.pp_rank = params.pp_rank
         self.pp_size = params.pp_size
         self.work_list = []
-        # EIC host load-back runs only for a single PP stage (pp_size<=1); under PP>1
-        # it is disabled because its cross-PP length reconciliation would need rank0
-        # to receive a peer report in the scheduler thread, which deadlocks the
-        # out-of-phase pipeline in this gloo build. See loading_check.
-        self.pending_report = {}  # rid_hash -> local admit len, awaiting resolution
-        self._admit_verdict = {}  # rid_hash -> resolved admit len, consumed by the gate
+        # --- Cross-PP load-back reconciliation (two-phase verdict protocol) ---
+        # Each PP stage load-backs from its own EIC namespace (deploy_key embeds
+        # pp_rank), so per-stage loaded amounts -- and, transitively, radix trees
+        # and allocator headroom -- would diverge, breaking SPMD scheduling
+        # (divergent extend_input_len => main_norm_rope assert at cp>1).
+        # Two GPU-proven constraints shape the protocol: this gloo build's p2p is
+        # effectively synchronous, and PP rank0 is the pipeline-output receiver,
+        # so rank0 must NEVER post a receive in the scheduler thread; the only
+        # safe p2p shape is the rank0-isend-down DAG at the lockstep site.
+        # Hence: reports go UP through the default-PG TCPStore (non-collective
+        # KV RPCs to a separate daemon -- not a p2p receive), verdicts come DOWN
+        # on the DAG in a fixed tensor, so every stage applies the same decision
+        # in the same scheduling loop (admission timing = batch composition).
+        # Two phases keep every tree/allocator mutation PP-uniform:
+        #   SPAN  = min over stages of (device_match + host_hit): fixes the
+        #           allocation BEFORE any load is kicked (quota never exceeds the
+        #           local host chain, so the alloc is a pure function of SPAN);
+        #   FINAL = min over stages of (device_match + actually loaded): fixes
+        #           the admitted prefix; the [FINAL, SPAN) tail is freed at a
+        #           verdict boundary on every stage in the same loop.
+        # Wire key = (rid_hash, epoch); the epoch kills stale-report pairing
+        # when a client reuses a rid after an abort.
+        self.ongoing_load_admit = {}  # rid -> per-req reconciliation state
+        self._admit_verdict = {}  # rid_hash -> FINAL admit len, consumed by the gate
+        self._h_rid = {}  # rid_hash -> rid, resolves incoming verdicts
+        self._rid_epoch = {}  # rid -> gate-entry ordinal; FIFO-capped, never reset
+        self._report_outbox = {}  # stage>0, tp0: (h, epoch, kind) -> report payload
+        self._span_reports = {}  # rank0 tp0: (h, epoch) -> ({stage: (d, hh)}, born)
+        self._load_reports = {}  # rank0 tp0: (h, epoch) -> ({stage: d+loaded}, born)
+        self._await_load = {}  # rank0 tp0: (h, epoch) -> (span, loaders, {stage: d}, born)
+        self._verdict_outbox = []  # rank0 tp0: formed verdicts awaiting a DAG slot
+        self._tombstone = {}  # rid_hash -> expiry round; released rids drop stragglers
+        self._pub_seq = 0  # stage>0: next store seq; bumps ONLY after a good set
+        self._next_seq = {}  # rank0: stage -> next store seq to drain
+        self._round = 0  # loading_check counter (tombstone/GC clock)
+        self._store_handle = None  # lazy default-PG TCPStore (tp0 lanes only)
         self._loadback_rid = {}  # load-back node_id -> rid (maps an EIC ack to its req)
         self.kv_cache = params.token_to_kv_pool_allocator.get_kvcache()
         self.sliding_window_size = params.sliding_window_size
@@ -240,11 +277,6 @@ class EICHiRadixCache(RadixCache):
         self.ongoing_write_through = {}
         # record the node segments with ongoing load back
         self.ongoing_load_back = {}
-        # async admission: reqs whose load-back was kicked but not yet admitted
-        # (rid -> (last_node, new_indices)). Mirrors ongoing_prefetch. Replaces
-        # the schedule_policy busy-wait, so loading_check runs only from the
-        # PP-aligned check_hicache_events -> its PP consensus can't deadlock.
-        self.ongoing_load_admit = {}
         # EIC is native to this cache (no pluggable L3 HiCacheStorage backend);
         # is_fully_idle() uses this flag to skip ongoing_prefetch/backup checks.
         self.enable_storage = False
@@ -253,6 +285,30 @@ class EICHiRadixCache(RadixCache):
             1 if server_args.hicache_write_policy == "write_through" else 3
         )
         self.load_back_threshold = 10
+        if self.pp_size > 1:
+            # The verdict protocol assumes lockstep candidate iteration and
+            # lockstep releases. These knobs break that: cache-aware policies
+            # re-match every waiting req per loop from per-stage trees (and
+            # clobber frozen matches), storage prefetch skips the gate per stage
+            # asynchronously, dp-attention lanes have private waiting queues,
+            # and the waiting timeout releases by per-stage clocks.
+            if server_args.schedule_policy != "fcfs":
+                raise ValueError(
+                    "EIC host load-back under PP requires schedule_policy=fcfs"
+                )
+            if getattr(server_args, "hicache_storage_backend", None):
+                raise ValueError(
+                    "EIC under PP is incompatible with hicache_storage_backend"
+                )
+            if server_args.enable_dp_attention:
+                raise ValueError(
+                    "EIC host load-back under PP is incompatible with dp-attention"
+                )
+            if float(os.getenv("SGLANG_REQ_WAITING_TIMEOUT", "-1")) > 0:
+                raise ValueError(
+                    "EIC host load-back under PP requires SGLANG_REQ_WAITING_TIMEOUT "
+                    "to stay disabled (per-stage clocks release non-lockstep)"
+                )
         super().__init__(params)
 
         self.save_decode_cache = True
@@ -291,9 +347,18 @@ class EICHiRadixCache(RadixCache):
         self.ongoing_load_back = {}
         self.ongoing_load_admit = {}
         self.ongoing_write_through = {}
-        self.pending_report = {}
         self._admit_verdict = {}
+        self._h_rid = {}
         self._loadback_rid = {}
+        self._report_outbox = {}
+        self._span_reports = {}
+        self._load_reports = {}
+        self._await_load = {}
+        self._verdict_outbox = []
+        # Comm-layer state deliberately survives reset: seq counters must stay
+        # monotonic (a pre-reset store batch may still be in flight), epochs
+        # must never reuse, tombstones expire by round. Flush is idle-gated, so
+        # everything cleared above can only reference dead rids.
         super().reset()
 
     def get_height(self, node: TreeNode):
@@ -520,14 +585,44 @@ class EICHiRadixCache(RadixCache):
         self._pp_bcast_from_first(tensor)
 
     def loading_check(self):
-        # Single stage: drain acks and resolve locally. PP>1: host load-back is
-        # disabled (its cross-PP reconciliation would need PP0 to receive a peer
-        # report in the scheduler thread -> deadlocks the out-of-phase pipeline in
-        # this gloo build), so pending_report stays empty and this is a no-op. The
-        # true PP-consistent load-back is the pipeline-piggyback follow-up.
+        # The lockstep heartbeat of the verdict protocol: called exactly once per
+        # get_new_batch_prefill on every rank, before any early return, so the
+        # k-th VERDICT bcast pairs with the k-th recv on every stage and a
+        # verdict lands at the same batch-forming call everywhere.
+        self._round += 1
         self._drain_local_acks()
-        for h in list(self.pending_report):
-            self._admit_verdict[h] = self.pending_report.pop(h)
+        if self.pp_size <= 1 or self.pp_group is None:
+            return
+        if self.rank == 0:
+            # tp0 speaks for its stage (reports are TP-uniform: complete_token
+            # is MIN-reduced inside the cache controller before the ack).
+            if self.pp_rank == 0:
+                self._drain_peer_reports()
+                self._form_verdicts()
+            else:
+                self._publish_reports()
+        buf = torch.zeros(1 + self._VERDICT_CAP * 4, dtype=torch.int64, device="cpu")
+        if self.pp_rank == 0:
+            if self.rank == 0:
+                n = min(len(self._verdict_outbox), self._VERDICT_CAP)
+                buf[0] = n
+                for i in range(n):
+                    buf[1 + i * 4 : 5 + i * 4] = torch.tensor(
+                        self._verdict_outbox[i], dtype=torch.int64
+                    )
+                del self._verdict_outbox[:n]
+            if self.tp_size > 1:
+                # Equalize the tp0-only poll result across this stage's lanes
+                # BEFORE it forks into the per-lane DAGs. Unconditional: the
+                # trigger is tp0-local, a skipped collective wedges the stage.
+                torch.distributed.broadcast(buf, group=self.tp_group, group_src=0)
+        self._pp_bcast_from_first(buf, tag=P2PTag.HIRADIX_PP_VERDICT)
+        # The packed tensor is the single source of truth on EVERY rank
+        # (including rank0): overflow verdicts wait in the outbox, so cap
+        # overflow can never desync which loop a req admits in.
+        self._apply_verdicts(buf)
+        if self._round % 1024 == 0:
+            self._sweep()
 
     def _rid_hash(self, rid):
         # Stable 56-bit id (fits a positive int64); hash() is per-process salted so
@@ -535,6 +630,224 @@ class EICHiRadixCache(RadixCache):
         return int.from_bytes(
             hashlib.blake2b(rid.encode(), digest_size=7).digest(), "big"
         )
+
+    @property
+    def _store(self):
+        # The default process group's TCPStore: non-collective KV RPCs served by
+        # a separate daemon thread -- polling it is NOT a p2p receive, so the
+        # rank0-must-never-receive constraint does not apply. Exceptions must
+        # propagate: a swallowed set with a bumped seq is a permanent hole the
+        # drain side polls forever (and a dead store means a dead job anyway).
+        if self._store_handle is None:
+            from torch.distributed import distributed_c10d
+
+            self._store_handle = distributed_c10d._get_default_store()
+        return self._store_handle
+
+    def _bump_epoch(self, rid):
+        # Per-rid gate-entry ordinal; never reused within a process, so a stale
+        # in-flight report of a released incarnation can never pair with a fresh
+        # one (client-supplied rids may repeat after an abort). Re-insertion
+        # keeps the FIFO cap tracking recency.
+        epoch = self._rid_epoch.pop(rid, 0) + 1
+        self._rid_epoch[rid] = epoch
+        while len(self._rid_epoch) > self._EPOCH_CAP:
+            self._rid_epoch.pop(next(iter(self._rid_epoch)))
+        return epoch
+
+    def _queue_report(self, st, kind, value):
+        if self.pp_size <= 1 or self.rank != 0:
+            return
+        key = (st["h"], st["epoch"])
+        if self.pp_rank == 0:
+            # rank0's own column feeds the decision tables directly.
+            table = (
+                self._span_reports if kind == self._KIND_SPAN else self._load_reports
+            )
+            table.setdefault(key, ({}, self._round))[0][0] = value
+        else:
+            self._report_outbox[(st["h"], st["epoch"], kind)] = value
+
+    def _publish_reports(self):
+        if not self._report_outbox:
+            return
+        payload = pickle.dumps(self._report_outbox)
+        self._store.set(f"eiclb/{self.pp_rank}/{self._pub_seq}", payload)
+        self._pub_seq += 1  # only after a successful set (no holes, ever)
+        self._report_outbox = {}
+
+    def _drain_peer_reports(self):
+        for stage in range(1, self.pp_size):
+            seq = self._next_seq.get(stage, 0)
+            while self._store.check([f"eiclb/{stage}/{seq}"]):
+                key = f"eiclb/{stage}/{seq}"
+                batch = pickle.loads(self._store.get(key))
+                self._store.delete_key(key)
+                seq += 1
+                for (h, epoch, kind), value in batch.items():
+                    tomb = self._tombstone.get(h)
+                    if tomb is not None and epoch <= tomb[0]:
+                        continue  # a released incarnation's straggler; a fresh
+                        # re-gate of the same rid carries a higher epoch and
+                        # must pass, or the retry wedges forever.
+                    table = (
+                        self._span_reports
+                        if kind == self._KIND_SPAN
+                        else self._load_reports
+                    )
+                    table.setdefault((h, epoch), ({}, self._round))[0][stage] = value
+            self._next_seq[stage] = seq
+
+    def _form_verdicts(self):
+        threshold = max(self.load_back_threshold, 1)
+        for key, (sr, _) in list(self._span_reports.items()):
+            if len(sr) < self.pp_size:
+                continue
+            del self._span_reports[key]
+            span = min(d + hh for d, hh in sr.values())
+            # A loader must clear the load threshold; every stage evaluates the
+            # same condition from the same numbers at span-apply time.
+            loaders = frozenset(s for s, (d, _) in sr.items() if span - d >= threshold)
+            if loaders:
+                dmap = {s: d for s, (d, _) in sr.items()}
+                self._await_load[key] = (span, loaders, dmap, self._round)
+                self._verdict_outbox.append((*key, self._KIND_SPAN, span))
+            else:
+                self._verdict_outbox.append(
+                    (*key, self._KIND_FINAL, min(d for d, _ in sr.values()))
+                )
+        for key, (lr, _) in list(self._load_reports.items()):
+            aw = self._await_load.get(key)
+            if aw is None or not aw[1] <= lr.keys():
+                continue
+            span, loaders, dmap, _ = aw
+            del self._load_reports[key]
+            del self._await_load[key]
+            # Admissible = what EVERY stage actually holds: loaders their loaded
+            # length, non-loaders their device match, all capped by the span.
+            final = min(
+                [span]
+                + [lr[s] for s in loaders]
+                + [d for s, d in dmap.items() if s not in loaders]
+            )
+            self._verdict_outbox.append((*key, self._KIND_FINAL, final))
+
+    def _apply_verdicts(self, buf):
+        for i in range(int(buf[0].item())):
+            h, epoch, kind, value = (int(x) for x in buf[1 + i * 4 : 5 + i * 4])
+            rid = self._h_rid.get(h)
+            st = self.ongoing_load_admit.get(rid) if rid is not None else None
+            if st is None or st["epoch"] != epoch:
+                continue  # released rid or a dead incarnation's verdict
+            if kind == self._KIND_SPAN:
+                self._apply_span(rid, st, value)
+            else:
+                self._admit_verdict[h] = value
+
+    def _apply_span(self, rid, st, span):
+        # SPAN is a cross-stage MIN, so quota = span - d never exceeds this
+        # stage's own host chain: the allocation is a pure function of the
+        # (uniform) verdict and allocator deltas stay PP-uniform. allow_evict is
+        # off under PP -- an alloc-failure eviction would mutate one stage's
+        # tree only; degrading to loaded=0 re-converges at FINAL instead.
+        st["span"] = span
+        d, hh = st["d"], st["hh"]
+        node = st["best_match_node"]
+        if (
+            span - d >= max(self.load_back_threshold, 1)
+            and node is not None
+            and self._swa_headroom_ok(span - d)
+        ):
+            node = self._clip_host_chain(node, d + hh - span, span - d)
+            if node is not None:
+                indices = self.load_back(node, allow_evict=self.pp_size <= 1)
+                if indices is not None:
+                    st["node_id"] = node.id
+                    st["load_node"] = node
+                    st["alloc"] = len(indices)
+                    st["new_indices"] = indices
+                    self._loadback_rid[node.id] = rid
+                    return  # the LOADED report follows the local EIC ack
+        # Nothing kicked on this stage: its admissible length is device-only.
+        if self.pp_size <= 1 or self.pp_group is None:
+            self._admit_verdict[st["h"]] = d
+        else:
+            self._queue_report(st, self._KIND_FINAL, d)
+
+    def _swa_headroom_ok(self, quota):
+        # A hybrid-SWA load allocates quota SWA slots that are released only
+        # when the admitted req actually batches (maybe_evict_swa) -- but the
+        # adder budgets fresh SWA for that batch without knowing about them.
+        # Unbounded kicks can therefore drain the (small) SWA pool to zero and
+        # deadlock admission outright: loads hold all SWA, batching would
+        # release it, batching needs SWA. Keep half the pool clear of load-back
+        # allocations. Per-stage headroom may diverge; an asymmetric kick-skip
+        # just degrades that stage's report to device-only, which the FINAL
+        # verdict reconciles (same class as the alloc-failure degrade).
+        swa = getattr(
+            self.cache_controller.mem_pool_device_allocator, "swa_attn_allocator", None
+        )
+        if swa is None:
+            return True
+        return swa.available_size() >= quota + swa.size // 2
+
+    def _clip_host_chain(self, node, excess, quota):
+        # Cut the evicted chain `excess` tokens above its bottom so the load
+        # covers exactly [d, span). The cut lands on a verdict boundary
+        # (PP-uniform) and touches only evicted (host-side) nodes, so device
+        # node shapes stay PP-uniform. Returns None unless the clipped chain
+        # still runs EXACTLY quota (= span - d) tokens down to the first
+        # resident ancestor: during the span round trip the frozen chain can
+        # break (host eviction / failed write ack) or its resident frontier can
+        # move (a concurrent same-prefix load kick makes [d, x) resident; an
+        # insert recompute re-evicts below d) -- loading anything but the frozen
+        # [d, span) would silently break the cross-stage uniformity the verdict
+        # promised, so any mismatch degrades to a device-only report instead.
+        while excess > 0 and node.evicted:
+            if not node.backuped:
+                return None
+            if len(node.key) <= excess:
+                excess -= len(node.key)
+                node = node.parent
+            else:
+                node = self._split_node(node.key, node, len(node.key) - excess)
+                excess = 0
+        if excess > 0 or not node.evicted:
+            return None
+        chain_len = 0
+        walk = node
+        while walk.evicted:
+            if not walk.backuped:
+                return None
+            chain_len += len(walk.key)
+            walk = walk.parent
+        if chain_len != quota:
+            return None
+        return node
+
+    def _sweep(self):
+        self._tombstone = {
+            h: t for h, t in self._tombstone.items() if t[1] > self._round
+        }
+        if self.rank != 0 or self.pp_rank != 0:
+            return
+        horizon = self._round - self._GC_AGE
+        for table in (self._span_reports, self._load_reports, self._await_load):
+            for key in list(table):
+                if table[key][-1] > horizon:
+                    continue
+                if self._h_rid.get(key[0]) is None:
+                    # dead-rid straggler (e.g. a report drained after a release
+                    # already purged its pairing state) -- plain garbage.
+                    del table[key]
+                else:
+                    logger.warning(
+                        "EIC PP load-back wedged: rid_hash=%d has waited %d+ "
+                        "rounds for peer reports (a stage's EIC ack may never "
+                        "have arrived); the req stays deferred until aborted.",
+                        key[0],
+                        self._GC_AGE,
+                    )
 
     def _drain_local_acks(self):
         queue_size = torch.tensor(
@@ -548,16 +861,21 @@ class EICHiRadixCache(RadixCache):
         for _ in range(int(queue_size.item())):
             node_id, complete_token = self.cache_controller.ack_load_queue.get_nowait()
             rid = self._loadback_rid.pop(node_id, None)
-            if rid is None or rid not in self.ongoing_load_admit:
-                # req aborted before its load landed -> free it here (with the true
-                # completed count) so its KV isn't pinned/leaked.
+            st = self.ongoing_load_admit.get(rid) if rid is not None else None
+            if st is None or st.get("node_id") != node_id:
+                # Req released before its load landed (the node_id check keeps a
+                # dead incarnation's ack from being attributed to a re-gated
+                # same-rid retry). Free the WHOLE span (a verdict-uniform
+                # boundary); a partial free at the per-stage completed count
+                # would fork device node shapes across stages.
                 if node_id in self.ongoing_load_back:
-                    self._free_failed_loadback(node_id, complete_token)
+                    self._free_failed_loadback(node_id, 0)
                 continue
-            st = self.ongoing_load_admit[rid]
             st["complete"] = complete_token
-            # local_actual becomes known post-load: device match + actually loaded.
-            self.pending_report[st["h"]] = st["device_match"] + complete_token
+            if self.pp_size <= 1 or self.pp_group is None:
+                self._admit_verdict[st["h"]] = st["d"] + complete_token
+            else:
+                self._queue_report(st, self._KIND_FINAL, st["d"] + complete_token)
 
     def _free_failed_loadback(self, node_id, complete_token):
         # Local cleanup: release the load lock and free the failed-load tail so the
@@ -759,6 +1077,9 @@ class EICHiRadixCache(RadixCache):
             assert x.lock_ref == 0 and x.host_value is not None
 
             assert self.cache_controller.evict_host(x.host_value) > 0
+            # Null the freed backup: frozen references (a deferring req's load
+            # chain) probe `backuped` and must degrade, not DMA from freed slots.
+            x.host_value = None
             for k, v in x.parent.children.items():
                 if v == x:
                     break
@@ -768,7 +1089,10 @@ class EICHiRadixCache(RadixCache):
                 heapq.heappush(leaves, x.parent)
 
     def load_back(
-        self, node: TreeNode, mem_quota: Optional[int] = None
+        self,
+        node: TreeNode,
+        mem_quota: Optional[int] = None,
+        allow_evict: bool = True,
     ) -> Optional[torch.Tensor]:
         # todo: more loading policies
         start_time = time.perf_counter()
@@ -798,7 +1122,7 @@ class EICHiRadixCache(RadixCache):
         device_indices = self.cache_controller.load(
             host_indices=host_indices, node_id=last_hit_node.id
         )
-        if device_indices is None:
+        if device_indices is None and allow_evict:
             self.evict(EvictParams(num_tokens=len(host_indices)))
             device_indices = self.cache_controller.load(
                 host_indices=host_indices, node_id=last_hit_node.id
@@ -823,143 +1147,124 @@ class EICHiRadixCache(RadixCache):
         return device_indices
 
     def check_load_back_progress(self, req) -> bool:
-        # Per-candidate admission gate. First encounter kicks the local load-back
-        # (if any) and records this stage's local_actual; the req then defers until
-        # the PP0-authoritative verdict (loading_check) lands, at which point the
-        # prefix is clamped to the cross-PP MIN and the req admits. Every num_ready
-        # candidate passes here -- even cold ones -- so rank0 always gets a full
-        # report set for the rid and the MIN can never leak/hang.
+        # Per-candidate admission gate. Under PP EVERY candidate passes here
+        # (host metadata is per-stage, so needs_host_load_back can't select
+        # candidates uniformly; gating all keeps report keysets symmetric,
+        # keyed by rid). First encounter freezes (d, hh), locks the device
+        # prefix and emits the SPAN report; the req then defers until the FINAL
+        # verdict lands -- in the same DAG slot on every stage, so all stages
+        # admit it in the same batch-forming loop. pp<=1 short-circuits both
+        # verdicts locally (cold reqs admit with zero deferral, as before).
         h = self._rid_hash(req.rid)
         if req.rid not in self.ongoing_load_admit:
-            device_match = len(req.prefix_indices)
-            new_indices, node_id = None, None
-            if req.needs_host_load_back():
-                new_indices, req.last_node = self.init_load_back(
-                    InitLoadBackParams(
-                        best_match_node=req.best_match_node,
-                        host_hit_length=req.host_hit_length,
-                        req=req,
-                    )
-                )
-                if req.last_node.id in self.ongoing_load_back:
-                    node_id = req.last_node.id
-                    self._loadback_rid[node_id] = req.rid
-            self.ongoing_load_admit[req.rid] = {
+            d = len(req.prefix_indices)
+            hh = req.host_hit_length if req.needs_host_load_back() else 0
+            # Lock the frozen device prefix across the verdict round trips so
+            # eviction can't reclaim slots the reports promised (lock the
+            # deepest RESIDENT ancestor -- last_node itself may be an evicted
+            # host node). Released in finalize/release.
+            lock_node = req.last_node
+            while lock_node.evicted:
+                lock_node = lock_node.parent
+            self.inc_lock_ref(lock_node)
+            st = {
                 "h": h,
-                "new_indices": new_indices,
-                "node_id": node_id,
-                "device_match": device_match,
+                "epoch": self._bump_epoch(req.rid),
+                "d": d,
+                "hh": hh,
+                "best_match_node": req.best_match_node if hh > 0 else None,
+                "deferred_lock": lock_node,
+                "span": None,
+                "alloc": 0,
+                "node_id": None,
+                "load_node": None,
+                "new_indices": None,
                 "complete": None,
-                "deferred_lock": None,
             }
-            if node_id is None:
-                # nothing async to wait on -> local_actual is known now.
-                extra = len(new_indices) if new_indices is not None else 0
-                self.pending_report[h] = device_match + extra
+            self.ongoing_load_admit[req.rid] = st
+            self._h_rid[h] = req.rid
             if self.pp_size <= 1 or self.pp_group is None:
-                if h in self.pending_report:
-                    self._admit_verdict[h] = self.pending_report.pop(h)
-            if h in self._admit_verdict:
-                return self._finalize_load_admit(req)
-            if node_id is None:
-                # Deferring a device-only / fell-back req: load_back took no lock, so
-                # lock the frozen device prefix ourselves so eviction can't reclaim
-                # its slots across the verdict round-trip. Released in finalize.
-                self.inc_lock_ref(req.last_node)
-                self.ongoing_load_admit[req.rid]["deferred_lock"] = req.last_node
-            return False
+                self._apply_span(req.rid, st, d + hh)
+            else:
+                self._queue_report(st, self._KIND_SPAN, (d, hh))
         if h not in self._admit_verdict:
-            return False  # still loading / awaiting peers; loading_check advances it
+            return False  # loading / awaiting verdicts; loading_check advances it
         return self._finalize_load_admit(req)
 
     def _finalize_load_admit(self, req) -> bool:
         st = self.ongoing_load_admit.pop(req.rid)
-        h, new_indices, node_id, device_match = (
-            st["h"],
-            st["new_indices"],
-            st["node_id"],
-            st["device_match"],
-        )
+        h, d = st["h"], st["d"]
+        self._h_rid.pop(h, None)
         admit = self._admit_verdict.pop(h)
-        dl = st.get("deferred_lock")
-        if dl is not None:
-            self.dec_lock_ref(dl)  # release the defer-time device-prefix lock
-        # host_hit == last_node's tree depth beyond device_match (the FULL host
-        # portion attempted, not just what loaded); host_hit == 0 when cold or
-        # when init_load_back fell back to a resident ancestor.
-        host_hit = len(new_indices) if new_indices is not None else 0
-        loaded = 0
-        if node_id is not None:
-            # free the local failed-load tail (garbage KV) and release the load lock.
-            loaded = st["complete"] or 0
-            self._free_failed_loadback(node_id, loaded)
-        if new_indices is not None and loaded > 0:
-            req.prefix_indices = torch.cat([req.prefix_indices, new_indices[:loaded]])
+        self.dec_lock_ref(st["deferred_lock"])
+        if st["node_id"] is not None:
+            # A FINAL verdict needs every loader's post-ack report, so it can
+            # never outrun the local DMA or the local KV. Loud beats a silent
+            # free of in-flight memory / a silent cross-stage length fork.
+            assert st["complete"] is not None, "EIC PP verdict before local load ack"
+            assert admit <= d + st["complete"], "EIC PP verdict exceeds local KV"
+            # Free [admit, d + alloc): the failed tail AND loaded-beyond-verdict
+            # in one cut at a verdict boundary, keeping trees and allocator
+            # accounting PP-identical.
+            self._free_failed_loadback(st["node_id"], max(admit - d, 0))
+        else:
+            assert admit <= d, "EIC PP verdict beyond device match without a load"
+        if st["new_indices"] is not None and admit > d:
+            req.prefix_indices = torch.cat(
+                [req.prefix_indices, st["new_indices"][: admit - d]]
+            )
         if admit < len(req.prefix_indices):
             req.prefix_indices = req.prefix_indices[:admit]
         prefix_len = len(req.prefix_indices)
-        # Repoint last_node at the deepest RESIDENT node still spanning the clamped
-        # prefix (bottom depth >= prefix_len), skipping the just-evicted failed
-        # tail. Seed at last_node's TRUE tree depth (device_match + host_hit); the
-        # sum of key lengths on the path is split-invariant so this stays exact.
-        # inc_lock_ref(last_node) then protects every slot the req reads (an
-        # over-locked resident tail past prefix_len is harmless).
-        node = req.last_node
-        depth = device_match + host_hit
+        # Repoint last_node at the deepest RESIDENT node still spanning the
+        # clamped prefix, seeding at the load chain's true depth (d + alloc);
+        # path key lengths are split-invariant so the walk stays exact.
+        node = st["load_node"] if st["load_node"] is not None else st["deferred_lock"]
+        depth = d + st["alloc"]
         while node is not self.root_node and (
             node.value is None or depth - len(node.key) >= prefix_len
         ):
             depth -= len(node.key)
             node = node.parent
         req.last_node = node
-        req._eic_loaded_len = max(0, prefix_len - device_match)
+        req._eic_loaded_len = max(0, prefix_len - d)
         req.set_extend_input_len(len(req.fill_ids) - prefix_len)
         req.cache_protected_len = prefix_len
         req.last_matched_prefix_len = prefix_len
         return True
 
     def release_load_admit(self, rid):
-        # Cleanup for a deferring candidate removed from the waiting queue WITHOUT
-        # admitting (abort / waiting-timeout / queued-limit): release every lock and
-        # drop all per-req reconciliation state so KV isn't pinned and is_fully_idle
-        # isn't wedged. No-op if the rid never entered the gate.
+        # Cleanup for a deferring candidate removed from the waiting queue
+        # WITHOUT admitting (abort / queued-limit): release every lock, drop all
+        # per-req state, and tombstone the wire key so straggler reports and
+        # verdicts of this incarnation die on arrival. Releases ride the same
+        # relayed request stream on every stage, so the whole-span free below
+        # stays PP-uniform. No-op if the rid never entered the gate.
         st = self.ongoing_load_admit.pop(rid, None)
         if st is None:
             return
         h = st["h"]
-        self.pending_report.pop(h, None)
+        self._h_rid.pop(h, None)
         self._admit_verdict.pop(h, None)
-        if st["deferred_lock"] is not None:
-            self.dec_lock_ref(st["deferred_lock"])
+        self.dec_lock_ref(st["deferred_lock"])
         node_id = st["node_id"]
         if node_id is not None and node_id in self.ongoing_load_back:
             if st["complete"] is not None:
-                # load already landed -> release its lock + free the failed tail now.
                 self._loadback_rid.pop(node_id, None)
-                self._free_failed_loadback(node_id, st["complete"])
-            # else: load still in flight -> leave it; _drain_local_acks frees the ack.
-
-    def init_load_back(
-        self,
-        params: InitLoadBackParams,
-    ):
-        last_node = params.best_match_node
-        mem_quota = params.mem_quota
-        if last_node.evicted:
-            loading_values = self.load_back(last_node, mem_quota)
-            if loading_values is not None:
-                logger.debug(
-                    f"loading back {len(loading_values)} tokens for node {last_node.id}"
-                )
-                return loading_values, last_node
-
-            while last_node.evicted:
-                last_node = last_node.parent
-
-        return (
-            torch.empty((0,), dtype=torch.int64, device=self.device),
-            last_node,
-        )
+                self._free_failed_loadback(node_id, 0)  # whole span: uniform boundary
+            # else: load still in flight -> _drain_local_acks frees it at ack.
+        if self.pp_size > 1 and self.pp_group is not None:
+            self._tombstone[h] = (st["epoch"], self._round + self._TOMBSTONE_TTL)
+            key = (h, st["epoch"])
+            for kind in (self._KIND_SPAN, self._KIND_FINAL):
+                self._report_outbox.pop((h, st["epoch"], kind), None)
+            self._span_reports.pop(key, None)
+            self._load_reports.pop(key, None)
+            self._await_load.pop(key, None)
+            if self._verdict_outbox:
+                self._verdict_outbox = [
+                    v for v in self._verdict_outbox if v[0] != h
+                ]
 
     def ready_to_load_host_cache(self):
         producer_index = self.cache_controller.layer_done_counter.update_producer()
@@ -1507,7 +1812,10 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         return len(host_indices)
 
     def load_back(
-        self, node: TreeNode, mem_quota: Optional[int] = None
+        self,
+        node: TreeNode,
+        mem_quota: Optional[int] = None,
+        allow_evict: bool = True,
     ) -> Optional[torch.Tensor]:
         # todo: more loading policies
         start_time = time.perf_counter()
@@ -1565,7 +1873,7 @@ class EICPagedHiRadixCache(EICHiRadixCache):
             node_id=last_hit_node.id,
             content_hash=host_content_hash,
         )
-        if device_indices is None:
+        if device_indices is None and allow_evict:
             self.evict(EvictParams(num_tokens=len(host_indices)))
             device_indices = self.cache_controller.load_page(
                 host_indices=host_indices,

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -25,6 +25,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 )
 from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.eic_pp_reconcile import eic_pp_unsupported_reason
 from sglang.srt.mem_cache.eic_memory_pool import (
     EICDeepSeekV4TokenToKVPoolHost,
     EICMHATokenToKVPoolHost,
@@ -292,23 +293,13 @@ class EICHiRadixCache(RadixCache):
             # clobber frozen matches), storage prefetch skips the gate per stage
             # asynchronously, dp-attention lanes have private waiting queues,
             # and the waiting timeout releases by per-stage clocks.
-            if server_args.schedule_policy != "fcfs":
-                raise ValueError(
-                    "EIC host load-back under PP requires schedule_policy=fcfs"
-                )
             if getattr(server_args, "hicache_storage_backend", None):
                 raise ValueError(
                     "EIC under PP is incompatible with hicache_storage_backend"
                 )
-            if server_args.enable_dp_attention:
-                raise ValueError(
-                    "EIC host load-back under PP is incompatible with dp-attention"
-                )
-            if float(os.getenv("SGLANG_REQ_WAITING_TIMEOUT", "-1")) > 0:
-                raise ValueError(
-                    "EIC host load-back under PP requires SGLANG_REQ_WAITING_TIMEOUT "
-                    "to stay disabled (per-stage clocks release non-lockstep)"
-                )
+            reason = eic_pp_unsupported_reason(server_args)
+            if reason is not None:
+                raise ValueError(f"EIC host load-back under PP: {reason}")
         super().__init__(params)
 
         self.save_decode_cache = True
@@ -552,12 +543,16 @@ class EICHiRadixCache(RadixCache):
                 f"queue size {queue_size.item()}"
             )
 
+    @property
+    def _pp_active(self):
+        return self.pp_size > 1 and self.pp_group is not None
+
     def _pp_bcast_from_first(self, tensor, tag=P2PTag.HIRADIX_PP_SYNC):
         # PP0-authoritative broadcast down the pipeline via non-blocking isend
         # (blocking/collective PP ops deadlock the out-of-phase pipeline). Each
         # logical stream passes its OWN tag so independent bcasts (num_ready vs the
         # admission verdict) never share a FIFO slot and can't cross-match.
-        if self.pp_size <= 1 or self.pp_group is None:
+        if not self._pp_active:
             return
         if self.pp_rank > 0:
             torch.distributed.recv(
@@ -591,7 +586,7 @@ class EICHiRadixCache(RadixCache):
         # verdict lands at the same batch-forming call everywhere.
         self._round += 1
         self._drain_local_acks()
-        if self.pp_size <= 1 or self.pp_group is None:
+        if not self._pp_active:
             return
         if self.rank == 0:
             # tp0 speaks for its stage (reports are TP-uniform: complete_token
@@ -733,8 +728,10 @@ class EICHiRadixCache(RadixCache):
             self._verdict_outbox.append((*key, self._KIND_FINAL, final))
 
     def _apply_verdicts(self, buf):
-        for i in range(int(buf[0].item())):
-            h, epoch, kind, value = (int(x) for x in buf[1 + i * 4 : 5 + i * 4])
+        n = int(buf[0].item())
+        flat = buf[1 : 1 + n * 4].tolist()
+        for i in range(0, n * 4, 4):
+            h, epoch, kind, value = flat[i : i + 4]
             rid = self._h_rid.get(h)
             st = self.ongoing_load_admit.get(rid) if rid is not None else None
             if st is None or st["epoch"] != epoch:
@@ -750,7 +747,6 @@ class EICHiRadixCache(RadixCache):
         # (uniform) verdict and allocator deltas stay PP-uniform. allow_evict is
         # off under PP -- an alloc-failure eviction would mutate one stage's
         # tree only; degrading to loaded=0 re-converges at FINAL instead.
-        st["span"] = span
         d, hh = st["d"], st["hh"]
         node = st["best_match_node"]
         if (
@@ -762,14 +758,13 @@ class EICHiRadixCache(RadixCache):
             if node is not None:
                 indices = self.load_back(node, allow_evict=self.pp_size <= 1)
                 if indices is not None:
-                    st["node_id"] = node.id
                     st["load_node"] = node
                     st["alloc"] = len(indices)
                     st["new_indices"] = indices
                     self._loadback_rid[node.id] = rid
                     return  # the LOADED report follows the local EIC ack
         # Nothing kicked on this stage: its admissible length is device-only.
-        if self.pp_size <= 1 or self.pp_group is None:
+        if not self._pp_active:
             self._admit_verdict[st["h"]] = d
         else:
             self._queue_report(st, self._KIND_FINAL, d)
@@ -862,7 +857,7 @@ class EICHiRadixCache(RadixCache):
             node_id, complete_token = self.cache_controller.ack_load_queue.get_nowait()
             rid = self._loadback_rid.pop(node_id, None)
             st = self.ongoing_load_admit.get(rid) if rid is not None else None
-            if st is None or st.get("node_id") != node_id:
+            if st is None or st["load_node"] is None or st["load_node"].id != node_id:
                 # Req released before its load landed (the node_id check keeps a
                 # dead incarnation's ack from being attributed to a re-gated
                 # same-rid retry). Free the WHOLE span (a verdict-uniform
@@ -872,7 +867,7 @@ class EICHiRadixCache(RadixCache):
                     self._free_failed_loadback(node_id, 0)
                 continue
             st["complete"] = complete_token
-            if self.pp_size <= 1 or self.pp_group is None:
+            if not self._pp_active:
                 self._admit_verdict[st["h"]] = st["d"] + complete_token
             else:
                 self._queue_report(st, self._KIND_FINAL, st["d"] + complete_token)
@@ -1155,8 +1150,9 @@ class EICHiRadixCache(RadixCache):
         # verdict lands -- in the same DAG slot on every stage, so all stages
         # admit it in the same batch-forming loop. pp<=1 short-circuits both
         # verdicts locally (cold reqs admit with zero deferral, as before).
-        h = self._rid_hash(req.rid)
-        if req.rid not in self.ongoing_load_admit:
+        st = self.ongoing_load_admit.get(req.rid)
+        h = st["h"] if st is not None else self._rid_hash(req.rid)
+        if st is None:
             d = len(req.prefix_indices)
             hh = req.host_hit_length if req.needs_host_load_back() else 0
             # Lock the frozen device prefix across the verdict round trips so
@@ -1174,16 +1170,14 @@ class EICHiRadixCache(RadixCache):
                 "hh": hh,
                 "best_match_node": req.best_match_node if hh > 0 else None,
                 "deferred_lock": lock_node,
-                "span": None,
                 "alloc": 0,
-                "node_id": None,
                 "load_node": None,
                 "new_indices": None,
                 "complete": None,
             }
             self.ongoing_load_admit[req.rid] = st
             self._h_rid[h] = req.rid
-            if self.pp_size <= 1 or self.pp_group is None:
+            if not self._pp_active:
                 self._apply_span(req.rid, st, d + hh)
             else:
                 self._queue_report(st, self._KIND_SPAN, (d, hh))
@@ -1197,7 +1191,7 @@ class EICHiRadixCache(RadixCache):
         self._h_rid.pop(h, None)
         admit = self._admit_verdict.pop(h)
         self.dec_lock_ref(st["deferred_lock"])
-        if st["node_id"] is not None:
+        if st["load_node"] is not None:
             # A FINAL verdict needs every loader's post-ack report, so it can
             # never outrun the local DMA or the local KV. Loud beats a silent
             # free of in-flight memory / a silent cross-stage length fork.
@@ -1206,7 +1200,7 @@ class EICHiRadixCache(RadixCache):
             # Free [admit, d + alloc): the failed tail AND loaded-beyond-verdict
             # in one cut at a verdict boundary, keeping trees and allocator
             # accounting PP-identical.
-            self._free_failed_loadback(st["node_id"], max(admit - d, 0))
+            self._free_failed_loadback(st["load_node"].id, max(admit - d, 0))
         else:
             assert admit <= d, "EIC PP verdict beyond device match without a load"
         if st["new_indices"] is not None and admit > d:
@@ -1227,7 +1221,7 @@ class EICHiRadixCache(RadixCache):
             depth -= len(node.key)
             node = node.parent
         req.last_node = node
-        req._eic_loaded_len = max(0, prefix_len - d)
+        req.eic_loaded_len = max(0, prefix_len - d)
         req.set_extend_input_len(len(req.fill_ids) - prefix_len)
         req.cache_protected_len = prefix_len
         req.last_matched_prefix_len = prefix_len
@@ -1247,13 +1241,13 @@ class EICHiRadixCache(RadixCache):
         self._h_rid.pop(h, None)
         self._admit_verdict.pop(h, None)
         self.dec_lock_ref(st["deferred_lock"])
-        node_id = st["node_id"]
+        node_id = st["load_node"].id if st["load_node"] is not None else None
         if node_id is not None and node_id in self.ongoing_load_back:
             if st["complete"] is not None:
                 self._loadback_rid.pop(node_id, None)
                 self._free_failed_loadback(node_id, 0)  # whole span: uniform boundary
             # else: load still in flight -> _drain_local_acks frees it at ack.
-        if self.pp_size > 1 and self.pp_group is not None:
+        if self._pp_active:
             self._tombstone[h] = (st["epoch"], self._round + self._TOMBSTONE_TTL)
             key = (h, st["epoch"])
             for kind in (self._KIND_SPAN, self._KIND_FINAL):
@@ -1483,7 +1477,7 @@ class EICPagedHiRadixCache(EICHiRadixCache):
     ):
         self.calculate_hash_fn = get_content_hash
         self.load_remote_threshold = 100
-        self.match_req_set = []
+        self.match_req_set = {}  # rid -> None, insertion-ordered for FIFO trim
         self.eic_check_max_num = -1
         super().__init__(params, server_args)
 
@@ -1695,7 +1689,7 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         if num_ready == 0:
             return
         if len(self.match_req_set) > 1000:
-            self.match_req_set = self.match_req_set[500:]
+            self.match_req_set = dict(list(self.match_req_set.items())[500:])
 
         fetches = []  # (slot, last_node, evict_len, compute_key, prev_hash)
         eic_keys = 0
@@ -1715,7 +1709,7 @@ class EICPagedHiRadixCache(EICHiRadixCache):
                 continue
             if _need_calculate_hash(last_node, self.page_size):
                 self._calculate_content_hash(last_node)
-            self.match_req_set.append(req.rid)
+            self.match_req_set[req.rid] = None
             prev_hash = last_node.content_hash[-1] if last_node.content_hash else None
             fetches.append((slot, last_node, evict_len, req_key[prefix_len:], prev_hash))
             eic_keys += (len(req_key) - prefix_len) // self.page_size

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -22,6 +22,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     MatchResult,
 )
+from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.eic_memory_pool import (
     EICDeepSeekV4TokenToKVPoolHost,
@@ -158,6 +159,9 @@ class EICHiRadixCache(RadixCache):
         # (deploy_key embeds pp_rank), so per-stage load-back can succeed/fail
         # independently. loading_check reconciles the admitted length across PP.
         self.pp_group = params.pp_cache_group
+        self.pp_rank = params.pp_rank
+        self.pp_size = params.pp_size
+        self.work_list = []
         self.kv_cache = params.token_to_kv_pool_allocator.get_kvcache()
         self.sliding_window_size = params.sliding_window_size
         self.load_cache_event = threading.Event()
@@ -229,6 +233,11 @@ class EICHiRadixCache(RadixCache):
         self.ongoing_write_through = {}
         # record the node segments with ongoing load back
         self.ongoing_load_back = {}
+        # async admission: reqs whose load-back was kicked but not yet admitted
+        # (rid -> (last_node, new_indices)). Mirrors ongoing_prefetch. Replaces
+        # the schedule_policy busy-wait, so loading_check runs only from the
+        # PP-aligned check_hicache_events -> its PP consensus can't deadlock.
+        self.ongoing_load_admit = {}
         # EIC is native to this cache (no pluggable L3 HiCacheStorage backend);
         # is_fully_idle() uses this flag to skip ongoing_prefetch/backup checks.
         self.enable_storage = False
@@ -273,6 +282,7 @@ class EICHiRadixCache(RadixCache):
         self.cache_controller.reset()
         self.token_to_kv_pool_host.clear()
         self.ongoing_load_back = {}
+        self.ongoing_load_admit = {}
         self.ongoing_write_through = {}
         super().reset()
 
@@ -467,17 +477,44 @@ class EICHiRadixCache(RadixCache):
                 f"queue size {queue_size.item()}"
             )
 
-    def _pp_reduce_min(self, tensor):
-        # PP stages store their layers' KV in distinct EIC namespaces, so
-        # per-stage load-back completes independently. MIN across PP keeps the
-        # radix tree (and thus the admitted extend_len) identical on every stage.
-        if (
-            self.pp_group is not None
-            and torch.distributed.get_world_size(group=self.pp_group) > 1
-        ):
-            torch.distributed.all_reduce(
-                tensor, op=torch.distributed.ReduceOp.MIN, group=self.pp_group
+    def _pp_bcast_from_first(self, tensor):
+        # Broadcast PP0's value down the pipeline: each stage overwrites its
+        # value with the upstream one, so the admitted length is identical
+        # everywhere. The pipeline runs stages out of phase, so any scheme where
+        # a stage BLOCKS waiting for another deadlocks (an all_reduce, or a
+        # blocking send/recv). A non-blocking isend down the stages never blocks
+        # the sender; the send is drained next round (_drain_async_work).
+        # NOTE: this is PP0-authoritative, not a true cross-PP MIN. Under EIC
+        # partial mget failure a downstream stage that loaded back fewer tokens
+        # than PP0 keeps unloaded (garbage) KV for the gap -- a known limitation,
+        # tracked for the pipelined-MIN follow-up.
+        if self.pp_size <= 1 or self.pp_group is None:
+            return
+        tag = P2PTag.HIRADIX_PP_SYNC
+        if self.pp_rank > 0:
+            torch.distributed.recv(
+                tensor, group_src=self.pp_rank - 1, group=self.pp_group, tag=tag
             )
+        if self.pp_rank + 1 < self.pp_size:
+            copied = tensor.clone()
+            self.work_list.append(
+                torch.distributed.isend(
+                    copied, group_dst=self.pp_rank + 1, group=self.pp_group, tag=tag
+                )
+            )
+
+    def _drain_async_work(self):
+        for work in self.work_list:
+            work.wait()
+        self.work_list.clear()
+
+    def _reduce_min(self, tensor):
+        # CP/TP is synchronous -> a real MIN; PP is out-of-phase -> PP0-authoritative.
+        if self.tp_size > 1:
+            torch.distributed.all_reduce(
+                tensor, op=torch.distributed.ReduceOp.MIN, group=self.tp_group
+            )
+        self._pp_bcast_from_first(tensor)
 
     def loading_check(self):
         if len(self.ongoing_load_back) == 0:
@@ -493,20 +530,19 @@ class EICHiRadixCache(RadixCache):
                 op=torch.distributed.ReduceOp.MIN,
                 group=self.tp_group,
             )
-        self._pp_reduce_min(queue_size)
+        # NOTE: no PP sync here. EIC acks arrive asynchronously so per-stage
+        # ack_load_queue sizes differ; a PP0-authoritative queue_size would make
+        # a lagging stage get_nowait() past its queue and crash, and the
+        # complete_token vector lengths would not match. Cross-PP consistency of
+        # the truncated tree needs a true MIN, which deadlocks the out-of-phase
+        # pipeline -- deferred to the pipelined-MIN follow-up. Each stage
+        # truncates locally (CP-consistent); harmless while attn_cp_size == 1.
         ack_list = []
         complete_tokens = []
         for _ in range(queue_size.item()):
             ack_id, complete_token = self.cache_controller.ack_load_queue.get_nowait()
             ack_list.append(ack_id)
             complete_tokens.append(complete_token)
-        # Load thread is a single FIFO consumer, so ack order is identical on
-        # every rank; complete_token is CP-reduced in the controller, MIN it
-        # across PP too so every stage truncates each node to the same length.
-        if ack_list:
-            ct = torch.tensor(complete_tokens, dtype=torch.int64)
-            self._pp_reduce_min(ct)
-            complete_tokens = ct.tolist()
         for ack_id, complete_token in zip(ack_list, complete_tokens):
             start_node, end_node, total_token_num = self.ongoing_load_back[ack_id]
             self.dec_lock_ref(end_node)
@@ -603,9 +639,13 @@ class EICHiRadixCache(RadixCache):
     def evict(self, params: EvictParams, retry_times: int = 3) -> EvictResult:
         start_time = time.perf_counter()
         num_tokens = max(params.num_tokens, params.swa_num_tokens)
-        while len(self.ongoing_write_through) > 50 or len(self.ongoing_load_back) > 50:
+        # Throttle on the write-through backlog only. loading_check() holds a PP
+        # collective; this loop fires on per-stage memory pressure (divergent
+        # cadence), so calling it here would deadlock the PP group. The load
+        # backlog drains at the single lockstep site (check_hicache_events) and
+        # in the schedule_policy busy-wait, both PP-uniform.
+        while len(self.ongoing_write_through) > 50:
             self.writing_check()
-            self.loading_check()
             time.sleep(0.1)
 
         num_evicted = 0
@@ -776,6 +816,66 @@ class EICHiRadixCache(RadixCache):
         self.loading_check()
         return node.id not in self.ongoing_load_back.keys()
 
+    def check_load_back_progress(self, req) -> bool:
+        # SCAFFOLD for the Part-2 follow-up (async admission), NOT wired in yet --
+        # the active path is the schedule_policy busy-wait. Verified in isolation
+        # that wiring this WITHOUT a PP-consistent loading_check diverges
+        # extend_input_len across PP and crashes (main_norm_rope.cuh:183, even at
+        # cp=1). Part 2 must call this from the scheduler gate AND make
+        # loading_check MIN complete_token + synchronize ongoing_load_back deletion
+        # across PP via a non-blocking isend+irecv delayed-MIN (a blocking recv
+        # deadlocks the out-of-phase pipeline). Mirrors check_prefetch_progress.
+        # First call kicks the async load and defers (False); later calls stay
+        # False while the ack is in flight; once loading_check has drained the
+        # ack, finalize prefix_indices/extend_input_len and admit (True).
+        if req.rid not in self.ongoing_load_admit:
+            if not req.needs_host_load_back():
+                return True
+            new_indices, req.last_node = self.init_load_back(
+                InitLoadBackParams(
+                    best_match_node=req.best_match_node,
+                    host_hit_length=req.host_hit_length,
+                    req=req,
+                )
+            )
+            self.ongoing_load_admit[req.rid] = (req.last_node, new_indices)
+            # init_load_back may fall back to a resident ancestor with no async
+            # load registered -> finalize right away.
+            if req.last_node.id not in self.ongoing_load_back:
+                return self._finalize_load_admit(req)
+            return False
+        if req.last_node.id in self.ongoing_load_back:
+            return False  # still loading; loading_check advances it next steps
+        return self._finalize_load_admit(req)
+
+    def _finalize_load_admit(self, req) -> bool:
+        _, new_indices = self.ongoing_load_admit.pop(req.rid)
+        # Relocated from schedule_policy's old busy-wait finalize block: on
+        # partial failure walk the evicted tail down to the resident node and
+        # truncate new_indices to the actually-loaded (device-resident) slots.
+        load_success = req.last_node.value is not None
+        complete_token_num = len(new_indices)
+        if not load_success:
+            gpu_node = req.last_node
+            while gpu_node.evicted:
+                complete_token_num -= len(gpu_node.key)
+                gpu_node = gpu_node.parent
+            assert complete_token_num >= 0
+            req.last_node = gpu_node
+            if complete_token_num > 0:
+                new_indices = new_indices[:complete_token_num]
+            else:
+                new_indices = torch.empty(
+                    (0,), dtype=torch.int64, device=req.prefix_indices.device
+                )
+        req._eic_loaded_len = len(new_indices)
+        req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
+        req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))
+        prefix_len = len(req.prefix_indices)
+        req.cache_protected_len = prefix_len
+        req.last_matched_prefix_len = prefix_len
+        return True
+
     def init_load_back(
         self,
         params: InitLoadBackParams,
@@ -804,6 +904,7 @@ class EICHiRadixCache(RadixCache):
         return producer_index
 
     def check_hicache_events(self):
+        self._drain_async_work()
         self.writing_check()
         self.loading_check()
 
@@ -1212,85 +1313,66 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         return total_prefix_length
 
     def match_from_remote(self, waiting_queue: List[Req]):
-        compute_keys = []
-        prev_hashes = []
-        fetch_list = []
+        # waiting_queue is the same global stream on every rank, but a PP stage
+        # can lag by a few requests (async forward). Gate on the common prefix so
+        # every reduce below has a PP-invariant length and can't deadlock, even
+        # if the local trees diverged.
+        num_ready = torch.tensor(len(waiting_queue), dtype=torch.int64, device="cpu")
+        self._reduce_min(num_ready)
+        # PP0-authoritative length -> the reduce vector below is the same size on
+        # every stage (so its p2p bcast can't hang). A lagging stage reads only
+        # the reqs it actually has (local_n); the rest of the vector stays 0.
+        num_ready = int(num_ready.item())
+        if num_ready == 0:
+            return
+        local_n = min(num_ready, len(waiting_queue))
         if len(self.match_req_set) > 1000:
             self.match_req_set = self.match_req_set[500:]
+
+        fetches = []  # (slot, last_node, evict_len, compute_key, prev_hash)
         eic_keys = 0
-        for req in waiting_queue:
-            logger.debug(f"req {req.rid} match from eic")
+        for slot in range(local_n):
+            req = waiting_queue[slot]
             if req.rid in self.match_req_set:
                 continue
             fill_ids = req.origin_input_ids + req.output_ids
             req_tokens = fill_ids[: len(fill_ids) - 1]
             if len(req_tokens) == 0:
-                logger.debug(
-                    f"req {req.rid} skip loading from eic: no committed tokens"
-                )
                 continue
             req_key = RadixKey(req_tokens, req.extra_key)
-            local_prefix_len, local_evict_len, last_node = self._match_for_remote_fetch(
+            prefix_len, evict_len, last_node = self._match_for_remote_fetch(
                 self.root_node, req_key
             )
-            if (
-                len(req_key) - local_prefix_len + local_evict_len
-                < self.load_remote_threshold
-            ):
-                # skip loading from eic if the remaining key is too short
-                logger.debug(f"req {req.rid} skip loading from eic")
+            if len(req_key) - prefix_len + evict_len < self.load_remote_threshold:
                 continue
-            compute_keys.append(req_key[local_prefix_len:])
             if _need_calculate_hash(last_node, self.page_size):
                 self._calculate_content_hash(last_node)
-            prev_hashes.append(
-                last_node.content_hash[-1] if last_node.content_hash else None
-            )
-            fetch_list.append((last_node, req, local_prefix_len, local_evict_len))
             self.match_req_set.append(req.rid)
-            eic_keys += (len(req_key) - local_prefix_len) // self.page_size
-            if self.eic_check_max_num > 0 and eic_keys >= self.eic_check_max_num:
-                logger.info(
-                    f"eic check max num {self.eic_check_max_num} reached, stop matching"
-                )
+            prev_hash = last_node.content_hash[-1] if last_node.content_hash else None
+            fetches.append((slot, last_node, evict_len, req_key[prefix_len:], prev_hash))
+            eic_keys += (len(req_key) - prefix_len) // self.page_size
+            if 0 < self.eic_check_max_num <= eic_keys:
                 break
-        if len(fetch_list) == 0:
-            return
-        # batch exist
-        eic_prefix_lens = self.cache_controller.batch_find_longest_prefix_in_eic(
-            compute_keys, prev_hashes
-        )
-        if len(eic_prefix_lens) == 0 or len(eic_prefix_lens) != len(fetch_list):
-            return
-        if self.tp_size > 1:
-            eic_prefix_len_tensor = torch.tensor(
-                eic_prefix_lens, dtype=torch.int64, device="cpu"
+
+        # Query EIC per fetched slot, scatter into a queue-length vector (0 =
+        # miss/fail), then MIN over CP/TP+PP so the admitted prefix -- and thus
+        # the radix tree -- is identical on every stage.
+        eic_prefix_lens = [0] * num_ready
+        if fetches:
+            lens = self.cache_controller.batch_find_longest_prefix_in_eic(
+                [f[3] for f in fetches], [f[4] for f in fetches]
             )
-            torch.distributed.all_reduce(
-                eic_prefix_len_tensor,
-                op=torch.distributed.ReduceOp.MIN,
-                group=self.tp_group,
-            )
-            eic_prefix_lens = eic_prefix_len_tensor.tolist()
-        # MIN across PP so the load-back decision is identical on every stage,
-        # else loading_check's PP reduce deadlocks on a divergent req set.
-        eic_prefix_len_tensor = torch.tensor(eic_prefix_lens, dtype=torch.int64)
-        self._pp_reduce_min(eic_prefix_len_tensor)
-        eic_prefix_lens = eic_prefix_len_tensor.tolist()
-        for i, (last_node, req, local_prefix_len, local_evict_len) in enumerate(
-            fetch_list
-        ):
-            eic_prefix_len = eic_prefix_lens[i]
-            if eic_prefix_len + local_evict_len < self.load_remote_threshold:
-                continue
-            eic_key = compute_keys[i][:eic_prefix_len]
-            logger.debug(
-                f"req {req.rid} match from eic, "
-                f"last node {last_node.id}, "
-                f"local prefix len {local_prefix_len}, "
-                f"eic prefix len {eic_prefix_len}"
-            )
-            self._insert_remote_node(last_node, eic_key)
+            if len(lens) == len(fetches):
+                for (slot, *_), n in zip(fetches, lens):
+                    eic_prefix_lens[slot] = n
+        len_tensor = torch.tensor(eic_prefix_lens, dtype=torch.int64, device="cpu")
+        self._reduce_min(len_tensor)
+        eic_prefix_lens = len_tensor.tolist()
+
+        for slot, last_node, evict_len, compute_key, _ in fetches:
+            eic_len = eic_prefix_lens[slot]
+            if eic_len + evict_len >= self.load_remote_threshold:
+                self._insert_remote_node(last_node, compute_key[:eic_len])
 
     def match_prefix(self, params: MatchPrefixParams):
         key = params.key

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -293,7 +293,7 @@ class EICHiRadixCache(RadixCache):
             # clobber frozen matches), storage prefetch skips the gate per stage
             # asynchronously, dp-attention lanes have private waiting queues,
             # and the waiting timeout releases by per-stage clocks.
-            if getattr(server_args, "hicache_storage_backend", None):
+            if server_args.hicache_storage_backend:
                 raise ValueError(
                     "EIC under PP is incompatible with hicache_storage_backend"
                 )
@@ -601,11 +601,12 @@ class EICHiRadixCache(RadixCache):
             if self.rank == 0:
                 n = min(len(self._verdict_outbox), self._VERDICT_CAP)
                 buf[0] = n
-                for i in range(n):
-                    buf[1 + i * 4 : 5 + i * 4] = torch.tensor(
-                        self._verdict_outbox[i], dtype=torch.int64
+                if n:
+                    buf[1 : 1 + n * 4] = torch.tensor(
+                        [x for row in self._verdict_outbox[:n] for x in row],
+                        dtype=torch.int64,
                     )
-                del self._verdict_outbox[:n]
+                    del self._verdict_outbox[:n]
             if self.tp_size > 1:
                 # Equalize the tp0-only poll result across this stage's lanes
                 # BEFORE it forks into the per-lane DAGs. Unconditional: the
@@ -1719,20 +1720,18 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         # Query EIC per fetched slot, scatter into a queue-length vector (0 =
         # miss/fail), then MIN over CP/TP+PP so the admitted prefix -- and thus
         # the radix tree -- is identical on every stage.
-        eic_prefix_lens = [0] * num_ready
+        len_tensor = torch.zeros(num_ready, dtype=torch.int64, device="cpu")
         if fetches:
             lens = self.cache_controller.batch_find_longest_prefix_in_eic(
                 [f[3] for f in fetches], [f[4] for f in fetches]
             )
             if len(lens) == len(fetches):
                 for (slot, *_), n in zip(fetches, lens):
-                    eic_prefix_lens[slot] = n
-        len_tensor = torch.tensor(eic_prefix_lens, dtype=torch.int64, device="cpu")
+                    len_tensor[slot] = n
         self._reduce_min(len_tensor)
-        eic_prefix_lens = len_tensor.tolist()
 
         for slot, last_node, evict_len, compute_key, _ in fetches:
-            eic_len = eic_prefix_lens[slot]
+            eic_len = int(len_tensor[slot])
             if eic_len + evict_len >= self.load_remote_threshold:
                 self._insert_remote_node(last_node, compute_key[:eic_len])
 

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1,3 +1,4 @@
+import hashlib
 import heapq
 import logging
 import os
@@ -155,13 +156,19 @@ class EICHiRadixCache(RadixCache):
         self.tp_group = params.tp_cache_group
         self.tp_size = self.tp_group.size()
         self.rank = self.tp_group.rank()
-        # PP stages store each layer-shard's KV under a distinct EIC namespace
-        # (deploy_key embeds pp_rank), so per-stage load-back can succeed/fail
-        # independently. loading_check reconciles the admitted length across PP.
+        # deploy_key embeds pp_rank, so each PP stage load-backs independently;
+        # loading_check reconciles the admitted length across stages.
         self.pp_group = params.pp_cache_group
         self.pp_rank = params.pp_rank
         self.pp_size = params.pp_size
         self.work_list = []
+        # EIC host load-back runs only for a single PP stage (pp_size<=1); under PP>1
+        # it is disabled because its cross-PP length reconciliation would need rank0
+        # to receive a peer report in the scheduler thread, which deadlocks the
+        # out-of-phase pipeline in this gloo build. See loading_check.
+        self.pending_report = {}  # rid_hash -> local admit len, awaiting resolution
+        self._admit_verdict = {}  # rid_hash -> resolved admit len, consumed by the gate
+        self._loadback_rid = {}  # load-back node_id -> rid (maps an EIC ack to its req)
         self.kv_cache = params.token_to_kv_pool_allocator.get_kvcache()
         self.sliding_window_size = params.sliding_window_size
         self.load_cache_event = threading.Event()
@@ -284,6 +291,9 @@ class EICHiRadixCache(RadixCache):
         self.ongoing_load_back = {}
         self.ongoing_load_admit = {}
         self.ongoing_write_through = {}
+        self.pending_report = {}
+        self._admit_verdict = {}
+        self._loadback_rid = {}
         super().reset()
 
     def get_height(self, node: TreeNode):
@@ -477,20 +487,13 @@ class EICHiRadixCache(RadixCache):
                 f"queue size {queue_size.item()}"
             )
 
-    def _pp_bcast_from_first(self, tensor):
-        # Broadcast PP0's value down the pipeline: each stage overwrites its
-        # value with the upstream one, so the admitted length is identical
-        # everywhere. The pipeline runs stages out of phase, so any scheme where
-        # a stage BLOCKS waiting for another deadlocks (an all_reduce, or a
-        # blocking send/recv). A non-blocking isend down the stages never blocks
-        # the sender; the send is drained next round (_drain_async_work).
-        # NOTE: this is PP0-authoritative, not a true cross-PP MIN. Under EIC
-        # partial mget failure a downstream stage that loaded back fewer tokens
-        # than PP0 keeps unloaded (garbage) KV for the gap -- a known limitation,
-        # tracked for the pipelined-MIN follow-up.
+    def _pp_bcast_from_first(self, tensor, tag=P2PTag.HIRADIX_PP_SYNC):
+        # PP0-authoritative broadcast down the pipeline via non-blocking isend
+        # (blocking/collective PP ops deadlock the out-of-phase pipeline). Each
+        # logical stream passes its OWN tag so independent bcasts (num_ready vs the
+        # admission verdict) never share a FIFO slot and can't cross-match.
         if self.pp_size <= 1 or self.pp_group is None:
             return
-        tag = P2PTag.HIRADIX_PP_SYNC
         if self.pp_rank > 0:
             torch.distributed.recv(
                 tensor, group_src=self.pp_rank - 1, group=self.pp_group, tag=tag
@@ -517,68 +520,75 @@ class EICHiRadixCache(RadixCache):
         self._pp_bcast_from_first(tensor)
 
     def loading_check(self):
-        if len(self.ongoing_load_back) == 0:
-            return
-        loading_check_start_time = time.perf_counter()
+        # Single stage: drain acks and resolve locally. PP>1: host load-back is
+        # disabled (its cross-PP reconciliation would need PP0 to receive a peer
+        # report in the scheduler thread -> deadlocks the out-of-phase pipeline in
+        # this gloo build), so pending_report stays empty and this is a no-op. The
+        # true PP-consistent load-back is the pipeline-piggyback follow-up.
+        self._drain_local_acks()
+        for h in list(self.pending_report):
+            self._admit_verdict[h] = self.pending_report.pop(h)
+
+    def _rid_hash(self, rid):
+        # Stable 56-bit id (fits a positive int64); hash() is per-process salted so
+        # not PP-uniform. ponytail: collision-free for a batch-sized in-flight set.
+        return int.from_bytes(
+            hashlib.blake2b(rid.encode(), digest_size=7).digest(), "big"
+        )
+
+    def _drain_local_acks(self):
         queue_size = torch.tensor(
             self.cache_controller.ack_load_queue.qsize(), dtype=torch.int
         )
-        if torch.distributed.get_world_size(group=self.tp_group) > 1:
-            # synchrnoize TP workers to make the same update to radix cache
+        if self.tp_size > 1:
+            # TP/CP share a namespace -> acks match; MIN guards qsize skew only.
             torch.distributed.all_reduce(
-                queue_size,
-                op=torch.distributed.ReduceOp.MIN,
-                group=self.tp_group,
+                queue_size, op=torch.distributed.ReduceOp.MIN, group=self.tp_group
             )
-        # NOTE: no PP sync here. EIC acks arrive asynchronously so per-stage
-        # ack_load_queue sizes differ; a PP0-authoritative queue_size would make
-        # a lagging stage get_nowait() past its queue and crash, and the
-        # complete_token vector lengths would not match. Cross-PP consistency of
-        # the truncated tree needs a true MIN, which deadlocks the out-of-phase
-        # pipeline -- deferred to the pipelined-MIN follow-up. Each stage
-        # truncates locally (CP-consistent); harmless while attn_cp_size == 1.
-        ack_list = []
-        complete_tokens = []
-        for _ in range(queue_size.item()):
-            ack_id, complete_token = self.cache_controller.ack_load_queue.get_nowait()
-            ack_list.append(ack_id)
-            complete_tokens.append(complete_token)
-        for ack_id, complete_token in zip(ack_list, complete_tokens):
-            start_node, end_node, total_token_num = self.ongoing_load_back[ack_id]
-            self.dec_lock_ref(end_node)
-            failed_token_num = total_token_num - complete_token
-            while end_node != start_node:
-                if failed_token_num >= len(end_node.value):
-                    # node load back full fail
-                    # no need to delete failed node because the kvcache will be set after compute
-                    self.cache_controller.mem_pool_device_allocator.free(end_node.value)
-                    self.evictable_size_ -= len(end_node.value)
-                    failed_token_num -= len(end_node.value)
-                    end_node.value = None
-                    end_node.host_value = None
-                    self._update_leaf_status(end_node)
-                    self._update_leaf_status(end_node.parent)
-                elif failed_token_num > 0:
-                    # node load back partial fail, split node
-                    split_len = len(end_node.value) - failed_token_num
-                    self._split_node(end_node.key, end_node, split_len)
-                    self.evictable_size_ -= failed_token_num
-                    self.cache_controller.mem_pool_device_allocator.free(end_node.value)
-                    failed_token_num -= len(end_node.value)
-                    end_node.value = None
-                    end_node.host_value = None
-                    self._update_leaf_status(end_node)
-                    self._update_leaf_status(end_node.parent)
-                    assert failed_token_num == 0, "failed_token_num should be zero"
-                end_node = end_node.parent
-            # clear the reference
-            del self.ongoing_load_back[ack_id]
-        cost_time = time.perf_counter() - loading_check_start_time
-        if cost_time > 1:
-            logger.warning(
-                f"loading check cost {cost_time:.3f} seconds, "
-                f"queue size {queue_size.item()}"
-            )
+        for _ in range(int(queue_size.item())):
+            node_id, complete_token = self.cache_controller.ack_load_queue.get_nowait()
+            rid = self._loadback_rid.pop(node_id, None)
+            if rid is None or rid not in self.ongoing_load_admit:
+                # req aborted before its load landed -> free it here (with the true
+                # completed count) so its KV isn't pinned/leaked.
+                if node_id in self.ongoing_load_back:
+                    self._free_failed_loadback(node_id, complete_token)
+                continue
+            st = self.ongoing_load_admit[rid]
+            st["complete"] = complete_token
+            # local_actual becomes known post-load: device match + actually loaded.
+            self.pending_report[st["h"]] = st["device_match"] + complete_token
+
+    def _free_failed_loadback(self, node_id, complete_token):
+        # Local cleanup: release the load lock and free the failed-load tail so the
+        # tree never holds garbage KV. Per-stage; the tree may diverge across PP.
+        start_node, end_node, total_token_num = self.ongoing_load_back.pop(node_id)
+        self.dec_lock_ref(end_node)
+        failed_token_num = total_token_num - complete_token
+        while end_node != start_node:
+            if failed_token_num >= len(end_node.value):
+                # node load back full fail
+                # no need to delete failed node because the kvcache will be set after compute
+                self.cache_controller.mem_pool_device_allocator.free(end_node.value)
+                self.evictable_size_ -= len(end_node.value)
+                failed_token_num -= len(end_node.value)
+                end_node.value = None
+                end_node.host_value = None
+                self._update_leaf_status(end_node)
+                self._update_leaf_status(end_node.parent)
+            elif failed_token_num > 0:
+                # node load back partial fail, split node
+                split_len = len(end_node.value) - failed_token_num
+                self._split_node(end_node.key, end_node, split_len)
+                self.evictable_size_ -= failed_token_num
+                self.cache_controller.mem_pool_device_allocator.free(end_node.value)
+                failed_token_num -= len(end_node.value)
+                end_node.value = None
+                end_node.host_value = None
+                self._update_leaf_status(end_node)
+                self._update_leaf_status(end_node.parent)
+                assert failed_token_num == 0, "failed_token_num should be zero"
+            end_node = end_node.parent
 
     # TODO: is not correct for eic, but neednt to be fixed rightnow
     def evictable_size(self):
@@ -812,69 +822,122 @@ class EICHiRadixCache(RadixCache):
 
         return device_indices
 
-    def loading_complete(self, node: TreeNode):
-        self.loading_check()
-        return node.id not in self.ongoing_load_back.keys()
-
     def check_load_back_progress(self, req) -> bool:
-        # SCAFFOLD for the Part-2 follow-up (async admission), NOT wired in yet --
-        # the active path is the schedule_policy busy-wait. Verified in isolation
-        # that wiring this WITHOUT a PP-consistent loading_check diverges
-        # extend_input_len across PP and crashes (main_norm_rope.cuh:183, even at
-        # cp=1). Part 2 must call this from the scheduler gate AND make
-        # loading_check MIN complete_token + synchronize ongoing_load_back deletion
-        # across PP via a non-blocking isend+irecv delayed-MIN (a blocking recv
-        # deadlocks the out-of-phase pipeline). Mirrors check_prefetch_progress.
-        # First call kicks the async load and defers (False); later calls stay
-        # False while the ack is in flight; once loading_check has drained the
-        # ack, finalize prefix_indices/extend_input_len and admit (True).
+        # Per-candidate admission gate. First encounter kicks the local load-back
+        # (if any) and records this stage's local_actual; the req then defers until
+        # the PP0-authoritative verdict (loading_check) lands, at which point the
+        # prefix is clamped to the cross-PP MIN and the req admits. Every num_ready
+        # candidate passes here -- even cold ones -- so rank0 always gets a full
+        # report set for the rid and the MIN can never leak/hang.
+        h = self._rid_hash(req.rid)
         if req.rid not in self.ongoing_load_admit:
-            if not req.needs_host_load_back():
-                return True
-            new_indices, req.last_node = self.init_load_back(
-                InitLoadBackParams(
-                    best_match_node=req.best_match_node,
-                    host_hit_length=req.host_hit_length,
-                    req=req,
+            device_match = len(req.prefix_indices)
+            new_indices, node_id = None, None
+            if req.needs_host_load_back():
+                new_indices, req.last_node = self.init_load_back(
+                    InitLoadBackParams(
+                        best_match_node=req.best_match_node,
+                        host_hit_length=req.host_hit_length,
+                        req=req,
+                    )
                 )
-            )
-            self.ongoing_load_admit[req.rid] = (req.last_node, new_indices)
-            # init_load_back may fall back to a resident ancestor with no async
-            # load registered -> finalize right away.
-            if req.last_node.id not in self.ongoing_load_back:
+                if req.last_node.id in self.ongoing_load_back:
+                    node_id = req.last_node.id
+                    self._loadback_rid[node_id] = req.rid
+            self.ongoing_load_admit[req.rid] = {
+                "h": h,
+                "new_indices": new_indices,
+                "node_id": node_id,
+                "device_match": device_match,
+                "complete": None,
+                "deferred_lock": None,
+            }
+            if node_id is None:
+                # nothing async to wait on -> local_actual is known now.
+                extra = len(new_indices) if new_indices is not None else 0
+                self.pending_report[h] = device_match + extra
+            if self.pp_size <= 1 or self.pp_group is None:
+                if h in self.pending_report:
+                    self._admit_verdict[h] = self.pending_report.pop(h)
+            if h in self._admit_verdict:
                 return self._finalize_load_admit(req)
+            if node_id is None:
+                # Deferring a device-only / fell-back req: load_back took no lock, so
+                # lock the frozen device prefix ourselves so eviction can't reclaim
+                # its slots across the verdict round-trip. Released in finalize.
+                self.inc_lock_ref(req.last_node)
+                self.ongoing_load_admit[req.rid]["deferred_lock"] = req.last_node
             return False
-        if req.last_node.id in self.ongoing_load_back:
-            return False  # still loading; loading_check advances it next steps
+        if h not in self._admit_verdict:
+            return False  # still loading / awaiting peers; loading_check advances it
         return self._finalize_load_admit(req)
 
     def _finalize_load_admit(self, req) -> bool:
-        _, new_indices = self.ongoing_load_admit.pop(req.rid)
-        # Relocated from schedule_policy's old busy-wait finalize block: on
-        # partial failure walk the evicted tail down to the resident node and
-        # truncate new_indices to the actually-loaded (device-resident) slots.
-        load_success = req.last_node.value is not None
-        complete_token_num = len(new_indices)
-        if not load_success:
-            gpu_node = req.last_node
-            while gpu_node.evicted:
-                complete_token_num -= len(gpu_node.key)
-                gpu_node = gpu_node.parent
-            assert complete_token_num >= 0
-            req.last_node = gpu_node
-            if complete_token_num > 0:
-                new_indices = new_indices[:complete_token_num]
-            else:
-                new_indices = torch.empty(
-                    (0,), dtype=torch.int64, device=req.prefix_indices.device
-                )
-        req._eic_loaded_len = len(new_indices)
-        req.prefix_indices = torch.cat([req.prefix_indices, new_indices])
-        req.set_extend_input_len(len(req.fill_ids) - len(req.prefix_indices))
+        st = self.ongoing_load_admit.pop(req.rid)
+        h, new_indices, node_id, device_match = (
+            st["h"],
+            st["new_indices"],
+            st["node_id"],
+            st["device_match"],
+        )
+        admit = self._admit_verdict.pop(h)
+        dl = st.get("deferred_lock")
+        if dl is not None:
+            self.dec_lock_ref(dl)  # release the defer-time device-prefix lock
+        # host_hit == last_node's tree depth beyond device_match (the FULL host
+        # portion attempted, not just what loaded); host_hit == 0 when cold or
+        # when init_load_back fell back to a resident ancestor.
+        host_hit = len(new_indices) if new_indices is not None else 0
+        loaded = 0
+        if node_id is not None:
+            # free the local failed-load tail (garbage KV) and release the load lock.
+            loaded = st["complete"] or 0
+            self._free_failed_loadback(node_id, loaded)
+        if new_indices is not None and loaded > 0:
+            req.prefix_indices = torch.cat([req.prefix_indices, new_indices[:loaded]])
+        if admit < len(req.prefix_indices):
+            req.prefix_indices = req.prefix_indices[:admit]
         prefix_len = len(req.prefix_indices)
+        # Repoint last_node at the deepest RESIDENT node still spanning the clamped
+        # prefix (bottom depth >= prefix_len), skipping the just-evicted failed
+        # tail. Seed at last_node's TRUE tree depth (device_match + host_hit); the
+        # sum of key lengths on the path is split-invariant so this stays exact.
+        # inc_lock_ref(last_node) then protects every slot the req reads (an
+        # over-locked resident tail past prefix_len is harmless).
+        node = req.last_node
+        depth = device_match + host_hit
+        while node is not self.root_node and (
+            node.value is None or depth - len(node.key) >= prefix_len
+        ):
+            depth -= len(node.key)
+            node = node.parent
+        req.last_node = node
+        req._eic_loaded_len = max(0, prefix_len - device_match)
+        req.set_extend_input_len(len(req.fill_ids) - prefix_len)
         req.cache_protected_len = prefix_len
         req.last_matched_prefix_len = prefix_len
         return True
+
+    def release_load_admit(self, rid):
+        # Cleanup for a deferring candidate removed from the waiting queue WITHOUT
+        # admitting (abort / waiting-timeout / queued-limit): release every lock and
+        # drop all per-req reconciliation state so KV isn't pinned and is_fully_idle
+        # isn't wedged. No-op if the rid never entered the gate.
+        st = self.ongoing_load_admit.pop(rid, None)
+        if st is None:
+            return
+        h = st["h"]
+        self.pending_report.pop(h, None)
+        self._admit_verdict.pop(h, None)
+        if st["deferred_lock"] is not None:
+            self.dec_lock_ref(st["deferred_lock"])
+        node_id = st["node_id"]
+        if node_id is not None and node_id in self.ongoing_load_back:
+            if st["complete"] is not None:
+                # load already landed -> release its lock + free the failed tail now.
+                self._loadback_rid.pop(node_id, None)
+                self._free_failed_loadback(node_id, st["complete"])
+            # else: load still in flight -> leave it; _drain_local_acks frees the ack.
 
     def init_load_back(
         self,
@@ -1323,9 +1386,9 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         # every stage (so its p2p bcast can't hang). A lagging stage reads only
         # the reqs it actually has (local_n); the rest of the vector stays 0.
         num_ready = int(num_ready.item())
+        local_n = min(num_ready, len(waiting_queue))
         if num_ready == 0:
             return
-        local_n = min(num_ready, len(waiting_queue))
         if len(self.match_req_set) > 1000:
             self.match_req_set = self.match_req_set[500:]
 

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -1967,7 +1967,9 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
             for page_id in range(len(page_hashes)):
                 start = page_id * self.page_chunk_count
                 end = start + self.page_chunk_count
-                page_mask.append(all(chunk_mask[start:end]))
+                chunk = chunk_mask[start:end]
+                # all([]) is True: a truncated reply would read as a full hit.
+                page_mask.append(len(chunk) == self.page_chunk_count and all(chunk))
             success_mask.extend(page_mask)
             if not all(page_mask):
                 break

--- a/python/sglang/srt/mem_cache/eic_pp_reconcile.py
+++ b/python/sglang/srt/mem_cache/eic_pp_reconcile.py
@@ -1,6 +1,6 @@
-"""PP-consistent per-request verdicts for storage prefetch.
+"""PP-consistent per-request verdicts for EIC storage prefetch.
 
-Storage keys are pp-scoped, so pipeline stages hit independently and the same
+EIC storage keys are pp-scoped, so pipeline stages hit independently and the same
 request can resolve to a different prefetch length per stage, forking the
 admitted prefix. Stages report their local result UP through the default
 process group's TCPStore (non-collective KV RPCs, so PP0 polling is not a p2p
@@ -20,7 +20,7 @@ import pickle
 logger = logging.getLogger(__name__)
 
 
-class PPReconciler:
+class EICPPReconciler:
     VERDICT_CAP = 32
     EPOCH_CAP = 65536
     TOMBSTONE_TTL = 4096
@@ -33,6 +33,7 @@ class PPReconciler:
         self.pp_size = pp_size
         self.pp_group = pp_group
         self.rank = rank
+        self.eic = False
 
         self.round = 0
         self._store_handle = None
@@ -46,7 +47,7 @@ class PPReconciler:
 
     @property
     def enabled(self):
-        return self.pp_size > 1 and self.pp_group is not None
+        return self.eic and self.pp_size > 1 and self.pp_group is not None
 
     @property
     def store(self):

--- a/python/sglang/srt/mem_cache/eic_pp_reconcile.py
+++ b/python/sglang/srt/mem_cache/eic_pp_reconcile.py
@@ -75,11 +75,15 @@ class EICPPReconciler:
         return self._store_handle
 
     @classmethod
+    def buf_len(cls, extra_scalars):
+        return extra_scalars + 1 + cls.VERDICT_CAP * 3
+
+    @classmethod
     def pack_rows(cls, rows, buf, base):
         buf[base] = len(rows)
-        for i, row in enumerate(rows):
-            buf[base + 1 + i * 3 : base + 4 + i * 3] = torch.tensor(
-                row, dtype=torch.int64
+        if rows:
+            buf[base + 1 : base + 1 + len(rows) * 3] = torch.tensor(
+                [x for row in rows for x in row], dtype=torch.int64
             )
 
     @classmethod
@@ -116,9 +120,10 @@ class EICPPReconciler:
         if not self.enabled:
             return
         self._tombstone[h] = (epoch, self.round + self.TOMBSTONE_TTL)
-        self._outbox = {k: v for k, v in self._outbox.items() if k[0] != h}
-        self._reports = {k: v for k, v in self._reports.items() if k[0] != h}
-        self._verdicts = [v for v in self._verdicts if v[0] != h]
+        self._outbox.pop((h, epoch), None)
+        self._reports.pop((h, epoch), None)
+        if self._verdicts:
+            self._verdicts = [v for v in self._verdicts if v[0] != h]
 
     def collect(self):
         """One round on tp0. PP0 returns up to VERDICT_CAP (h, epoch, min) rows;

--- a/python/sglang/srt/mem_cache/eic_pp_reconcile.py
+++ b/python/sglang/srt/mem_cache/eic_pp_reconcile.py
@@ -17,7 +17,24 @@ import hashlib
 import logging
 import pickle
 
+import torch
+
+from sglang.srt.environ import envs
+
 logger = logging.getLogger(__name__)
+
+
+def eic_pp_unsupported_reason(server_args):
+    if server_args.schedule_policy != "fcfs":
+        return "schedule_policy must be fcfs"
+    if server_args.enable_dp_attention:
+        return "dp_attention is incompatible"
+    if envs.SGLANG_REQ_WAITING_TIMEOUT.get() > 0:
+        return (
+            "SGLANG_REQ_WAITING_TIMEOUT must stay unset "
+            "(per-stage clocks release out of lockstep)"
+        )
+    return None
 
 
 class EICPPReconciler:
@@ -56,6 +73,20 @@ class EICPPReconciler:
 
             self._store_handle = distributed_c10d._get_default_store()
         return self._store_handle
+
+    @classmethod
+    def pack_rows(cls, rows, buf, base):
+        buf[base] = len(rows)
+        for i, row in enumerate(rows):
+            buf[base + 1 + i * 3 : base + 4 + i * 3] = torch.tensor(
+                row, dtype=torch.int64
+            )
+
+    @classmethod
+    def unpack_rows(cls, buf, base):
+        n = int(buf[base].item())
+        flat = buf[base + 1 : base + 1 + n * 3].tolist()
+        return [tuple(flat[i : i + 3]) for i in range(0, n * 3, 3)]
 
     @staticmethod
     def rid_hash(rid):

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -106,6 +106,18 @@ class HiRadixCache(RadixCache):
         self.pp_rank = params.pp_rank
         self.pp_size = params.pp_size
         self.enable_storage = server_args.hicache_storage_backend is not None
+        if self.enable_storage and self.pp_size > 1:
+            # Storage keys are pp-scoped, so stages hit independently; this
+            # cache has no cross-PP reconciliation of the prefetched length, so
+            # host trees fork per stage. Only UnifiedRadixCache
+            # (SGLANG_ENABLE_UNIFIED_RADIX_TREE=1) reconciles. Degrade instead
+            # of crashing: run without the storage tier.
+            logger.error(
+                "hicache_storage_backend with pipeline parallelism requires the "
+                "unified radix tree (SGLANG_ENABLE_UNIFIED_RADIX_TREE=1); "
+                "disabling the storage tier"
+            )
+            self.enable_storage = False
         self.enable_storage_metrics = self.enable_storage and params.enable_metrics
         self.extra_metric_labels = server_args.extra_metric_labels
 

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -109,7 +109,8 @@ class HiRadixCache(RadixCache):
         if server_args.hicache_storage_backend == "eic" and self.pp_size > 1:
             logger.error(
                 "eic hicache_storage_backend with pipeline parallelism requires "
-                "the unified radix tree (SGLANG_ENABLE_UNIFIED_RADIX_TREE=1); "
+                "the unified radix tree (SGLANG_ENABLE_UNIFIED_RADIX_TREE=1, "
+                "plus fcfs, no dp_attention, no SGLANG_REQ_WAITING_TIMEOUT); "
                 "disabling the storage tier"
             )
             self.enable_storage = False
@@ -283,6 +284,13 @@ class HiRadixCache(RadixCache):
         requests to avoid races.
         """
         # Validate inputs first (no side effects).
+        if storage_backend == "eic" and self.pp_size > 1:
+            return (
+                False,
+                "eic storage under pipeline parallelism needs the unified radix "
+                "tree's cross-PP reconciliation (SGLANG_ENABLE_UNIFIED_RADIX_TREE=1 "
+                "plus fcfs, no dp_attention, no SGLANG_REQ_WAITING_TIMEOUT).",
+            )
         if hicache_storage_prefetch_policy is not None:
             allowed = ["best_effort", "wait_complete", "timeout"]
             if hicache_storage_prefetch_policy not in allowed:

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -106,15 +106,10 @@ class HiRadixCache(RadixCache):
         self.pp_rank = params.pp_rank
         self.pp_size = params.pp_size
         self.enable_storage = server_args.hicache_storage_backend is not None
-        if self.enable_storage and self.pp_size > 1:
-            # Storage keys are pp-scoped, so stages hit independently; this
-            # cache has no cross-PP reconciliation of the prefetched length, so
-            # host trees fork per stage. Only UnifiedRadixCache
-            # (SGLANG_ENABLE_UNIFIED_RADIX_TREE=1) reconciles. Degrade instead
-            # of crashing: run without the storage tier.
+        if server_args.hicache_storage_backend == "eic" and self.pp_size > 1:
             logger.error(
-                "hicache_storage_backend with pipeline parallelism requires the "
-                "unified radix tree (SGLANG_ENABLE_UNIFIED_RADIX_TREE=1); "
+                "eic hicache_storage_backend with pipeline parallelism requires "
+                "the unified radix tree (SGLANG_ENABLE_UNIFIED_RADIX_TREE=1); "
                 "disabling the storage tier"
             )
             self.enable_storage = False

--- a/python/sglang/srt/mem_cache/pp_reconcile.py
+++ b/python/sglang/srt/mem_cache/pp_reconcile.py
@@ -1,0 +1,156 @@
+"""PP-consistent per-request verdicts for storage prefetch.
+
+Storage keys are pp-scoped, so pipeline stages hit independently and the same
+request can resolve to a different prefetch length per stage, forking the
+admitted prefix. Stages report their local result UP through the default
+process group's TCPStore (non-collective KV RPCs, so PP0 polling is not a p2p
+receive); PP0 forms the MIN once every stage answered. Delivery DOWN rides the
+tensor loading_check already _pp_syncs -- adding a second receive chain at that
+site deadlocks against the pipeline's own sends.
+
+This owns pairing, verdict formation and GC; the caller owns transport DOWN.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import pickle
+
+logger = logging.getLogger(__name__)
+
+
+class PPReconciler:
+    VERDICT_CAP = 32
+    EPOCH_CAP = 65536
+    TOMBSTONE_TTL = 4096
+    GC_AGE = 8192
+    SWEEP_EVERY = 1024
+
+    def __init__(self, prefix, pp_rank, pp_size, pp_group, rank):
+        self.prefix = prefix
+        self.pp_rank = pp_rank
+        self.pp_size = pp_size
+        self.pp_group = pp_group
+        self.rank = rank
+
+        self.round = 0
+        self._store_handle = None
+        self._pub_seq = 0
+        self._next_seq = {}
+        self._outbox = {}
+        self._reports = {}
+        self._verdicts = []
+        self._tombstone = {}
+        self._epoch = {}
+
+    @property
+    def enabled(self):
+        return self.pp_size > 1 and self.pp_group is not None
+
+    @property
+    def store(self):
+        if self._store_handle is None:
+            from torch.distributed import distributed_c10d
+
+            self._store_handle = distributed_c10d._get_default_store()
+        return self._store_handle
+
+    @staticmethod
+    def rid_hash(rid):
+        # hash() is per-process salted, so it is not PP-uniform.
+        return int.from_bytes(
+            hashlib.blake2b(rid.encode(), digest_size=7).digest(), "big"
+        )
+
+    def bump_epoch(self, rid):
+        # Clients may reuse a rid after an abort; a never-reused ordinal keeps a
+        # straggler from pairing with the fresh incarnation.
+        epoch = self._epoch.pop(rid, 0) + 1
+        self._epoch[rid] = epoch
+        while len(self._epoch) > self.EPOCH_CAP:
+            self._epoch.pop(next(iter(self._epoch)))
+        return epoch
+
+    def report(self, h, epoch, value):
+        if not self.enabled or self.rank != 0:
+            return
+        if self.pp_rank == 0:
+            self._reports.setdefault((h, epoch), ({}, self.round))[0][0] = value
+        else:
+            self._outbox[(h, epoch)] = value
+
+    def release(self, h, epoch):
+        if not self.enabled:
+            return
+        self._tombstone[h] = (epoch, self.round + self.TOMBSTONE_TTL)
+        self._outbox = {k: v for k, v in self._outbox.items() if k[0] != h}
+        self._reports = {k: v for k, v in self._reports.items() if k[0] != h}
+        self._verdicts = [v for v in self._verdicts if v[0] != h]
+
+    def collect(self):
+        """One round on tp0. PP0 returns up to VERDICT_CAP (h, epoch, min) rows;
+        other stages publish their outbox and return []."""
+        self.round += 1
+        if not self.enabled or self.rank != 0:
+            return []
+        if self.pp_rank != 0:
+            self._publish()
+            rows = []
+        else:
+            self._drain_peers()
+            self._form()
+            rows = self._verdicts[: self.VERDICT_CAP]
+            del self._verdicts[: len(rows)]
+        if self.round % self.SWEEP_EVERY == 0:
+            self._sweep()
+        return rows
+
+    def _form(self):
+        for key, (stages, _) in list(self._reports.items()):
+            if len(stages) < self.pp_size:
+                continue
+            del self._reports[key]
+            self._verdicts.append((*key, min(stages.values())))
+
+    def _publish(self):
+        if not self._outbox:
+            return
+        self.store.set(
+            f"{self.prefix}/{self.pp_rank}/{self._pub_seq}", pickle.dumps(self._outbox)
+        )
+        self._pub_seq += 1  # only after a successful set, so there are no holes
+        self._outbox = {}
+
+    def _drain_peers(self):
+        for stage in range(1, self.pp_size):
+            seq = self._next_seq.get(stage, 0)
+            while self.store.check([f"{self.prefix}/{stage}/{seq}"]):
+                key = f"{self.prefix}/{stage}/{seq}"
+                batch = pickle.loads(self.store.get(key))
+                self.store.delete_key(key)
+                seq += 1
+                for (h, epoch), value in batch.items():
+                    tomb = self._tombstone.get(h)
+                    # A re-gate of the same rid carries a higher epoch and must
+                    # pass, or that retry wedges forever.
+                    if tomb is not None and epoch <= tomb[0]:
+                        continue
+                    self._reports.setdefault((h, epoch), ({}, self.round))[0][
+                        stage
+                    ] = value
+            self._next_seq[stage] = seq
+
+    def _sweep(self):
+        for h, (_, expiry) in list(self._tombstone.items()):
+            if expiry <= self.round:
+                del self._tombstone[h]
+        horizon = self.round - self.GC_AGE
+        for key, (stages, born) in list(self._reports.items()):
+            if born < horizon:
+                del self._reports[key]
+                logger.warning(
+                    "pp reconcile: dropped report %s, missing stages %s",
+                    key,
+                    sorted(set(range(self.pp_size)) - set(stages)),
+                )

--- a/python/sglang/srt/mem_cache/storage/eic/eic_storage.py
+++ b/python/sglang/srt/mem_cache/storage/eic/eic_storage.py
@@ -269,6 +269,8 @@ class EICStorage(HiCacheStorage):
         self.is_mla_model = hicache_config.is_mla_model
         self.rank = hicache_config.tp_rank
         self.world_size = hicache_config.tp_size
+        self.pp_rank = hicache_config.pp_rank
+        self.pp_size = hicache_config.pp_size
         self.page_size = self.memory_pool_host.page_size
         self.registered_pools = {}
         self.logical_anchor = self.memory_pool_host.kv_buffer is None
@@ -350,12 +352,16 @@ class EICStorage(HiCacheStorage):
         self._register_tensors(self._pool_buffers(host_pool))
 
     def _init_eic_prefix(self):
+        # Same content hash means different bytes per stage; without this the
+        # stages overwrite each other's KV. Suffix only when pp_size > 1 so
+        # existing single-stage keys stay valid.
+        pp = f"_pp{self.pp_size}_{self.pp_rank}" if self.pp_size > 1 else ""
         if self.is_mla_model:
             self.eic_prefix = (
-                f"{self.model_name}_mla_att_{self.host_kvcache_layout}@sglang"
+                f"{self.model_name}_mla_att_{self.host_kvcache_layout}{pp}@sglang"
             )
         else:
-            self.eic_prefix = f"{self.model_name}_mha_attn_{self.host_kvcache_layout}_{self.rank}_{self.world_size}_@sglang"
+            self.eic_prefix = f"{self.model_name}_mha_attn_{self.host_kvcache_layout}_{self.rank}_{self.world_size}{pp}_@sglang"
 
     def _get_eic_key(self, keys: List[str]) -> str:
         return [f"{self.eic_prefix}_{key}" for key in keys]

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -33,6 +33,7 @@ from sglang.srt.mem_cache.hicache_storage import (
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
+from sglang.srt.mem_cache.pp_reconcile import PPReconciler
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.unified_cache_components import (
     _NUM_COMPONENT_TYPES,
@@ -421,6 +422,15 @@ class UnifiedRadixCache(BasePrefixCache):
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
         self.ongoing_prefetch: dict = {}
         self.ongoing_backup: dict = {}
+        self._pp_prefetch_gate: dict = {}
+        self._pp_prefetch_verdict: dict = {}
+        self._pp_prefetch = PPReconciler(
+            prefix="hipf",
+            pp_rank=self.pp_rank,
+            pp_size=self.pp_size,
+            pp_group=self.pp_group,
+            rank=self.tp_group.rank() if self.tp_group is not None else 0,
+        )
 
         if self.cache_controller is not None:
             self.cache_controller.reset()
@@ -1849,9 +1859,67 @@ class UnifiedRadixCache(BasePrefixCache):
         return can_terminate or operation_terminated
 
     def check_prefetch_progress(self, req_id: str) -> bool:
-        if req_id not in self.ongoing_prefetch:
-            return True
+        if not self._pp_prefetch.enabled:
+            local = self._prefetch_local_result(req_id)
+            if local is None:
+                return False
+            if local[0] is None:
+                return True
+            return self._commit_prefetch(req_id, local[0], local[0], local[1])
+        return self._check_prefetch_progress_pp(req_id)
 
+    def _prefetch_local_result(self, req_id: str):
+        """(completed_tokens, hash_value) once this stage is done, else None.
+
+        completed_tokens is None when the stage has nothing to commit at all.
+        """
+        if req_id not in self.ongoing_prefetch:
+            return (None, None)
+        operation = self.ongoing_prefetch[req_id][3]
+        if operation.host_indices is None:
+            return (None, None)
+        if not self.can_terminate_prefetch(operation):
+            return None
+
+        completed_tokens, hash_value = self.cache_controller.terminate_prefetch(
+            operation
+        )
+        if self.tp_world_size > 1:
+            tensor = torch.tensor(completed_tokens, dtype=torch.int)
+            torch.distributed.all_reduce(
+                tensor, op=torch.distributed.ReduceOp.MIN, group=self.tp_group
+            )
+            completed_tokens = int(tensor.item())
+        return (completed_tokens, hash_value)
+
+    def _check_prefetch_progress_pp(self, req_id: str) -> bool:
+        # Terminate locally before reporting: that is what makes the free safe.
+        h = PPReconciler.rid_hash(req_id)
+        st = self._pp_prefetch_gate.get(req_id)
+        if st is None:
+            local = self._prefetch_local_result(req_id)
+            if local is None:
+                return False
+            epoch = self._pp_prefetch.bump_epoch(req_id)
+            st = {"epoch": epoch, "completed": local[0], "hash_value": local[1]}
+            self._pp_prefetch_gate[req_id] = st
+            self._pp_prefetch.report(h, epoch, local[0] if local[0] is not None else 0)
+
+        verdict = self._pp_prefetch_verdict.pop((h, st["epoch"]), None)
+        if verdict is None:
+            return False
+        del self._pp_prefetch_gate[req_id]
+        if st["completed"] is None:
+            return True
+        return self._commit_prefetch(
+            req_id, min(verdict, st["completed"]), st["completed"], st["hash_value"]
+        )
+
+    def _commit_prefetch(
+        self, req_id: str, min_completed_tokens: int, completed_tokens: int, hash_value
+    ) -> bool:
+        if req_id not in self.ongoing_prefetch:
+            return True  # revoked while the verdict was in flight
         (
             last_host_node,
             prefetch_key,
@@ -1860,25 +1928,6 @@ class UnifiedRadixCache(BasePrefixCache):
             anchor_lock_params,
             comp_xfers,
         ) = self.ongoing_prefetch[req_id]
-        if operation.host_indices is None:
-            return True
-        if not self.can_terminate_prefetch(operation):
-            return False
-
-        completed_tokens, hash_value = self.cache_controller.terminate_prefetch(
-            operation
-        )
-        min_completed_tokens = completed_tokens
-        if self.tp_world_size > 1:
-            completed_tokens_tensor = torch.tensor(
-                min_completed_tokens, dtype=torch.int
-            )
-            torch.distributed.all_reduce(
-                completed_tokens_tensor,
-                op=torch.distributed.ReduceOp.MIN,
-                group=self.tp_group,
-            )
-            min_completed_tokens = int(completed_tokens_tensor.item())
 
         fetched_key = prefetch_key[:min_completed_tokens]
         insert_result = self._insert_helper_host(
@@ -1934,8 +1983,17 @@ class UnifiedRadixCache(BasePrefixCache):
     def pop_prefetch_loaded_tokens(self, req_id: str) -> int:
         return self.prefetch_loaded_tokens_by_reqid.pop(req_id, 0)
 
+    def _release_pp_prefetch(self, rid: str) -> None:
+        st = self._pp_prefetch_gate.pop(rid, None)
+        if st is None:
+            return
+        h = PPReconciler.rid_hash(rid)
+        self._pp_prefetch_verdict.pop((h, st["epoch"]), None)
+        self._pp_prefetch.release(h, st["epoch"])
+
     def release_aborted_request(self, rid: str) -> None:
         self.prefetch_loaded_tokens_by_reqid.pop(rid, None)
+        self._release_pp_prefetch(rid)
         if rid not in self.ongoing_prefetch:
             return
 
@@ -2235,9 +2293,14 @@ class UnifiedRadixCache(BasePrefixCache):
                     break
                 finish_count += 1
 
-        finish_count_tensor = torch.tensor(finish_count, dtype=torch.int, device="cpu")
-        self._all_reduce(finish_count_tensor, torch.distributed.ReduceOp.MIN)
-        finish_count = int(finish_count_tensor.item())
+        if self._pp_prefetch.enabled:
+            finish_count = self._loading_check_pp(finish_count)
+        else:
+            finish_count_tensor = torch.tensor(
+                finish_count, dtype=torch.int, device="cpu"
+            )
+            self._all_reduce(finish_count_tensor, torch.distributed.ReduceOp.MIN)
+            finish_count = int(finish_count_tensor.item())
 
         while finish_count > 0:
             _, finish_event, ack_list = cc.ack_load_queue.pop(0)
@@ -2247,6 +2310,31 @@ class UnifiedRadixCache(BasePrefixCache):
                 self.dec_lock_ref(node, lock_params)
                 self.dec_host_lock_ref(node, host_lock_params)
             finish_count -= 1
+
+    def _loading_check_pp(self, finish_count: int) -> int:
+        # Prefetch verdicts ride the tensor loading_check already _pp_syncs; a
+        # second receive chain at this site deadlocks against the pipeline's
+        # own sends (PP0 waits in _pp_commit_comm_work for a recv the next
+        # stage only reaches after finishing this call).
+        cap = PPReconciler.VERDICT_CAP
+        buf = torch.zeros(2 + cap * 3, dtype=torch.int64, device="cpu")
+        rows = self._pp_prefetch.collect()
+        if self.pp_rank == 0:
+            count = torch.tensor(finish_count, dtype=torch.int, device="cpu")
+            self._all_reduce_attn_groups(count, torch.distributed.ReduceOp.MIN)
+            buf[0] = int(count.item())
+            buf[1] = len(rows)
+            for i, row in enumerate(rows):
+                buf[2 + i * 3 : 5 + i * 3] = torch.tensor(row, dtype=torch.int64)
+            if self.tp_world_size > 1:
+                torch.distributed.broadcast(buf, group=self.tp_group, group_src=0)
+        self._pp_sync(buf)
+        for i in range(int(buf[1].item())):
+            h, epoch, value = (int(x) for x in buf[2 + i * 3 : 5 + i * 3])
+            self._pp_prefetch_verdict[(h, epoch)] = value
+        while len(self._pp_prefetch_verdict) > PPReconciler.EPOCH_CAP:
+            self._pp_prefetch_verdict.pop(next(iter(self._pp_prefetch_verdict)))
+        return int(buf[0].item())
 
     # ---- HiCache: Scheduler Entry Points ----
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -35,7 +35,7 @@ from sglang.srt.mem_cache.hicache_storage import (
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
-from sglang.srt.mem_cache.pp_reconcile import PPReconciler
+from sglang.srt.mem_cache.eic_pp_reconcile import EICPPReconciler
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.unified_cache_components import (
     _NUM_COMPONENT_TYPES,
@@ -426,7 +426,7 @@ class UnifiedRadixCache(BasePrefixCache):
         self.ongoing_backup: dict = {}
         self._pp_prefetch_gate: dict = {}
         self._pp_prefetch_verdict: dict = {}
-        self._pp_prefetch = PPReconciler(
+        self._pp_prefetch = EICPPReconciler(
             prefix="hipf",
             pp_rank=self.pp_rank,
             pp_size=self.pp_size,
@@ -456,12 +456,7 @@ class UnifiedRadixCache(BasePrefixCache):
             attach_hybrid_pool_to_unified_cache,
         )
 
-        if server_args.hicache_storage_backend is not None and self.pp_size > 1:
-            # The prefetch verdict admits every request in the same round on
-            # every stage; anything that lets stages act on private state
-            # breaks that. LPM reorders the queue per local tree, and the
-            # waiting timeout aborts on per-stage clocks. Degrade instead of
-            # crashing: run without the storage tier.
+        if server_args.hicache_storage_backend == "eic" and self.pp_size > 1:
             reason = None
             if server_args.schedule_policy != "fcfs":
                 reason = "--schedule-policy must be fcfs"
@@ -474,12 +469,13 @@ class UnifiedRadixCache(BasePrefixCache):
                 )
             if reason is not None:
                 logger.error(
-                    "hicache_storage_backend under PP: %s; disabling the "
+                    "eic hicache_storage_backend under PP: %s; disabling the "
                     "storage tier",
                     reason,
                 )
                 server_args = copy.copy(server_args)
                 server_args.hicache_storage_backend = None
+        self._pp_prefetch.eic = server_args.hicache_storage_backend == "eic"
 
         # Direct IO layout fixup (must happen before pool creation)
         if server_args.hicache_io_backend == "direct":
@@ -1921,7 +1917,7 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def _check_prefetch_progress_pp(self, req_id: str) -> bool:
         # Terminate locally before reporting: that is what makes the free safe.
-        h = PPReconciler.rid_hash(req_id)
+        h = EICPPReconciler.rid_hash(req_id)
         st = self._pp_prefetch_gate.get(req_id)
         if st is None:
             local = self._prefetch_local_result(req_id)
@@ -2014,7 +2010,7 @@ class UnifiedRadixCache(BasePrefixCache):
         st = self._pp_prefetch_gate.pop(rid, None)
         if st is None:
             return
-        h = PPReconciler.rid_hash(rid)
+        h = EICPPReconciler.rid_hash(rid)
         self._pp_prefetch_verdict.pop((h, st["epoch"]), None)
         self._pp_prefetch.release(h, st["epoch"])
 
@@ -2343,7 +2339,7 @@ class UnifiedRadixCache(BasePrefixCache):
         # second receive chain at this site deadlocks against the pipeline's
         # own sends (PP0 waits in _pp_commit_comm_work for a recv the next
         # stage only reaches after finishing this call).
-        cap = PPReconciler.VERDICT_CAP
+        cap = EICPPReconciler.VERDICT_CAP
         buf = torch.zeros(2 + cap * 3, dtype=torch.int64, device="cpu")
         rows = self._pp_prefetch.collect()
         if self.pp_rank == 0:
@@ -2359,7 +2355,7 @@ class UnifiedRadixCache(BasePrefixCache):
         for i in range(int(buf[1].item())):
             h, epoch, value = (int(x) for x in buf[2 + i * 3 : 5 + i * 3])
             self._pp_prefetch_verdict[(h, epoch)] = value
-        while len(self._pp_prefetch_verdict) > PPReconciler.EPOCH_CAP:
+        while len(self._pp_prefetch_verdict) > EICPPReconciler.EPOCH_CAP:
             self._pp_prefetch_verdict.pop(next(iter(self._pp_prefetch_verdict)))
         return int(buf[0].item())
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import logging
-import os
 import threading
 import time
 from collections import defaultdict
@@ -35,7 +34,10 @@ from sglang.srt.mem_cache.hicache_storage import (
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
-from sglang.srt.mem_cache.eic_pp_reconcile import EICPPReconciler
+from sglang.srt.mem_cache.eic_pp_reconcile import (
+    EICPPReconciler,
+    eic_pp_unsupported_reason,
+)
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.unified_cache_components import (
     _NUM_COMPONENT_TYPES,
@@ -457,16 +459,7 @@ class UnifiedRadixCache(BasePrefixCache):
         )
 
         if server_args.hicache_storage_backend == "eic" and self.pp_size > 1:
-            reason = None
-            if server_args.schedule_policy != "fcfs":
-                reason = "--schedule-policy must be fcfs"
-            elif server_args.enable_dp_attention:
-                reason = "dp_attention is incompatible"
-            elif float(os.getenv("SGLANG_REQ_WAITING_TIMEOUT", "-1")) > 0:
-                reason = (
-                    "SGLANG_REQ_WAITING_TIMEOUT must be unset (per-stage "
-                    "clocks release out of lockstep)"
-                )
+            reason = eic_pp_unsupported_reason(server_args)
             if reason is not None:
                 logger.error(
                     "eic hicache_storage_backend under PP: %s; disabling the "
@@ -2339,21 +2332,19 @@ class UnifiedRadixCache(BasePrefixCache):
         # second receive chain at this site deadlocks against the pipeline's
         # own sends (PP0 waits in _pp_commit_comm_work for a recv the next
         # stage only reaches after finishing this call).
-        cap = EICPPReconciler.VERDICT_CAP
-        buf = torch.zeros(2 + cap * 3, dtype=torch.int64, device="cpu")
+        buf = torch.zeros(
+            2 + EICPPReconciler.VERDICT_CAP * 3, dtype=torch.int64, device="cpu"
+        )
         rows = self._pp_prefetch.collect()
         if self.pp_rank == 0:
             count = torch.tensor(finish_count, dtype=torch.int, device="cpu")
             self._all_reduce_attn_groups(count, torch.distributed.ReduceOp.MIN)
             buf[0] = int(count.item())
-            buf[1] = len(rows)
-            for i, row in enumerate(rows):
-                buf[2 + i * 3 : 5 + i * 3] = torch.tensor(row, dtype=torch.int64)
+            EICPPReconciler.pack_rows(rows, buf, 1)
             if self.tp_world_size > 1:
                 torch.distributed.broadcast(buf, group=self.tp_group, group_src=0)
         self._pp_sync(buf)
-        for i in range(int(buf[1].item())):
-            h, epoch, value = (int(x) for x in buf[2 + i * 3 : 5 + i * 3])
+        for h, epoch, value in EICPPReconciler.unpack_rows(buf, 1):
             self._pp_prefetch_verdict[(h, epoch)] = value
         while len(self._pp_prefetch_verdict) > EICPPReconciler.EPOCH_CAP:
             self._pp_prefetch_verdict.pop(next(iter(self._pp_prefetch_verdict)))

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2332,9 +2332,7 @@ class UnifiedRadixCache(BasePrefixCache):
         # second receive chain at this site deadlocks against the pipeline's
         # own sends (PP0 waits in _pp_commit_comm_work for a recv the next
         # stage only reaches after finishing this call).
-        buf = torch.zeros(
-            2 + EICPPReconciler.VERDICT_CAP * 3, dtype=torch.int64, device="cpu"
-        )
+        buf = torch.zeros(EICPPReconciler.buf_len(1), dtype=torch.int64, device="cpu")
         rows = self._pp_prefetch.collect()
         if self.pp_rank == 0:
             count = torch.tensor(finish_count, dtype=torch.int, device="cpu")

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import copy
 import logging
+import os
 import threading
 import time
 from collections import defaultdict
@@ -453,6 +455,31 @@ class UnifiedRadixCache(BasePrefixCache):
         from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
             attach_hybrid_pool_to_unified_cache,
         )
+
+        if server_args.hicache_storage_backend is not None and self.pp_size > 1:
+            # The prefetch verdict admits every request in the same round on
+            # every stage; anything that lets stages act on private state
+            # breaks that. LPM reorders the queue per local tree, and the
+            # waiting timeout aborts on per-stage clocks. Degrade instead of
+            # crashing: run without the storage tier.
+            reason = None
+            if server_args.schedule_policy != "fcfs":
+                reason = "--schedule-policy must be fcfs"
+            elif server_args.enable_dp_attention:
+                reason = "dp_attention is incompatible"
+            elif float(os.getenv("SGLANG_REQ_WAITING_TIMEOUT", "-1")) > 0:
+                reason = (
+                    "SGLANG_REQ_WAITING_TIMEOUT must be unset (per-stage "
+                    "clocks release out of lockstep)"
+                )
+            if reason is not None:
+                logger.error(
+                    "hicache_storage_backend under PP: %s; disabling the "
+                    "storage tier",
+                    reason,
+                )
+                server_args = copy.copy(server_args)
+                server_args.hicache_storage_backend = None
 
         # Direct IO layout fixup (must happen before pool creation)
         if server_args.hicache_io_backend == "direct":

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -690,6 +690,46 @@ class TestEICHiCacheRegression(unittest.TestCase):
         with self.assertRaises(AssertionError):
             EICPagedHiRadixCache._finalize_load_admit(s, req)
 
+    def _make_load_controller(self, page_data):
+        cc = object.__new__(EICCacheController)
+        cc.tp_world_size = 1
+        cc.page_size = 4
+        cc.ack_load_queue = Queue()
+        cc.mem_pool_host = SimpleNamespace(
+            get_page_data=mock.Mock(side_effect=page_data)
+        )
+        return cc
+
+    def _load_op(self):
+        op = object.__new__(EICCacheOperation)
+        op.node_id = 7
+        op.content_hash = ["h0", "h1", "h2"]
+        op.host_indices = torch.arange(12, dtype=torch.int64)
+        op.device_indices = torch.arange(12, dtype=torch.int64)
+        return op
+
+    def test_load_acks_zero_when_backend_raises(self):
+        # A missing ack strands the request holding its KV until abort, and
+        # under PP it also blocks the verdict for every other stage.
+        cc = self._make_load_controller(RuntimeError("eic client blew up"))
+        EICCacheController.load_operation_shared(cc, self._load_op())
+        self.assertEqual(cc.ack_load_queue.get_nowait(), (7, 0))
+
+    def test_short_all_true_mask_is_not_full_success(self):
+        # The backend bails out early on failure, returning fewer mask entries
+        # than pages; all(mask) would read that as a complete hit.
+        cc = self._make_load_controller([[True]])
+        EICCacheController.load_operation_shared(cc, self._load_op())
+        self.assertEqual(cc.ack_load_queue.get_nowait(), (7, 4))
+
+        cc = self._make_load_controller([[]])
+        EICCacheController.load_operation_shared(cc, self._load_op())
+        self.assertEqual(cc.ack_load_queue.get_nowait(), (7, 0))
+
+    def test_full_mask_acks_every_token(self):
+        cc = self._make_load_controller([[True, True, True]])
+        EICCacheController.load_operation_shared(cc, self._load_op())
+        self.assertEqual(cc.ack_load_queue.get_nowait(), (7, 12))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -11,7 +11,7 @@ from sglang.srt.managers.eic_cache_controller import (
     EICCacheOperation,
 )
 from sglang.srt.mem_cache.eic_chunk_cache import EICChunkCache
-from sglang.srt.mem_cache.pp_reconcile import PPReconciler
+from sglang.srt.mem_cache.eic_pp_reconcile import EICPPReconciler
 from sglang.srt.mem_cache.eic_hiradix_cache import EICPagedHiRadixCache
 from sglang.srt.mem_cache.unified_cache_components import ComponentType
 from sglang.srt.mem_cache.unified_radix_cache import UnifiedTreeNode
@@ -732,16 +732,17 @@ class TestEICHiCacheRegression(unittest.TestCase):
         EICCacheController.load_operation_shared(cc, self._load_op())
         self.assertEqual(cc.ack_load_queue.get_nowait(), (7, 12))
     def _make_reconciler(self, pp_rank, store, pp_size=2):
-        r = PPReconciler(
+        r = EICPPReconciler(
             prefix="hipf", pp_rank=pp_rank, pp_size=pp_size, pp_group=object(), rank=0
         )
+        r.eic = True
         r._store_handle = store
         return r
 
     def test_reconciler_min_across_stages(self):
         store = self.FakeStore()
         s0, s1 = self._make_reconciler(0, store), self._make_reconciler(1, store)
-        h = PPReconciler.rid_hash("r")
+        h = EICPPReconciler.rid_hash("r")
         s0.report(h, 1, 512)
         s1.report(h, 1, 256)
         self.assertEqual(s1.collect(), [])
@@ -749,13 +750,13 @@ class TestEICHiCacheRegression(unittest.TestCase):
 
     def test_reconciler_waits_for_every_stage(self):
         s0 = self._make_reconciler(0, self.FakeStore())
-        s0.report(PPReconciler.rid_hash("r"), 1, 512)
+        s0.report(EICPPReconciler.rid_hash("r"), 1, 512)
         self.assertEqual(s0.collect(), [])
 
     def test_reconciler_tombstone_is_epoch_aware(self):
         store = self.FakeStore()
         s0, s1 = self._make_reconciler(0, store), self._make_reconciler(1, store)
-        h = PPReconciler.rid_hash("r")
+        h = EICPPReconciler.rid_hash("r")
         s0.release(h, 1)
         s1.report(h, 1, 256)
         s1.report(h, 2, 128)

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -19,6 +19,15 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="stage-a-test-cpu")
 
 
+class FakeTreeNode:
+    # Minimal radix node for the finalize last_node walk: len(key), value (None ==
+    # evicted), parent. Depth bookkeeping uses the sum of key lengths on the path.
+    def __init__(self, key_len: int, resident: bool, parent):
+        self.key = list(range(key_len))
+        self.value = [0] if resident else None
+        self.parent = parent
+
+
 class FakeHostPool:
     def alloc(self, size: int):
         return torch.arange(size, dtype=torch.int32)
@@ -286,6 +295,85 @@ class TestEICHiCacheRegression(unittest.TestCase):
             t = torch.tensor(8, dtype=torch.int64)
             EICPagedHiRadixCache._pp_bcast_from_first(c1, t)
         self.assertEqual(t.item(), 3)
+
+
+    def test_loading_check_single_stage_reconciles_locally(self):
+        # With one PP stage the local_actual is already global.
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.pp_size, cache.pp_group = 1, None
+        cache.pending_report = {}
+        cache._admit_verdict = {}
+        cache._drain_local_acks = lambda: cache.pending_report.update({10: 8})
+        EICPagedHiRadixCache.loading_check(cache)
+        self.assertEqual(cache._admit_verdict, {10: 8})
+        self.assertEqual(cache.pending_report, {})
+
+    def test_finalize_cross_pp_clamp_keeps_spanning_resident_last_node(self):
+        # Device-only warm req, cross-PP MIN 10 lands MID-node (below this stage's
+        # device match 12). last_node must stay the resident node SPANNING depth 10
+        # (bottom 12 >= 10) so inc_lock_ref protects every slot the req reads.
+        cache = object.__new__(EICPagedHiRadixCache)
+        root = FakeTreeNode(0, True, None)
+        cache.root_node = root
+        node_a = FakeTreeNode(8, True, root)  # covers (0, 8]
+        node_b = FakeTreeNode(4, True, node_a)  # covers (8, 12], spans clamp 10
+        req = mock.Mock()
+        req.rid = "r0"
+        req.prefix_indices = torch.arange(12, dtype=torch.int64)
+        req.fill_ids = list(range(20))
+        req.last_node = node_b
+        cache.ongoing_load_admit = {
+            "r0": {
+                "h": 7,
+                "new_indices": None,
+                "node_id": None,
+                "device_match": 12,
+                "complete": None,
+            }
+        }
+        cache._admit_verdict = {7: 10}
+        ok = EICPagedHiRadixCache._finalize_load_admit(cache, req)
+        self.assertTrue(ok)
+        self.assertEqual(len(req.prefix_indices), 10)
+        self.assertIs(req.last_node, node_b)  # spanning resident node kept
+        req.set_extend_input_len.assert_called_once_with(20 - 10)
+        self.assertEqual(req._eic_loaded_len, 0)
+        self.assertEqual(cache.ongoing_load_admit, {})
+        self.assertEqual(cache._admit_verdict, {})
+
+    def test_finalize_partial_load_lands_on_resident_not_evicted_tail(self):
+        # Partial load-back (loaded 10 < host_hit 16): the failed tail node is
+        # evicted. last_node must land on the deepest RESIDENT node at depth 14
+        # (device 4 + loaded 10), NOT the evicted tail the walk skips over.
+        cache = object.__new__(EICPagedHiRadixCache)
+        root = FakeTreeNode(0, True, None)
+        cache.root_node = root
+        node_a = FakeTreeNode(4, True, root)  # device match, (0, 4]
+        node_c = FakeTreeNode(10, True, node_a)  # loaded host, (4, 14]
+        node_d = FakeTreeNode(6, False, node_c)  # failed tail, evicted, (14, 20]
+        req = mock.Mock()
+        req.rid = "r1"
+        req.prefix_indices = torch.arange(4, dtype=torch.int64)
+        req.fill_ids = list(range(20))
+        req.last_node = node_d
+        cache.ongoing_load_admit = {
+            "r1": {
+                "h": 9,
+                "new_indices": torch.arange(100, 116, dtype=torch.int64),  # 16 slots
+                "node_id": 55,
+                "device_match": 4,
+                "complete": 10,
+            }
+        }
+        cache._admit_verdict = {9: 14}  # no cross-PP clamp below the loaded length
+        cache._free_failed_loadback = lambda nid, c: None  # tree already reflects free
+        ok = EICPagedHiRadixCache._finalize_load_admit(cache, req)
+        self.assertTrue(ok)
+        self.assertEqual(len(req.prefix_indices), 14)  # 4 device + 10 loaded
+        self.assertEqual(req.prefix_indices[4:].tolist(), list(range(100, 110)))
+        self.assertIs(req.last_node, node_c)  # resident node at depth 14, not node_d
+        req.set_extend_input_len.assert_called_once_with(20 - 14)
+        self.assertEqual(req._eic_loaded_len, 10)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -33,6 +33,9 @@ class TestEICHiCacheRegression(unittest.TestCase):
     def test_match_from_remote_skips_zero_committed_tokens(self):
         cache = object.__new__(EICPagedHiRadixCache)
         cache.match_req_set = []
+        cache.tp_size = 1
+        cache.pp_size = 1
+        cache.pp_group = None
         cache.cache_controller = mock.Mock()
         cache._match_for_remote_fetch = mock.Mock(
             side_effect=AssertionError("empty remote key should be skipped")
@@ -50,6 +53,56 @@ class TestEICHiCacheRegression(unittest.TestCase):
         cache._match_for_remote_fetch.assert_not_called()
         cache.cache_controller.batch_find_longest_prefix_in_eic.assert_not_called()
         self.assertEqual(cache.match_req_set, [])
+
+    def test_match_from_remote_gates_and_indexes_by_queue(self):
+        # match_from_remote first MIN-reduces the queue length (num_ready gate),
+        # then reduces a vector indexed by queue position -- both PP-invariant
+        # lengths. Here we capture the CP/TP reduce (PP uses p2p, tested
+        # separately); the shapes are what keep the reduces in lockstep.
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.match_req_set = []
+        cache.tp_size = 2
+        cache.tp_group = object()
+        cache.pp_size = 1
+        cache.pp_group = None
+        cache.page_size = 1
+        cache.load_remote_threshold = 1
+        cache.eic_check_max_num = 0
+        cache.root_node = object()
+        cache._insert_remote_node = mock.Mock()
+        node = SimpleNamespace(id=1, content_hash=None)
+
+        # Fetch only the middle req; the others' prefix already covers the key.
+        def match(root, key):
+            match.i += 1
+            return (0, 0, node) if match.i == 2 else (len(key), 0, node)
+
+        match.i = 0
+        cache._match_for_remote_fetch = match
+        cache.cache_controller = mock.Mock()
+        cache.cache_controller.batch_find_longest_prefix_in_eic.return_value = [8]
+        reqs = [
+            mock.Mock(rid=r, origin_input_ids=list(range(8)), output_ids=[9], extra_key=None)
+            for r in ("a", "b", "c")
+        ]
+
+        captured = []
+
+        def fake_all_reduce(t, op=None, group=None):
+            if group is cache.tp_group:
+                captured.append(t.tolist())
+
+        with mock.patch(
+            "sglang.srt.mem_cache.eic_hiradix_cache._need_calculate_hash",
+            return_value=False,
+        ), mock.patch.object(
+            torch.distributed, "all_reduce", side_effect=fake_all_reduce
+        ):
+            EICPagedHiRadixCache.match_from_remote(cache, reqs)
+
+        # First the num_ready gate (scalar == queue length), then the per-slot
+        # vector (length == queue, only the fetched middle slot carries the hit).
+        self.assertEqual(captured, [3, [0, 8, 0]])
 
     def test_eic_controller_write_uses_queue_api(self):
         controller = object.__new__(EICCacheController)
@@ -186,44 +239,53 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(sorted(freed.tolist()), [512, 768])
 
 
-    def test_loading_check_reduces_load_back_across_pp(self):
-        # PP stages store their layers' KV in distinct EIC namespaces, so a
-        # shared node can load back a different token count per stage. Without a
-        # PP-group MIN on both the drain count and complete_token, the radix
-        # tree truncates differently per stage and the admitted extend_len
-        # diverges -> fused_q_norm_rope batch_size crash. Assert both are
-        # reduced over pp_group with MIN.
+    def test_pp_bcast_from_first_is_nonblocking_isend(self):
+        # PP consensus must be a non-blocking isend down the pipeline: the stages
+        # run out of phase, so a collective or a blocking send/recv (which makes
+        # one stage wait for another) deadlocks. First stage isends its value
+        # downstream (queued in work_list) and keeps it; a later stage overwrites
+        # with the upstream (PP0's) value via recv. No all_reduce anywhere.
         from sglang.srt.mem_cache.eic_hiradix_cache import EICPagedHiRadixCache
 
-        cache = object.__new__(EICPagedHiRadixCache)
-        cache.tp_group = None  # TP reduces (group=None) are ignored by the test
-        cache.pp_group = object()
-        node = SimpleNamespace()
-        cache.ongoing_load_back = {0: (node, node, 64)}  # start==end: loop is a no-op
-        q = Queue()
-        q.put((0, 64))
-        cache.cache_controller = SimpleNamespace(ack_load_queue=q)
-        cache.dec_lock_ref = lambda n: None
+        # first stage (rank 0 of 2): isend downstream, never recv
+        c0 = object.__new__(EICPagedHiRadixCache)
+        c0.pp_size, c0.pp_rank, c0.pp_group, c0.work_list = 2, 0, object(), []
+        sent = []
 
-        pp_reduces = []
-
-        def fake_all_reduce(tensor, op=None, group=None):
-            self.assertEqual(op, torch.distributed.ReduceOp.MIN)
-            if group is cache.pp_group:
-                pp_reduces.append(tensor.numel())
+        def fake_isend(t, group_dst=None, group=None, tag=None):
+            sent.append((group_dst, t.item()))
+            return "work"
 
         with mock.patch.object(
-            torch.distributed, "get_world_size", return_value=2
+            torch.distributed, "isend", side_effect=fake_isend
         ), mock.patch.object(
-            torch.distributed, "all_reduce", side_effect=fake_all_reduce
+            torch.distributed, "recv", side_effect=AssertionError("source never recvs")
+        ), mock.patch.object(
+            torch.distributed, "all_reduce", side_effect=AssertionError("no collective")
         ):
-            EICPagedHiRadixCache.loading_check(cache)
+            t = torch.tensor(5, dtype=torch.int64)
+            EICPagedHiRadixCache._pp_bcast_from_first(c0, t)
+        self.assertEqual(sent, [(1, 5)])
+        self.assertEqual(c0.work_list, ["work"])  # drained next round
+        self.assertEqual(t.item(), 5)  # authoritative source keeps its value
 
-        # Both the drain count and the complete_token vector are MIN-reduced
-        # over the PP group (each numel==1 for this single-ack case).
-        self.assertEqual(
-            pp_reduces, [1, 1], "expected drain-count + complete_token PP reduces"
-        )
+        # last stage (rank 1 of 2): recv overwrites with PP0's value, no isend
+        c1 = object.__new__(EICPagedHiRadixCache)
+        c1.pp_size, c1.pp_rank, c1.pp_group, c1.work_list = 2, 1, object(), []
+
+        def fake_recv(t, group_src=None, group=None, tag=None):
+            t.fill_(3)  # PP0's authoritative value
+
+        with mock.patch.object(
+            torch.distributed, "recv", side_effect=fake_recv
+        ), mock.patch.object(
+            torch.distributed, "isend", side_effect=AssertionError("last rank sends nothing")
+        ), mock.patch.object(
+            torch.distributed, "all_reduce", side_effect=AssertionError("no collective")
+        ):
+            t = torch.tensor(8, dtype=torch.int64)
+            EICPagedHiRadixCache._pp_bcast_from_first(c1, t)
+        self.assertEqual(t.item(), 3)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -42,7 +42,7 @@ class FakeDeviceAllocator:
 class TestEICHiCacheRegression(unittest.TestCase):
     def test_match_from_remote_skips_zero_committed_tokens(self):
         cache = object.__new__(EICPagedHiRadixCache)
-        cache.match_req_set = []
+        cache.match_req_set = {}
         cache.tp_size = 1
         cache.pp_size = 1
         cache.pp_group = None
@@ -62,7 +62,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
 
         cache._match_for_remote_fetch.assert_not_called()
         cache.cache_controller.batch_find_longest_prefix_in_eic.assert_not_called()
-        self.assertEqual(cache.match_req_set, [])
+        self.assertEqual(cache.match_req_set, {})
 
     def test_match_from_remote_gates_and_indexes_by_queue(self):
         # match_from_remote first MIN-reduces the queue length (num_ready gate),
@@ -70,7 +70,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
         # lengths. Here we capture the CP/TP reduce (PP uses p2p, tested
         # separately); the shapes are what keep the reduces in lockstep.
         cache = object.__new__(EICPagedHiRadixCache)
-        cache.match_req_set = []
+        cache.match_req_set = {}
         cache.tp_size = 2
         cache.tp_group = object()
         cache.pp_size = 1
@@ -305,7 +305,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
         cache._admit_verdict = {}
         cache._loadback_rid = {55: "r0"}
         cache.ongoing_load_admit = {
-            "r0": {"h": 10, "d": 4, "node_id": 55, "complete": None}
+            "r0": {"h": 10, "d": 4, "load_node": SimpleNamespace(id=55), "complete": None}
         }
         cache.ongoing_load_back = {}
         q = Queue()
@@ -336,7 +336,6 @@ class TestEICHiCacheRegression(unittest.TestCase):
                 "h": 7,
                 "d": 12,
                 "alloc": 0,
-                "node_id": None,
                 "load_node": None,
                 "new_indices": None,
                 "deferred_lock": node_b,
@@ -349,7 +348,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(len(req.prefix_indices), 10)
         self.assertIs(req.last_node, node_b)  # spanning resident node kept
         req.set_extend_input_len.assert_called_once_with(20 - 10)
-        self.assertEqual(req._eic_loaded_len, 0)
+        self.assertEqual(req.eic_loaded_len, 0)
         self.assertEqual(cache.ongoing_load_admit, {})
         self.assertEqual(cache._admit_verdict, {})
         self.assertEqual(cache._h_rid, {})
@@ -367,6 +366,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
         node_a = FakeTreeNode(4, True, root)  # device match, (0, 4]
         node_c = FakeTreeNode(10, True, node_a)  # loaded host, (4, 14]
         node_d = FakeTreeNode(6, False, node_c)  # failed tail, evicted, (14, 20]
+        node_d.id = 55
         req = mock.Mock()
         req.rid = "r1"
         req.prefix_indices = torch.arange(4, dtype=torch.int64)
@@ -377,7 +377,6 @@ class TestEICHiCacheRegression(unittest.TestCase):
                 "h": 9,
                 "d": 4,
                 "alloc": 16,
-                "node_id": 55,
                 "load_node": node_d,
                 "new_indices": torch.arange(100, 116, dtype=torch.int64),
                 "deferred_lock": node_a,
@@ -394,7 +393,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(req.prefix_indices[4:].tolist(), list(range(100, 110)))
         self.assertIs(req.last_node, node_c)  # resident node at depth 14, not node_d
         req.set_extend_input_len.assert_called_once_with(20 - 14)
-        self.assertEqual(req._eic_loaded_len, 10)
+        self.assertEqual(req.eic_loaded_len, 10)
 
     # ---- two-stage lockstep protocol tests --------------------------------
 
@@ -495,16 +494,12 @@ class TestEICHiCacheRegression(unittest.TestCase):
         # round 1: s1 publishes its span report; s0 sees only its own.
         EICPagedHiRadixCache.loading_check(s0)
         EICPagedHiRadixCache.loading_check(s1)
-        self.assertEqual(s0.ongoing_load_admit["req-a"]["node_id"], None)
+        self.assertEqual(s0.ongoing_load_admit["req-a"]["load_node"], None)
         # round 2: s0 drains the store, forms SPAN=16, both stages kick alloc 12.
         EICPagedHiRadixCache.loading_check(s0)
         EICPagedHiRadixCache.loading_check(s1)
         self.assertEqual(s0.ongoing_load_admit["req-a"]["alloc"], 12)
         self.assertEqual(s1.ongoing_load_admit["req-a"]["alloc"], 12)
-        self.assertEqual(
-            s0.ongoing_load_admit["req-a"]["span"],
-            s1.ongoing_load_admit["req-a"]["span"],
-        )
         # acks land: stage0 loads 12/12, stage1 only 8/12.
         s0.cache_controller.ack_load_queue.put((100, 12))
         s1.cache_controller.ack_load_queue.put((200, 8))
@@ -627,7 +622,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
         for _ in range(2):  # span verdict forms and applies -> loads kicked
             EICPagedHiRadixCache.loading_check(s0)
             EICPagedHiRadixCache.loading_check(s1)
-        self.assertEqual(s0.ongoing_load_admit["req-e"]["node_id"], 100)
+        self.assertEqual(s0.ongoing_load_admit["req-e"]["load_node"].id, 100)
         EICPagedHiRadixCache.release_load_admit(s0, "req-e")
         EICPagedHiRadixCache.release_load_admit(s1, "req-e")
         # same rid re-gates (epoch 2, no load kicked yet: node_id None)
@@ -659,7 +654,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
         )
         req = self._make_req("req-g", 4, 16, load_node_id=100)
         self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s, req))
-        self.assertEqual(s.ongoing_load_admit["req-g"]["node_id"], 100)
+        self.assertEqual(s.ongoing_load_admit["req-g"]["load_node"].id, 100)
         s.cache_controller.ack_load_queue.put((100, 10))
         EICPagedHiRadixCache.loading_check(s)
         self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s, req))
@@ -679,7 +674,6 @@ class TestEICHiCacheRegression(unittest.TestCase):
                 "h": 5,
                 "d": 4,
                 "alloc": 12,
-                "node_id": 100,
                 "load_node": node,
                 "new_indices": torch.arange(12, dtype=torch.int64),
                 "deferred_lock": node,

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -297,16 +297,22 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(t.item(), 3)
 
 
-    def test_loading_check_single_stage_reconciles_locally(self):
-        # With one PP stage the local_actual is already global.
+    def test_drain_acks_single_stage_resolves_locally(self):
+        # With one PP stage the local ack IS the verdict: d + complete.
         cache = object.__new__(EICPagedHiRadixCache)
-        cache.pp_size, cache.pp_group = 1, None
-        cache.pending_report = {}
+        cache.pp_size, cache.pp_group, cache.tp_size = 1, None, 1
         cache._admit_verdict = {}
-        cache._drain_local_acks = lambda: cache.pending_report.update({10: 8})
-        EICPagedHiRadixCache.loading_check(cache)
-        self.assertEqual(cache._admit_verdict, {10: 8})
-        self.assertEqual(cache.pending_report, {})
+        cache._loadback_rid = {55: "r0"}
+        cache.ongoing_load_admit = {
+            "r0": {"h": 10, "d": 4, "node_id": 55, "complete": None}
+        }
+        cache.ongoing_load_back = {}
+        q = Queue()
+        q.put((55, 8))
+        cache.cache_controller = SimpleNamespace(ack_load_queue=q)
+        EICPagedHiRadixCache._drain_local_acks(cache)
+        self.assertEqual(cache._admit_verdict, {10: 12})
+        self.assertEqual(cache.ongoing_load_admit["r0"]["complete"], 8)
 
     def test_finalize_cross_pp_clamp_keeps_spanning_resident_last_node(self):
         # Device-only warm req, cross-PP MIN 10 lands MID-node (below this stage's
@@ -315,6 +321,8 @@ class TestEICHiCacheRegression(unittest.TestCase):
         cache = object.__new__(EICPagedHiRadixCache)
         root = FakeTreeNode(0, True, None)
         cache.root_node = root
+        cache.dec_lock_ref = lambda node: None
+        cache._h_rid = {7: "r0"}
         node_a = FakeTreeNode(8, True, root)  # covers (0, 8]
         node_b = FakeTreeNode(4, True, node_a)  # covers (8, 12], spans clamp 10
         req = mock.Mock()
@@ -325,9 +333,12 @@ class TestEICHiCacheRegression(unittest.TestCase):
         cache.ongoing_load_admit = {
             "r0": {
                 "h": 7,
-                "new_indices": None,
+                "d": 12,
+                "alloc": 0,
                 "node_id": None,
-                "device_match": 12,
+                "load_node": None,
+                "new_indices": None,
+                "deferred_lock": node_b,
                 "complete": None,
             }
         }
@@ -340,14 +351,18 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(req._eic_loaded_len, 0)
         self.assertEqual(cache.ongoing_load_admit, {})
         self.assertEqual(cache._admit_verdict, {})
+        self.assertEqual(cache._h_rid, {})
 
     def test_finalize_partial_load_lands_on_resident_not_evicted_tail(self):
-        # Partial load-back (loaded 10 < host_hit 16): the failed tail node is
+        # Partial load-back (loaded 10 < span alloc 16): the failed tail node is
         # evicted. last_node must land on the deepest RESIDENT node at depth 14
-        # (device 4 + loaded 10), NOT the evicted tail the walk skips over.
+        # (device 4 + loaded 10), NOT the evicted tail the walk skips over; the
+        # whole [14, 20) tail is freed at the verdict boundary.
         cache = object.__new__(EICPagedHiRadixCache)
         root = FakeTreeNode(0, True, None)
         cache.root_node = root
+        cache.dec_lock_ref = lambda node: None
+        cache._h_rid = {9: "r1"}
         node_a = FakeTreeNode(4, True, root)  # device match, (0, 4]
         node_c = FakeTreeNode(10, True, node_a)  # loaded host, (4, 14]
         node_d = FakeTreeNode(6, False, node_c)  # failed tail, evicted, (14, 20]
@@ -359,21 +374,321 @@ class TestEICHiCacheRegression(unittest.TestCase):
         cache.ongoing_load_admit = {
             "r1": {
                 "h": 9,
-                "new_indices": torch.arange(100, 116, dtype=torch.int64),  # 16 slots
+                "d": 4,
+                "alloc": 16,
                 "node_id": 55,
-                "device_match": 4,
+                "load_node": node_d,
+                "new_indices": torch.arange(100, 116, dtype=torch.int64),
+                "deferred_lock": node_a,
                 "complete": 10,
             }
         }
-        cache._admit_verdict = {9: 14}  # no cross-PP clamp below the loaded length
-        cache._free_failed_loadback = lambda nid, c: None  # tree already reflects free
+        cache._admit_verdict = {9: 14}  # FINAL == this stage's loaded length
+        freed = []
+        cache._free_failed_loadback = lambda nid, c: freed.append((nid, c))
         ok = EICPagedHiRadixCache._finalize_load_admit(cache, req)
         self.assertTrue(ok)
+        self.assertEqual(freed, [(55, 10)])  # free [14, 20) at the verdict boundary
         self.assertEqual(len(req.prefix_indices), 14)  # 4 device + 10 loaded
         self.assertEqual(req.prefix_indices[4:].tolist(), list(range(100, 110)))
         self.assertIs(req.last_node, node_c)  # resident node at depth 14, not node_d
         req.set_extend_input_len.assert_called_once_with(20 - 14)
         self.assertEqual(req._eic_loaded_len, 10)
+
+    # ---- two-stage lockstep protocol tests --------------------------------
+
+    class FakeStore:
+        def __init__(self):
+            self.kv = {}
+
+        def set(self, key, value):
+            self.kv[key] = value
+
+        def get(self, key):
+            return self.kv[key]
+
+        def check(self, keys):
+            return all(k in self.kv for k in keys)
+
+        def delete_key(self, key):
+            return self.kv.pop(key, None) is not None
+
+    def _make_stage(self, pp_rank, store, dag_box, pp_size=2):
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.pp_size, cache.pp_rank = pp_size, pp_rank
+        cache.pp_group = object() if pp_size > 1 else None
+        cache.tp_size, cache.rank, cache.tp_group = 1, 0, None
+        cache.load_back_threshold = 10
+        cache.root_node = FakeTreeNode(0, True, None)
+        cache.ongoing_load_admit = {}
+        cache.ongoing_load_back = {}
+        cache._admit_verdict = {}
+        cache._h_rid = {}
+        cache._rid_epoch = {}
+        cache._loadback_rid = {}
+        cache._report_outbox = {}
+        cache._span_reports = {}
+        cache._load_reports = {}
+        cache._await_load = {}
+        cache._verdict_outbox = []
+        cache._tombstone = {}
+        cache._pub_seq = 0
+        cache._next_seq = {}
+        cache._round = 0
+        cache._store_handle = store
+        cache.locks = []
+        cache.inc_lock_ref = lambda node: cache.locks.append(node)
+        cache.dec_lock_ref = lambda node: cache.locks.remove(node)
+        cache.freed = []
+        cache._free_failed_loadback = lambda nid, c: cache.freed.append((nid, c))
+        cache._clip_host_chain = lambda node, excess, quota: node
+        if pp_rank == 0:
+            # rank0 isends: record the packed verdicts for this round.
+            cache._pp_bcast_from_first = lambda buf, tag=None: dag_box.__setitem__(
+                "buf", buf.clone()
+            )
+        else:
+            # rank>0 blocking-recv: the k-th recv pairs with the k-th send.
+            cache._pp_bcast_from_first = lambda buf, tag=None: buf.copy_(
+                dag_box["buf"]
+            )
+        q = Queue()
+        cache.cache_controller = SimpleNamespace(
+            ack_load_queue=q, mem_pool_device_allocator=SimpleNamespace()
+        )
+        return cache
+
+    def _make_req(self, rid, d, hh, load_node_id):
+        node = mock.Mock()
+        node.evicted = False
+        node.value = [1]
+        node.key = list(range(max(hh, 1)))
+        node.parent = None
+        node.id = load_node_id
+        req = mock.Mock()
+        req.rid = rid
+        req.prefix_indices = torch.arange(d, dtype=torch.int64)
+        req.fill_ids = list(range(64))
+        req.host_hit_length = hh
+        req.needs_host_load_back = lambda: hh > 0
+        req.best_match_node = node
+        req.last_node = node
+        return req
+
+    def test_two_stage_load_back_reconciles_span_and_final(self):
+        # Host metadata diverges (hh 16 vs 12): SPAN = min(4+16, 4+12) = 16, both
+        # stages allocate quota 12 in the SAME round; loads land 12 vs 8: FINAL =
+        # min(16, 4+12, 4+8) = 12; both admit 12 in the SAME round and free the
+        # [12, 16) tail with identical arguments.
+        store, box = self.FakeStore(), {}
+        s0 = self._make_stage(0, store, box)
+        s1 = self._make_stage(1, store, box)
+        for s in (s0, s1):
+            s.load_back = lambda node, allow_evict=None: torch.arange(
+                12, dtype=torch.int64
+            )
+        r0 = self._make_req("req-a", 4, 16, load_node_id=100)
+        r1 = self._make_req("req-a", 4, 12, load_node_id=200)
+        self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s0, r0))
+        self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s1, r1))
+        # round 1: s1 publishes its span report; s0 sees only its own.
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)
+        self.assertEqual(s0.ongoing_load_admit["req-a"]["node_id"], None)
+        # round 2: s0 drains the store, forms SPAN=16, both stages kick alloc 12.
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)
+        self.assertEqual(s0.ongoing_load_admit["req-a"]["alloc"], 12)
+        self.assertEqual(s1.ongoing_load_admit["req-a"]["alloc"], 12)
+        self.assertEqual(
+            s0.ongoing_load_admit["req-a"]["span"],
+            s1.ongoing_load_admit["req-a"]["span"],
+        )
+        # acks land: stage0 loads 12/12, stage1 only 8/12.
+        s0.cache_controller.ack_load_queue.put((100, 12))
+        s1.cache_controller.ack_load_queue.put((200, 8))
+        # round 3: acks drain; s1 publishes its LOADED report.
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)
+        self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s0, r0))
+        # round 4: s0 drains it, forms FINAL=12, both apply in the same round.
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s0, r0))
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s1, r1))
+        self.assertEqual(len(r0.prefix_indices), 12)
+        self.assertEqual(len(r1.prefix_indices), 12)
+        r0.set_extend_input_len.assert_called_once_with(64 - 12)
+        r1.set_extend_input_len.assert_called_once_with(64 - 12)
+        # identical uniform-boundary frees: [FINAL, SPAN) == complete arg 8.
+        self.assertEqual(s0.freed, [(100, 8)])
+        self.assertEqual(s1.freed, [(200, 8)])
+        # no leaked state, no leaked locks.
+        for s in (s0, s1):
+            self.assertEqual(s.ongoing_load_admit, {})
+            self.assertEqual(s._admit_verdict, {})
+            self.assertEqual(s._h_rid, {})
+            self.assertEqual(s.locks, [])
+        self.assertEqual(store.kv, {})  # every store batch consumed and deleted
+
+    def test_two_stage_cold_req_single_round_trip(self):
+        # No stage has host data: SPAN decision short-circuits to FINAL=min(d)
+        # (one round trip), both admit device-only in the same round.
+        store, box = self.FakeStore(), {}
+        s0 = self._make_stage(0, store, box)
+        s1 = self._make_stage(1, store, box)
+        r0 = self._make_req("req-b", 8, 0, load_node_id=0)
+        r1 = self._make_req("req-b", 8, 0, load_node_id=0)
+        self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s0, r0))
+        self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s1, r1))
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s0, r0))
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s1, r1))
+        self.assertEqual(len(r0.prefix_indices), 8)
+        self.assertEqual(len(r1.prefix_indices), 8)
+        for s in (s0, s1):
+            self.assertEqual(s.locks, [])
+
+    def test_release_tombstones_and_drops_straggler_verdicts(self):
+        # Release after the span reports are in flight: the late verdict and any
+        # straggler reports must die on arrival (epoch/tombstone), leaving no
+        # state and no locks behind.
+        store, box = self.FakeStore(), {}
+        s0 = self._make_stage(0, store, box)
+        s1 = self._make_stage(1, store, box)
+        r0 = self._make_req("req-c", 4, 16, load_node_id=100)
+        r1 = self._make_req("req-c", 4, 16, load_node_id=200)
+        EICPagedHiRadixCache.check_load_back_progress(s0, r0)
+        EICPagedHiRadixCache.check_load_back_progress(s1, r1)
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)  # s1's span report is now in the store
+        EICPagedHiRadixCache.release_load_admit(s0, "req-c")
+        EICPagedHiRadixCache.release_load_admit(s1, "req-c")
+        h = s0._rid_hash("req-c")
+        self.assertIn(h, s0._tombstone)
+        # rank0 drains the straggler AFTER the release: tombstone drops it.
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)
+        self.assertEqual(s0._span_reports, {})
+        self.assertEqual(s0._verdict_outbox, [])
+        for s in (s0, s1):
+            self.assertEqual(s.ongoing_load_admit, {})
+            self.assertEqual(s.locks, [])
+
+    def test_rid_reuse_after_release_still_reconciles(self):
+        # A client retry reuses the rid within the tombstone TTL. The tombstone
+        # must kill only the RELEASED incarnation's stragglers; the retry's
+        # higher-epoch reports must pass or the retry wedges forever.
+        store, box = self.FakeStore(), {}
+        s0 = self._make_stage(0, store, box)
+        s1 = self._make_stage(1, store, box)
+        EICPagedHiRadixCache.check_load_back_progress(
+            s0, self._make_req("req-d", 8, 0, load_node_id=0)
+        )
+        EICPagedHiRadixCache.check_load_back_progress(
+            s1, self._make_req("req-d", 8, 0, load_node_id=0)
+        )
+        EICPagedHiRadixCache.loading_check(s0)
+        EICPagedHiRadixCache.loading_check(s1)  # epoch-1 span report published
+        EICPagedHiRadixCache.release_load_admit(s0, "req-d")
+        EICPagedHiRadixCache.release_load_admit(s1, "req-d")
+        # retry: same rid re-enters the gate (epoch 2) while tombstoned.
+        r0 = self._make_req("req-d", 8, 0, load_node_id=0)
+        r1 = self._make_req("req-d", 8, 0, load_node_id=0)
+        self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s0, r0))
+        self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s1, r1))
+        for _ in range(3):
+            EICPagedHiRadixCache.loading_check(s0)
+            EICPagedHiRadixCache.loading_check(s1)
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s0, r0))
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s1, r1))
+        self.assertEqual(len(r0.prefix_indices), 8)
+
+    def test_stale_ack_after_release_is_orphaned_not_attributed(self):
+        # Release with the load still in flight, then the same rid re-gates.
+        # The OLD incarnation's ack must be orphan-freed (whole span), never
+        # attributed to the new incarnation (whose node_id differs).
+        store, box = self.FakeStore(), {}
+        s0 = self._make_stage(0, store, box)
+        s1 = self._make_stage(1, store, box)
+        for s in (s0, s1):
+            s.load_back = lambda node, allow_evict=None, _s=s: (
+                _s.ongoing_load_back.__setitem__(node.id, (node, node, 12)),
+                torch.arange(12, dtype=torch.int64),
+            )[1]
+        r0 = self._make_req("req-e", 4, 16, load_node_id=100)
+        r1 = self._make_req("req-e", 4, 16, load_node_id=200)
+        EICPagedHiRadixCache.check_load_back_progress(s0, r0)
+        EICPagedHiRadixCache.check_load_back_progress(s1, r1)
+        for _ in range(2):  # span verdict forms and applies -> loads kicked
+            EICPagedHiRadixCache.loading_check(s0)
+            EICPagedHiRadixCache.loading_check(s1)
+        self.assertEqual(s0.ongoing_load_admit["req-e"]["node_id"], 100)
+        EICPagedHiRadixCache.release_load_admit(s0, "req-e")
+        EICPagedHiRadixCache.release_load_admit(s1, "req-e")
+        # same rid re-gates (epoch 2, no load kicked yet: node_id None)
+        EICPagedHiRadixCache.check_load_back_progress(
+            s0, self._make_req("req-e", 4, 16, load_node_id=101)
+        )
+        # the old incarnation's ack lands now: must orphan-free the WHOLE span.
+        s0.cache_controller.ack_load_queue.put((100, 12))
+        EICPagedHiRadixCache.loading_check(s0)
+        self.assertEqual(s0.freed, [(100, 0)])
+        self.assertIsNone(s0.ongoing_load_admit["req-e"]["complete"])
+
+    def test_pp1_cold_req_admits_with_zero_deferral(self):
+        # pp<=1 keeps the old behavior: a cold/device-only req admits on its
+        # FIRST gate pass, no verdict round trip.
+        s = self._make_stage(0, self.FakeStore(), {}, pp_size=1)
+        req = self._make_req("req-f", 8, 0, load_node_id=0)
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s, req))
+        self.assertEqual(len(req.prefix_indices), 8)
+        self.assertEqual(s.locks, [])
+        self.assertEqual(s.ongoing_load_admit, {})
+
+    def test_pp1_warm_req_kicks_at_gate_and_admits_on_ack(self):
+        # pp<=1 warm path: load kicks at gate entry, req defers, the local ack
+        # IS the verdict (d + complete), failed tail freed at that boundary.
+        s = self._make_stage(0, self.FakeStore(), {}, pp_size=1)
+        s.load_back = lambda node, allow_evict=None: torch.arange(
+            16, dtype=torch.int64
+        )
+        req = self._make_req("req-g", 4, 16, load_node_id=100)
+        self.assertFalse(EICPagedHiRadixCache.check_load_back_progress(s, req))
+        self.assertEqual(s.ongoing_load_admit["req-g"]["node_id"], 100)
+        s.cache_controller.ack_load_queue.put((100, 10))
+        EICPagedHiRadixCache.loading_check(s)
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s, req))
+        self.assertEqual(len(req.prefix_indices), 14)  # 4 device + 10 loaded
+        self.assertEqual(s.freed, [(100, 10)])
+        self.assertEqual(s.locks, [])
+
+    def test_finalize_asserts_on_verdict_before_ack(self):
+        # I5 enforcement: a FINAL verdict may never land before the local ack
+        # when a load was kicked -- silent free of in-flight DMA otherwise.
+        s = self._make_stage(0, self.FakeStore(), {}, pp_size=1)
+        s.dec_lock_ref = lambda n: None
+        node = self._make_req("x", 4, 16, load_node_id=100).best_match_node
+        req = self._make_req("req-h", 4, 16, load_node_id=100)
+        s.ongoing_load_admit = {
+            "req-h": {
+                "h": 5,
+                "d": 4,
+                "alloc": 12,
+                "node_id": 100,
+                "load_node": node,
+                "new_indices": torch.arange(12, dtype=torch.int64),
+                "deferred_lock": node,
+                "complete": None,
+            }
+        }
+        s._h_rid = {5: "req-h"}
+        s._admit_verdict = {5: 10}
+        with self.assertRaises(AssertionError):
+            EICPagedHiRadixCache._finalize_load_admit(s, req)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -11,6 +11,7 @@ from sglang.srt.managers.eic_cache_controller import (
     EICCacheOperation,
 )
 from sglang.srt.mem_cache.eic_chunk_cache import EICChunkCache
+from sglang.srt.mem_cache.pp_reconcile import PPReconciler
 from sglang.srt.mem_cache.eic_hiradix_cache import EICPagedHiRadixCache
 from sglang.srt.mem_cache.unified_cache_components import ComponentType
 from sglang.srt.mem_cache.unified_radix_cache import UnifiedTreeNode
@@ -730,6 +731,43 @@ class TestEICHiCacheRegression(unittest.TestCase):
         cc = self._make_load_controller([[True, True, True]])
         EICCacheController.load_operation_shared(cc, self._load_op())
         self.assertEqual(cc.ack_load_queue.get_nowait(), (7, 12))
+    def _make_reconciler(self, pp_rank, store, pp_size=2):
+        r = PPReconciler(
+            prefix="hipf", pp_rank=pp_rank, pp_size=pp_size, pp_group=object(), rank=0
+        )
+        r._store_handle = store
+        return r
+
+    def test_reconciler_min_across_stages(self):
+        store = self.FakeStore()
+        s0, s1 = self._make_reconciler(0, store), self._make_reconciler(1, store)
+        h = PPReconciler.rid_hash("r")
+        s0.report(h, 1, 512)
+        s1.report(h, 1, 256)
+        self.assertEqual(s1.collect(), [])
+        self.assertEqual(s0.collect(), [(h, 1, 256)])
+
+    def test_reconciler_waits_for_every_stage(self):
+        s0 = self._make_reconciler(0, self.FakeStore())
+        s0.report(PPReconciler.rid_hash("r"), 1, 512)
+        self.assertEqual(s0.collect(), [])
+
+    def test_reconciler_tombstone_is_epoch_aware(self):
+        store = self.FakeStore()
+        s0, s1 = self._make_reconciler(0, store), self._make_reconciler(1, store)
+        h = PPReconciler.rid_hash("r")
+        s0.release(h, 1)
+        s1.report(h, 1, 256)
+        s1.report(h, 2, 128)
+        s1.collect()
+        s0._drain_peers()
+        self.assertNotIn((h, 1), s0._reports)
+        self.assertIn((h, 2), s0._reports)
+
+    def test_reconciler_epoch_never_reused(self):
+        r = self._make_reconciler(0, self.FakeStore())
+        self.assertEqual([r.bump_epoch("r"), r.bump_epoch("r")], [1, 2])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

DSV4 PD-disaggregated prefill (pp2 × tp4 × attn_cp4) with EIC crashes at
`main_norm_rope.cuh:183` (`len(positions) != q.shape[0]`), right after partial
`eic mget ... failed` logs.

Root cause: EIC keys embed `pp_rank`, so each PP stage loads back from its own
namespace and mgets fail independently. PP scheduling is SPMD — every rank must
rebuild identical `(prefix_len, extend_len)` per request; a one-token divergence
trips the assert, and diverged radix trees make the next match diverge further.

## Hard constraints (GPU-proven, py-spy evidence)

1. This gloo build's p2p is effectively synchronous: `isend` completes only when
   the peer recvs; polling `is_completed()` blocks too.
2. PP0 receives the pipeline output (PP1 → PP0 sampled tokens), so PP0 must
   NEVER post a receive in the scheduler thread — it deadlocks against the
   pipeline's own sends.

Hence: reports go UP via the default process group's TCPStore (non-collective
KV RPCs — PP0 polling is not a p2p receive); verdicts come DOWN on a
PP0-authoritative isend-only chain at the lockstep site (once per
`get_new_batch_prefill`, before any early return), so the k-th message pairs
with the k-th recv and every stage applies the verdict in the same round.

## Fixes

**L2 (EIC pool load-back) — two-phase verdicts.** SPAN = min over stages of
(device_match + host_hit) fixes the allocation before any load kicks; FINAL =
min of actually-loaded lengths fixes admission; the [FINAL, SPAN) tail is freed
at a verdict boundary on every stage. One vote is not enough: per-stage
allocations drift allocator headroom until a full pool flips NO_TOKEN on one
stage only. Epochs kill stale-report pairing on rid reuse; tombstones are
epoch-aware; an SWA headroom guard keeps load-backs at half pool.

**L3 (EIC storage backend prefetch) — single-phase MIN, piggybacked.** Stages
terminate prefetch locally, report completed lengths up, commit
min(verdict, local) in the same round. Delivery DOWN rides the tensor
`loading_check` already `_pp_sync`s (widened by ≤32 verdict rows). A parallel
receive chain passed a 48-concurrency stress test and then deadlocked in
single-request idle mode — the number of PP message streams at a lockstep site
is an invariant: widen an existing message, never add one.

**Three side defects.** Controller workers now ack on exception (a swallowed
ack left the request wedged until abort); short result masks no longer read as
full hits (`all([]) == True` acked 0-byte loads as full length — silent
corruption); `EICStorage` keys gain a `_pp{size}_{rank}` suffix under pp>1
(stages used to overwrite each other's KV under the same key).

**Guards, degrade-not-crash.** eic + PP requires fcfs / no dp_attention / no
`SGLANG_REQ_WAITING_TIMEOUT` (one shared predicate, read via the typed env
registry so the legacy alias counts). Unified tree logs an error and disables
the storage tier when unmet; the classic tree disables it and points at
`SGLANG_ENABLE_UNIFIED_RADIX_TREE=1`; runtime `attach_storage_backend` refuses
eic under PP (it used to bypass the constructor guard). All gating is scoped to
the eic backend — other backends keep upstream behavior.

## Validation (8×H20, pp2 × tp4 × attn_cp4, DSV4-Flash-FP8, remote EIC)

| Case | Result |
|---|---|
| L2 normal | 2×480/480, eic hit peak 0.94, 8 PP×CP lanes batch-identical cached-token sequences, 0 asserts |
| L3 normal | 960/960, previously-deadlocking single-request + 90s idle soak pass, 240+ commits local==synced |
| L2 fault injection (PP1 drops 116 pages) | admission clipped (2048 vs healthy 4352), 8 lanes × 169 batches order-identical, 960/960 |
| L3 fault injection | 46× local=1280/verdict=0 with full tail release, 960/960, 0 divergence |
| CPU | 27 registered unit tests (verdict protocol, rid reuse, stale acks, must-ack/short-mask, reconciler) |

Note: temperature-0 token equality is not a valid cache-correctness criterion
(near-tie argmax flips from batch composition — the healthy control also
mismatched 3/4); the criterion above is per-lane batch-order cached-token
identity plus zero asserts.

## Follow-ups (tracked, not in this PR)

- Merge the inline L2 protocol implementation with `EICPPReconciler`
  (two same-origin copies today; needs GPU revalidation, separate PR).
- Normalize the degraded `hicache_storage_backend` at ServerArgs validation
  (currently `/get_server_info` still reports eic after a degrade).
- `Req.eic_loaded_len` is not reset across chunks (hit-metrics skew only).
- Upstream: `flush_write_through_acks` calls `writing_check` off the lockstep
  site; NIXL storage keys ignore pp; `wait_complete` prefetch has no deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
