### PR TITLE
[fix]reject media input for text-only models

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -137,6 +137,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_MEDIA_CONTENT_PART_TYPES = frozenset({"image_url", "video_url", "audio_url"})
+
 
 def normalize_tool_content(role: str, content):
     """Normalize tool message content from OpenAI array format to plain string.
@@ -327,6 +329,10 @@ class OpenAIServingChat(OpenAIServingBase):
         if not request.messages:
             return "Messages cannot be empty."
 
+        media_error = self._validate_media_content(request)
+        if media_error:
+            return media_error
+
         if (
             isinstance(request.tool_choice, str)
             and request.tool_choice.lower() == "required"
@@ -369,6 +375,28 @@ class OpenAIServingChat(OpenAIServingBase):
                 return "schema_ is required for json_schema response format request."
 
         return None
+
+    def _validate_media_content(self, request: ChatCompletionRequest) -> Optional[str]:
+        if self.tokenizer_manager.model_config.is_multimodal:
+            return None
+
+        media_type = next(
+            (
+                part.type
+                for message in request.messages
+                if isinstance(message.content, list)
+                for part in message.content
+                if part.type in _MEDIA_CONTENT_PART_TYPES
+            ),
+            None,
+        )
+        if media_type is None:
+            return None
+
+        return (
+            "Model only supports text input; "
+            f"received unsupported content type '{media_type}'."
+        )
 
     def _convert_to_internal_request(
         self,

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -67,6 +67,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class _MediaInputValidationError(ValueError):
+    pass
+
+
 class OpenAIServingResponses(OpenAIServingChat):
     """Handler for /v1/responses requests"""
 
@@ -196,6 +200,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                     request, prev_response, tokenizer
                 )
 
+        except _MediaInputValidationError as e:
+            return self.create_error_response(str(e))
         except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")
             return self.create_error_response(f"{e} {e.__cause__}")
@@ -386,6 +392,10 @@ class OpenAIServingResponses(OpenAIServingChat):
                 stream=request.stream,
             )
 
+            media_error = self._validate_media_content(chat_request)
+            if media_error:
+                raise _MediaInputValidationError(media_error)
+
             # Follow SGLang's _process_messages pattern
             is_multimodal = self.tokenizer_manager.model_config.is_multimodal
             processed_messages = self._process_messages(chat_request, is_multimodal)
@@ -398,6 +408,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                 request_prompts = [processed_messages.prompt_ids]
                 engine_prompts = [processed_messages.prompt_ids]
 
+        except _MediaInputValidationError:
+            raise
         except Exception as e:
             logger.warning(f"Chat processing failed, using fallback: {e}")
             # Fallback to simple encoding

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -10,6 +10,7 @@ from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
 
+import asyncio
 import json
 import unittest
 import uuid
@@ -22,11 +23,13 @@ from fastapi import Request
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     MessageProcessingResult,
+    ResponsesRequest,
 )
 from sglang.srt.entrypoints.openai.serving_chat import (
     OpenAIServingChat,
     normalize_tool_content,
 )
+from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.managers.template_detection import ReasoningToggleConfig
 from sglang.srt.utils import get_or_create_event_loop
@@ -819,24 +822,102 @@ class ServingChatTestCase(unittest.TestCase):
         out = encoding_dsv4.encode_messages(messages, thinking_mode="chat")
         self.assertIn("<｜User｜>say hi", out)
 
-        # Multiple text parts concat with single space; non-text parts dropped.
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "describe"},
-                    {"type": "image_url", "image_url": {"url": "x"}},
-                ],
-            }
-        ]
-        for i, msg in enumerate(messages):
-            if isinstance(msg.get("content"), list):
-                messages[i] = process_content_for_template_format(
-                    msg, "string", [], [], [], []
+    def test_text_only_model_rejects_media_before_generation(self):
+        media_parts = {
+            "image_url": {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.png"},
+            },
+            "video_url": {
+                "type": "video_url",
+                "video_url": {"url": "https://example.com/video.mp4"},
+            },
+            "audio_url": {
+                "type": "audio_url",
+                "audio_url": {"url": "https://example.com/audio.wav"},
+            },
+        }
+
+        for media_type, media_part in media_parts.items():
+            with self.subTest(media_type=media_type):
+                request = ChatCompletionRequest(
+                    model="x",
+                    messages=[
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "describe"},
+                                media_part,
+                            ],
+                        }
+                    ],
                 )
-        out = encoding_dsv4.encode_messages(messages, thinking_mode="chat")
-        self.assertIn("<｜User｜>describe", out)
-        self.assertNotIn("image_url", out)
+                response = get_or_create_event_loop().run_until_complete(
+                    self.chat.handle_request(request, self.fastapi_request)
+                )
+                error = json.loads(response.body)
+                self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+                self.assertEqual(error["type"], "BadRequestError")
+                self.assertIn(media_type, error["message"])
+        self.tm.generate_request.assert_not_called()
+
+    def test_media_validation_does_not_reject_supported_content(self):
+        text_request = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_reference", "name": "get_weather"}],
+                }
+            ],
+        )
+        self.assertIsNone(self.chat._validate_request(text_request))
+
+        self.tm.model_config.is_multimodal = True
+        multimodal_request = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/image.png"},
+                        }
+                    ],
+                }
+            ],
+        )
+        self.assertIsNone(self.chat._validate_request(multimodal_request))
+
+    def test_text_only_responses_rejects_media_before_generation(self):
+        serving = OpenAIServingResponses(self.tm, self.template_manager)
+        serving._process_messages = Mock()
+        request = ResponsesRequest(
+            model="x",
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe it"},
+                        {
+                            "type": "input_image",
+                            "image_url": "http://example.com/cat.png",
+                        },
+                    ],
+                }
+            ],
+            store=False,
+        )
+
+        response = asyncio.run(serving.create_responses(request))
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn(
+            b"received unsupported content type 'image_url'", response.body
+        )
+        serving._process_messages.assert_not_called()
+        self.tm.generate_request.assert_not_called()
 
     def test_dsv4_task_and_reminder_encode_end_to_end(self):
         """Task + latest_reminder plumb through to the dsv4 encoder correctly."""


### PR DESCRIPTION
## Motivation

DeepSeek-V4 is text-only, but OpenAI-compatible chat and Responses schemas accept media content parts. Before validation, the DSV4 string-content path could silently drop image, video, or audio parts and continue generation with partial or empty text.

## Modifications

- Reuse `OpenAIServingChat._validate_media_content()` for capability validation.
- Reject `image_url`, `video_url`, and `audio_url` for text-only Chat Completions requests.
- Apply the same validation to the Responses API before template processing or generation.
- Preserve text, `tool_reference`, and multimodal-model behavior.
- Keep the fork's existing Responses fallback, while allowing media-validation errors to bypass it and return HTTP 400.
- Add regression coverage for Chat and Responses request paths.

This matches the behavior and implementation semantics of sgl-project/sglang#32914, with only the Responses fallback adaptation required by the older `bytedance/deepseek_v4` code structure.

## Validation

- `git diff --check`
- `python3 -m py_compile` for the two serving modules and focused test
- `python3 -m compileall -q` for the two serving modules and focused test
- Targeted unittest startup was attempted but the local environment lacks `numpy`; CI still needs to run the focused test.
