### PR TITLE
ci: fail closed when AMD VRAM checks are unavailable

### DIFF
--- a/scripts/ci/amd/check_vram_clear.sh
+++ b/scripts/ci/amd/check_vram_clear.sh
@@ -17,7 +17,10 @@ check_vram_clear() {
             echo "✓ VRAM usage is within acceptable limits on all GPUs"
             return 0
         fi
-   fi
+    fi
+
+    echo "ERROR: rocm-smi is not available; cannot verify that VRAM is clear." >&2
+    return 1
 }
 
 # If this script is run directly (not sourced), run the check


### PR DESCRIPTION
## Summary

- report a failed VRAM check when `rocm-smi` is unavailable
- keep AMD cleanup validation from silently succeeding without any measurement

## Motivation

`check_vram_clear` previously returned success implicitly when `rocm-smi` was missing. On a misconfigured runner, the cleanup workflow could therefore report a clean GPU state without checking anything. The check now fails closed and emits an actionable error.

## Validation

- `git diff --check`
- verified the missing-tool path returns non-zero by inspection

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->