### PR TITLE
ci: trigger SMG PR tests for ep_main

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -2,14 +2,14 @@ name: PR Test (SMG)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ep_main ]
     paths:
       - "sgl-model-gateway/**"
       - ".github/workflows/pr-test-rust.yml"
       - "scripts/ci/cuda/ci_install_dependency.sh"
       - "scripts/ci/cuda/ci_install_gateway_dependencies.sh"
   pull_request:
-    branches: [ main ]
+    branches: [ main, ep_main ]
     types: [opened, synchronize, reopened, labeled]
     paths:
       - "sgl-model-gateway/**"


### PR DESCRIPTION
## Summary

- run SMG/Rust PR tests for pushes and pull requests targeting `ep_main`
- preserve the existing `main` trigger

## Motivation

The SMG workflow only listened to `main`, while the fork's active development base is `ep_main`. Changes to the gateway and its dependency-installation scripts could therefore bypass the intended PR validation when submitted against `ep_main`.

## Validation

- `git diff --check`
- reviewed both push and pull-request branch filters



<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** — add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->