### PR TITLE
[HiCache][DSV4] Fix batched PP completion deadlock

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -404,13 +404,10 @@ class UnifiedRadixCache(BasePrefixCache):
         if mode == "legacy":
             return
 
-        from sglang.srt.distributed.parallel_state import get_world_group
         from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
             DeepSeekV4TokenToKVPool,
         )
 
-        world_group = get_world_group()
-        expected_world_size = server_args.tp_size * server_args.pp_size
         checks = (
             (
                 isinstance(
@@ -428,10 +425,6 @@ class UnifiedRadixCache(BasePrefixCache):
             (not server_args.enable_eic_cache, "EIC enabled"),
             (not server_args.enable_dp_attention, "DP attention enabled"),
             (server_args.dp_size == 1, f"DP size {server_args.dp_size}"),
-            (
-                world_group.world_size == expected_world_size,
-                f"world size {world_group.world_size} != TP×PP {expected_world_size}",
-            ),
         )
         unsupported_reasons = [reason for supported, reason in checks if not supported]
 
@@ -442,19 +435,12 @@ class UnifiedRadixCache(BasePrefixCache):
                 + "; ".join(unsupported_reasons)
             )
 
-        # Use a dedicated Gloo group. The world CPU group is also used by PP
-        # scheduler traffic, so inserting a new collective there could violate
-        # its point-to-point ordering.
-        self._hicache_pp_sync_group = torch.distributed.new_group(
-            ranks=world_group.ranks,
-            backend="gloo",
-        )
         self._hicache_pp_sync_counts = torch.zeros(
             2, dtype=torch.int32, device="cpu"
         )
         logger.info(
-            "Using batched HiCache PP completion synchronization across %d ranks",
-            world_group.world_size,
+            "Using batched HiCache completion synchronization across %d PP stages",
+            self.pp_size,
         )
 
     def _uses_batched_hicache_pp_sync(self) -> bool:
@@ -470,7 +456,7 @@ class UnifiedRadixCache(BasePrefixCache):
         return finish_count
 
     def _sync_hicache_completion_counts(self) -> tuple[int, int]:
-        """Synchronize ready write/load ACK prefixes with one CPU collective."""
+        """Reduce write/load ACK prefixes once, then propagate along PP."""
         cc = self.cache_controller
         if cc is None:
             raise RuntimeError(
@@ -478,13 +464,11 @@ class UnifiedRadixCache(BasePrefixCache):
             )
 
         counts = self._hicache_pp_sync_counts
-        counts[0] = self._count_ready_hicache_acks(cc.ack_write_queue)
-        counts[1] = self._count_ready_hicache_acks(cc.ack_load_queue)
-        torch.distributed.all_reduce(
-            counts,
-            op=torch.distributed.ReduceOp.MIN,
-            group=self._hicache_pp_sync_group,
-        )
+        counts.zero_()
+        if self.pp_rank == 0:
+            counts[0] = self._count_ready_hicache_acks(cc.ack_write_queue)
+            counts[1] = self._count_ready_hicache_acks(cc.ack_load_queue)
+        self._all_reduce(counts, torch.distributed.ReduceOp.MIN)
         return int(counts[0].item()), int(counts[1].item())
 
     def reset(self) -> None:
@@ -2355,7 +2339,7 @@ class UnifiedRadixCache(BasePrefixCache):
         finish_count: int,
         *,
         kind: str,
-    ) -> list[list[int]]:
+    ) -> list[tuple[Any, Any, list[int]]]:
         if len(queue) < finish_count:
             raise RuntimeError(
                 f"HiCache {kind} ACK queue diverged: pp_rank={self.pp_rank}, "
@@ -2363,20 +2347,14 @@ class UnifiedRadixCache(BasePrefixCache):
             )
 
         ready_acks = queue[:finish_count]
-        for _, finish_event, ack_list in ready_acks:
-            if not finish_event.query():
-                raise RuntimeError(
-                    f"HiCache {kind} ACK readiness diverged: "
-                    f"pp_rank={self.pp_rank}, ack_ids={ack_list}"
-                )
-
+        for _, _, ack_list in ready_acks:
             missing_ids = [ack_id for ack_id in ack_list if ack_id not in ongoing]
             if missing_ids:
                 raise RuntimeError(
                     f"HiCache {kind} ACK IDs diverged: pp_rank={self.pp_rank}, "
                     f"missing_ids={missing_ids}, ongoing={len(ongoing)}"
                 )
-        return [ack_list for _, _, ack_list in ready_acks]
+        return ready_acks
 
     def writing_check(self, write_back: bool = False) -> None:
         """Poll write-through completions."""
@@ -2534,6 +2512,7 @@ class UnifiedRadixCache(BasePrefixCache):
     def check_hicache_events(self) -> None:
         """Called per scheduler step to poll async HiCache events."""
         if self._uses_batched_hicache_pp_sync():
+            self._drain_async_work()
             write_count, load_count = self._sync_hicache_completion_counts()
             cc = self.cache_controller
             assert cc is not None
@@ -2549,13 +2528,22 @@ class UnifiedRadixCache(BasePrefixCache):
                 load_count,
                 kind="load",
             )
+
+            # PP0 decides the common ACK prefix. A downstream stage may still
+            # be finishing its local transfer, so retain legacy's local event
+            # wait before releasing any device or host locks.
+            for _, finish_event, _ in write_acks:
+                finish_event.synchronize()
+            for _, finish_event, _ in load_acks:
+                finish_event.synchronize()
+
             del cc.ack_write_queue[:write_count]
             del cc.ack_load_queue[:load_count]
-            for ack_list in write_acks:
+            for _, _, ack_list in write_acks:
                 for ack_id in ack_list:
                     node, params = self.ongoing_write_through.pop(ack_id)
                     self.dec_lock_ref(node, params)
-            for ack_list in load_acks:
+            for _, _, ack_list in load_acks:
                 for ack_id in ack_list:
                     node, lock_params, host_lock_params = (
                         self.ongoing_load_back.pop(ack_id)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_pp_sync.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_pp_sync.py
@@ -27,7 +27,9 @@ class _Holder:
     _uses_batched_hicache_pp_sync = (
         UnifiedRadixCache._uses_batched_hicache_pp_sync
     )
-    _count_ready_hicache_acks = UnifiedRadixCache._count_ready_hicache_acks
+    _count_ready_hicache_acks = staticmethod(
+        UnifiedRadixCache._count_ready_hicache_acks
+    )
     _sync_hicache_completion_counts = (
         UnifiedRadixCache._sync_hicache_completion_counts
     )
@@ -45,7 +47,6 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
     ):
         holder = _Holder()
         holder._hicache_pp_sync_mode = "batched"
-        holder._hicache_pp_sync_group = object()
         holder._hicache_pp_sync_counts = torch.zeros(2, dtype=torch.int32)
         holder.cache_controller = SimpleNamespace(
             ack_write_queue=list(write_acks or []),
@@ -57,6 +58,7 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
         holder.enable_storage = False
         holder.enable_storage_metrics = False
         holder.storage_metrics_collector = None
+        holder._all_reduce = mock.Mock()
         holder.dec_lock_ref = mock.Mock()
         holder.dec_host_lock_ref = mock.Mock()
         return holder
@@ -75,7 +77,7 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
         values.update(overrides)
         return SimpleNamespace(**values)
 
-    def test_batched_mode_initializes_dedicated_full_replica_group(self):
+    def test_batched_mode_initializes_without_a_new_process_group(self):
         holder = _Holder()
         holder.pp_size = 4
         kvcache = object.__new__(DeepSeekV4TokenToKVPool)
@@ -84,22 +86,16 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
                 get_kvcache=mock.Mock(return_value=kvcache)
             )
         )
-        world_group = SimpleNamespace(world_size=8, ranks=list(range(8)))
-        dedicated_group = object()
-
-        with envs.SGLANG_HICACHE_PP_SYNC_MODE.override("batched"), mock.patch(
-            "sglang.srt.distributed.parallel_state.get_world_group",
-            return_value=world_group,
-        ), mock.patch.object(
-            torch.distributed, "new_group", return_value=dedicated_group
-        ) as new_group:
+        with envs.SGLANG_HICACHE_PP_SYNC_MODE.override(
+            "batched"
+        ), mock.patch.object(torch.distributed, "new_group") as new_group:
             UnifiedRadixCache._init_hicache_pp_sync_mode(
                 holder, self._make_batched_init_args(), params
             )
 
-        new_group.assert_called_once_with(ranks=list(range(8)), backend="gloo")
+        new_group.assert_not_called()
         self.assertEqual(holder._hicache_pp_sync_mode, "batched")
-        self.assertIs(holder._hicache_pp_sync_group, dedicated_group)
+        self.assertFalse(hasattr(holder, "_hicache_pp_sync_group"))
         torch.testing.assert_close(
             holder._hicache_pp_sync_counts,
             torch.zeros(2, dtype=torch.int32),
@@ -222,7 +218,58 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
         holder.dec_lock_ref.assert_called_once_with(node, lock_params)
         self.assertEqual(holder.cache_controller.ack_write_queue, [])
 
-    def test_batched_check_consumes_both_with_one_collective_and_no_wait(self):
+    def test_batched_sync_queries_pp0_and_propagates_one_vector(self):
+        write_event = mock.Mock()
+        write_event.query.return_value = True
+        load_event = mock.Mock()
+        load_event.query.return_value = True
+        holder = self._make_batched_holder(
+            write_acks=[(None, write_event, [11])],
+            load_acks=[(None, load_event, [12])],
+        )
+
+        counts = UnifiedRadixCache._sync_hicache_completion_counts(holder)
+
+        self.assertEqual(counts, (1, 1))
+        write_event.query.assert_called_once()
+        load_event.query.assert_called_once()
+        holder._all_reduce.assert_called_once()
+        synced_counts, reduce_op = holder._all_reduce.call_args.args
+        torch.testing.assert_close(
+            synced_counts, torch.tensor([1, 1], dtype=torch.int32)
+        )
+        self.assertEqual(reduce_op, torch.distributed.ReduceOp.MIN)
+
+    def test_batched_sync_nonzero_pp_stage_uses_propagated_counts(self):
+        write_event = mock.Mock()
+        load_event = mock.Mock()
+        holder = self._make_batched_holder(
+            write_acks=[(None, write_event, [11])],
+            load_acks=[(None, load_event, [12])],
+        )
+        holder.pp_rank = 1
+
+        def propagate_counts(counts, _op):
+            counts.copy_(torch.tensor([1, 1], dtype=torch.int32))
+
+        holder._all_reduce.side_effect = propagate_counts
+
+        counts = UnifiedRadixCache._sync_hicache_completion_counts(holder)
+
+        self.assertEqual(counts, (1, 1))
+        write_event.query.assert_not_called()
+        load_event.query.assert_not_called()
+        holder._all_reduce.assert_called_once()
+
+    def test_batched_empty_queues_still_participate_in_one_sync(self):
+        holder = self._make_batched_holder()
+
+        counts = UnifiedRadixCache._sync_hicache_completion_counts(holder)
+
+        self.assertEqual(counts, (0, 0))
+        holder._all_reduce.assert_called_once()
+
+    def test_batched_check_consumes_both_after_local_event_completion(self):
         write_event = mock.Mock()
         write_event.query.return_value = True
         load_event = mock.Mock()
@@ -236,22 +283,30 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
             ongoing_loads={12: (load_node, device_lock, host_lock)},
         )
         holder._drain_async_work = mock.Mock()
+        call_order = []
+        write_event.synchronize.side_effect = lambda: call_order.append("write_event")
+        load_event.synchronize.side_effect = lambda: call_order.append("load_event")
+        holder.dec_lock_ref.side_effect = lambda *_: call_order.append("device_unlock")
+        holder.dec_host_lock_ref.side_effect = lambda *_: call_order.append(
+            "host_unlock"
+        )
 
-        with mock.patch.object(
-            torch.distributed, "all_reduce"
-        ) as all_reduce, mock.patch.object(
-            torch.distributed, "recv"
-        ) as recv, mock.patch.object(
-            torch.distributed, "isend"
-        ) as isend:
-            UnifiedRadixCache.check_hicache_events(holder)
+        UnifiedRadixCache.check_hicache_events(holder)
 
-        all_reduce.assert_called_once()
-        recv.assert_not_called()
-        isend.assert_not_called()
-        holder._drain_async_work.assert_not_called()
-        write_event.synchronize.assert_not_called()
-        load_event.synchronize.assert_not_called()
+        holder._drain_async_work.assert_called_once()
+        holder._all_reduce.assert_called_once()
+        write_event.synchronize.assert_called_once()
+        load_event.synchronize.assert_called_once()
+        self.assertEqual(
+            call_order,
+            [
+                "write_event",
+                "load_event",
+                "device_unlock",
+                "device_unlock",
+                "host_unlock",
+            ],
+        )
         holder.dec_lock_ref.assert_has_calls(
             [
                 mock.call(write_node, write_lock),
@@ -260,6 +315,30 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
         )
         holder.dec_host_lock_ref.assert_called_once_with(load_node, host_lock)
         self.assertEqual(holder.cache_controller.ack_write_queue, [])
+        self.assertEqual(holder.cache_controller.ack_load_queue, [])
+
+    def test_batched_nonzero_pp_stage_waits_for_its_local_event(self):
+        finish_event = mock.Mock()
+        finish_event.query.return_value = False
+        node, device_lock, host_lock = object(), object(), object()
+        holder = self._make_batched_holder(
+            load_acks=[(None, finish_event, [13])],
+            ongoing_loads={13: (node, device_lock, host_lock)},
+        )
+        holder.pp_rank = 1
+        holder._drain_async_work = mock.Mock()
+
+        def propagate_load_count(counts, _op):
+            counts.copy_(torch.tensor([0, 1], dtype=torch.int32))
+
+        holder._all_reduce.side_effect = propagate_load_count
+
+        UnifiedRadixCache.check_hicache_events(holder)
+
+        finish_event.query.assert_not_called()
+        finish_event.synchronize.assert_called_once()
+        holder.dec_lock_ref.assert_called_once_with(node, device_lock)
+        holder.dec_host_lock_ref.assert_called_once_with(node, host_lock)
         self.assertEqual(holder.cache_controller.ack_load_queue, [])
 
     def test_batched_scheduler_flush_does_not_repeat_collective(self):
@@ -271,10 +350,9 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
             ongoing_writes={23: (write_node, write_lock)},
         )
 
-        with mock.patch.object(torch.distributed, "all_reduce") as all_reduce:
-            UnifiedRadixCache.flush_write_through_acks(holder)
+        UnifiedRadixCache.flush_write_through_acks(holder)
 
-        all_reduce.assert_not_called()
+        holder._all_reduce.assert_not_called()
         write_event.query.assert_not_called()
         self.assertEqual(len(holder.cache_controller.ack_write_queue), 1)
         self.assertIn(23, holder.ongoing_write_through)
@@ -297,6 +375,22 @@ class TestUnifiedRadixCachePPSync(unittest.TestCase):
 
         self.assertEqual(len(holder.cache_controller.ack_write_queue), 1)
         finish_event.synchronize.assert_not_called()
+        finish_event.query.assert_not_called()
+
+    def test_batched_consume_fails_before_mutation_on_short_queue(self):
+        holder = self._make_batched_holder(ongoing_writes={41: (object(), object())})
+
+        with self.assertRaisesRegex(RuntimeError, "write ACK queue diverged"):
+            UnifiedRadixCache._validated_hicache_acks(
+                holder,
+                holder.cache_controller.ack_write_queue,
+                holder.ongoing_write_through,
+                1,
+                kind="write",
+            )
+
+        self.assertEqual(holder.cache_controller.ack_write_queue, [])
+        self.assertIn(41, holder.ongoing_write_through)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

#676 batches HiCache write/load completion counts into one synchronization, but its dedicated all-world Gloo collective requires every PP rank to enter the scheduler-side collective in identical order.

PD Prefill pipeline stages are not scheduler-lockstep. During warmup or pipeline communication, PP0 can enter the HiCache all-reduce while a downstream PP stage is still waiting on PP traffic, creating a circular wait before the first effective prefill batch.

## Modifications

- Remove the batched-only all-world Gloo process group and its world-size validation.
- Keep the preallocated `int32[2]` vector:
  - write completion count
  - load completion count
- Let only PP0 inspect the consecutive ready ACK prefix.
- Reuse the legacy synchronization topology:
  - one vector MIN reduction across PP0's attention CP/TP groups;
  - one asynchronous propagation through the existing PP pipeline.
- Preserve per-stage completion semantics:
  - downstream PP stages do not query local event readiness;
  - each stage waits for its local finish event before releasing device and host locks.
- Validate ACK queue lengths and ACK IDs before mutating queue, lock, or ongoing-operation state.
- Drain the previous asynchronous PP send before starting the next batched synchronization.
- Keep `flush_write_through_acks()` from issuing a duplicate synchronization in batched mode.

This change does not modify legacy mode, write-back, flush/reset, scheduler/PD communication ordering, SWA, L3, EIC, online compression, MTP, attention kernels, or non-HiCache paths.

## Validation

- Focused unit tests: `15 passed`
- `python3 -m compileall`: passed
- `git diff --check`: passed
- Rebased onto current `bytedance/deepseek_v4@030f0ff540`
- The rebased commit has the same stable patch ID as the tested local commit

## Pending runtime validation

This remains a draft until it passes the production topology regression:

- TP=4 × PP=2 × ATTN_CP=4
- PD Prefill
- HiCache L2, write-through
- `SGLANG_HICACHE_PP_SYNC_MODE=batched`
- PD warmup reaches the first effective Prefill batch
- `/health` returns 200
- cold request, L2-hit replay, and short concurrent traffic complete without collective timeout, ACK divergence, or lock leakage
- output/logits match legacy mode

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->