### PR TITLE
ci: trigger core PR tests for ep_main

### DIFF
--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -11,7 +11,7 @@ name: PR Test Extra
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, ep_main]
   workflow_dispatch:
     inputs:
       force_continue_on_error:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 1,9,17 * * *'  # Run 3x daily: 2am / 10am / 6pm Pacific (PDT)
   pull_request:
-    branches: [main]
+    branches: [main, ep_main]
   workflow_dispatch:
     inputs:
       force_continue_on_error:


### PR DESCRIPTION
## Summary

- run the core PR test workflows for pull requests targeting `ep_main`
- preserve the existing `main` trigger for repositories that still use it

## Motivation

The fork's active development base is `ep_main`, but these workflows only filtered pull requests whose base branch was `main`. PRs opened against `ep_main` therefore skipped the core and extra PR test workflows.

## Validation

- `git diff --check`
- reviewed the workflow branch filters and confirmed both `main` and `ep_main` are retained



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->[Run #30817681198](https://github.com/bytedance-iaas/sglang/actions/runs/30817681198)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->