### PR TITLE
fix: harden GitHub CLI installation script

### DIFF
--- a/scripts/code_sync/install_github_cli.sh
+++ b/scripts/code_sync/install_github_cli.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
+set -euo pipefail
 
 # Check if gh is installed before attempting to install it
-if ! command -v gh &> /dev/null
-then
-echo "GitHub CLI not found. Installing now..."
-(type -p wget >/dev/null || ( apt update &&  apt install wget -y)) \
-&&  mkdir -p -m 755 /etc/apt/keyrings \
-&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-&& cat $out |  tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-&&  chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-&&  mkdir -p -m 755 /etc/apt/sources.list.d \
-&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |  tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-&&  apt update \
-&&  apt install gh -y
+if ! command -v gh >/dev/null 2>&1; then
+    echo "GitHub CLI not found. Installing now..."
+
+    if ! command -v wget >/dev/null 2>&1; then
+        apt-get update
+        apt-get install -y wget
+    fi
+
+    install -d -m 755 /etc/apt/keyrings /etc/apt/sources.list.d
+    keyring_tmp=$(mktemp)
+    trap 'rm -f "$keyring_tmp"' EXIT
+
+    wget -nv -O "$keyring_tmp" \
+        https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    install -m 0644 "$keyring_tmp" \
+        /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+
+    printf '%s\n' \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        >/etc/apt/sources.list.d/github-cli.list
+
+    apt-get update
+    apt-get install -y gh
 else
-echo "GitHub CLI is already installed. Skipping installation."
+    echo "GitHub CLI is already installed. Skipping installation."
 fi


### PR DESCRIPTION
## Summary

- make the GitHub CLI installer fail fast on download or package-manager errors
- quote the temporary keyring path
- clean up the temporary keyring file after installation

## Motivation

The installer previously chained commands with `&&` but did not enable strict error handling, used an unquoted temporary path, and left the downloaded keyring in `/tmp`. A failed intermediate command could be difficult to diagnose in the code-sync workflows. The updated script keeps the same installation flow while making failures explicit and cleanup deterministic.

## Validation

- `git diff --check`
- reviewed the installer in both the existing-`gh` and installation paths

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->