### PR TITLE
fix(disagg): avoid invalid PD hidden cleanup in prealloc queue

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1135,7 +1135,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     )
                 decode_req.kv_receiver.clear()
                 decode_req.kv_receiver = None
-                self._release_pd_hidden_rows(decode_req)
                 failed_reqs.append(decode_req)
                 indices_to_remove.add(i)
 


### PR DESCRIPTION
## Summary

- remove the invalid PD hidden-row cleanup call from DecodePreallocQueue
- prevent decode scheduler crashes when an aborted request is removed from the preallocation queue

## Root cause

PD hidden receive rows are allocated only after the preallocation abort scan and are owned by DecodeTransferQueue. The abort path called a helper that is defined only on DecodeTransferQueue, causing an AttributeError before the request could be removed.

## Verification

- reproduced the AttributeError against the target branch tip
- verified the patched abort cleanup path completes and removes the request
- ruff passed for python/sglang/srt/disaggregation/decode.py
- git diff --check passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->