### PR TITLE
[PD]: fix hidden rows dynamic allocation

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -277,6 +277,10 @@ class CommonKVManager(BaseKVManager):
     def supports_pd_hidden_streaming(self) -> bool:
         return False
 
+    def supports_pd_hidden_dynamic_allocation(self) -> bool:
+        """Whether receive rows can be granted after prefill produces a chunk."""
+        return False
+
     def mark_pd_hidden_request_done(
         self,
         bootstrap_room: int,

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1431,6 +1431,12 @@ class CommonKVSender(BaseKVSender):
             "Aborted by AbortReq.",
         )
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
+        # Streaming PD hidden chunks can be parked behind destination-row
+        # allocation or ACK waiters.  Once the request is aborted no peer will
+        # complete those handshakes, so wake the parked chunks immediately.
+        # The transfer worker observes the Failed room and releases their
+        # source rows instead of holding the Prefill hidden pool until timeout.
+        self.kv_mgr._wake_pd_hidden_ack_waiters(self.bootstrap_room)
         self.conclude_state = KVPoll.Failed
 
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -411,6 +411,35 @@ class CommonKVManager(BaseKVManager):
                     self.request_status[bootstrap_room], status
                 )
 
+    def _clear_sender_room_state(self, bootstrap_room: int) -> None:
+        self.request_status.pop(bootstrap_room, None)
+        if hasattr(self, "req_to_decode_prefix_len"):
+            self.req_to_decode_prefix_len.pop(bootstrap_room, None)
+        if hasattr(self, "req_to_pd_hidden_meta"):
+            self.req_to_pd_hidden_meta.pop(bootstrap_room, None)
+        if hasattr(self, "transfer_infos"):
+            self.transfer_infos.pop(bootstrap_room, None)
+
+    def clear_sender_room(self, bootstrap_room: int) -> bool:
+        hidden_events = getattr(self, "pd_hidden_events", None)
+        if (
+            hidden_events is not None
+            and self.request_status.get(bootstrap_room) != KVPoll.Failed
+            and hidden_events.defer_clear_if_active(bootstrap_room)
+        ):
+            return False
+        self._clear_sender_room_state(bootstrap_room)
+        return True
+
+    def finish_deferred_sender_clear(self, bootstrap_room: int) -> bool:
+        hidden_events = getattr(self, "pd_hidden_events", None)
+        if hidden_events is None or not hidden_events.take_deferred_clear(
+            bootstrap_room
+        ):
+            return False
+        self._clear_sender_room_state(bootstrap_room)
+        return True
+
     def record_failure(self, bootstrap_room: int, failure_reason: str):
         with self.failure_lock:
             self.failure_records[bootstrap_room] = failure_reason
@@ -1394,13 +1423,7 @@ class CommonKVSender(BaseKVSender):
         raise Exception("Fake KVReceiver Exception")
 
     def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
-            self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "req_to_pd_hidden_meta"):
-            self.kv_mgr.req_to_pd_hidden_meta.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "transfer_infos"):
-            self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
+        self.kv_mgr.clear_sender_room(self.bootstrap_room)
 
     def abort(self):
         self.kv_mgr.record_failure(

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -176,9 +176,7 @@ class CommonKVManager(BaseKVManager):
         # DeepSeek-V4 PCP -> DCP transfer must use a one-to-one rank mapping.
         # The generic all-CP fan-out cannot make forward progress in this
         # topology, so this is an invariant rather than a user-tunable option.
-        self.enable_pcp_dcp_rank_affinity = (
-            self._should_enable_pcp_dcp_rank_affinity()
-        )
+        self.enable_pcp_dcp_rank_affinity = self._should_enable_pcp_dcp_rank_affinity()
         self._check_pcp_dcp_rank_affinity_local_topology()
         cp_sharded_prefill = self.attn_cp_size > 1 and (
             self.is_hybrid_mla_backend or server_args.enable_dsa_cache_layer_split
@@ -370,8 +368,7 @@ class CommonKVManager(BaseKVManager):
             )
         if self.server_args.enable_dsa_cache_layer_split:
             raise RuntimeError(
-                "PCP-DCP rank affinity is incompatible with "
-                "DSA cache layer split"
+                "PCP-DCP rank affinity is incompatible with " "DSA cache layer split"
             )
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             if self.dcp_size != 1:

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -3,7 +3,7 @@ import dataclasses
 import struct
 import threading
 from collections import deque
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -37,6 +37,9 @@ class TransferKVChunk:
     pd_hidden_row_len: int = 0
     pd_hidden_is_last_chunk: bool = False
     pd_hidden_release_indices: Optional[List[int]] = None
+    pd_hidden_alloc_requested: bool = False
+    pd_hidden_alloc_grants: Optional[Dict[str, List[int]]] = None
+    pd_hidden_alloc_timed_out: bool = False
     enqueue_time: float = 0.0
     source_event: Optional[Any] = None
     trace_ctx: Union[TraceReqContext, TraceNullContext] = dataclasses.field(

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -79,6 +79,7 @@ from sglang.srt.managers.schedule_batch import (
 )
 from sglang.srt.managers.schedule_policy import match_prefix_for_req
 from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
     BasePrefixCache,
     DecLockRefParams,
@@ -86,7 +87,6 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     zero_match_result,
 )
-from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.common import (
     kv_to_page_indices,
     page_align_floor,
@@ -99,8 +99,8 @@ from sglang.srt.mem_cache.memory_pool import (
     ReqToTokenPool,
 )
 from sglang.srt.mem_cache.radix_cache import RadixKey
-from sglang.srt.mem_cache.utils import get_hash_str
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.mem_cache.utils import get_hash_str
 from sglang.srt.observability.req_time_stats import (
     set_schedule_time_batch,
     set_time_batch,
@@ -1307,9 +1307,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             state_types = self.kv_manager.kv_args.state_types
             if (
                 self.scheduler.spec_algorithm.is_dspark()
-                and not _is_fake_transfer(
-                    decode_req.req, self.scheduler.server_args
-                )
+                and not _is_fake_transfer(decode_req.req, self.scheduler.server_args)
                 and StateType.PD_HIDDEN in state_types
                 and pd_hidden_len > 0
             ):
@@ -1503,17 +1501,12 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                         pp_slice["dst_indices"] = []
                         pd_hidden_dst_indices_by_pp[int(pp_rank)] = []
                 else:
-                    allocated_hidden_indices = dspark_pool.alloc(
-                        pd_hidden_window_rows
-                    )
+                    allocated_hidden_indices = dspark_pool.alloc(pd_hidden_window_rows)
                     if allocated_hidden_indices is None:
                         if prefix_len > 0:
                             self.tree_cache.dec_lock_ref(decode_req.req.last_node)
                         now = time.monotonic()
-                        if (
-                            now - self._last_pd_hidden_recv_credit_warning_time
-                            > 30
-                        ):
+                        if now - self._last_pd_hidden_recv_credit_warning_time > 30:
                             logger.warning(
                                 "PD decode hidden pool blocked prealloc: "
                                 "rid=%s window_rows=%d hidden_len=%d free_rows=%d pool_rows=%d "
@@ -1546,9 +1539,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                         int(pd_hidden_start), hidden_end
                     )
                     if pd_hidden_streaming
-                    else PDHiddenRequestState.full(
-                        int(pd_hidden_start), hidden_end
-                    )
+                    else PDHiddenRequestState.full(int(pd_hidden_start), hidden_end)
                 )
                 if pp_size == 1 and not pd_hidden_dynamic_allocation:
                     pd_hidden_dst_indices = pd_hidden_dst_indices_by_pp.get(0)
@@ -1612,9 +1603,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             dsv4_dcp_transfer = (
                 isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool)
                 or isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)
-            ) and (
-                dcp_size_local > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get()
-            )
+            ) and (dcp_size_local > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get())
             if dcp_size_local > 1 and not dsv4_dcp_transfer:
                 kv_indices = filter_kv_indices_for_dcp_rank(
                     kv_indices, dcp_size_local, dcp_rank_local
@@ -1654,9 +1643,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                         window_kv_indices_full.cpu().numpy(),
                         np.array([window_start], dtype=np.int32),
                     ]
-                return kv_to_page_indices(
-                    window_kv_indices_swa_np, page_size
-                )
+                return kv_to_page_indices(window_kv_indices_swa_np, page_size)
 
             def _dsa_payload():
                 kv_indices_full = self.req_to_token_pool.req_to_token[
@@ -1729,8 +1716,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 state_indices = None
 
             metadata_state_indices = state_indices
-            if dsv4_dcp_transfer and state_indices and isinstance(
-                state_indices[0], (list, tuple)
+            if (
+                dsv4_dcp_transfer
+                and state_indices
+                and isinstance(state_indices[0], (list, tuple))
             ):
                 # DSV4 transfer carries an expanded SWA payload:
                 # [swa_locs, swa_pages, full_locs, position_offset].
@@ -1758,9 +1747,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 spec_metadata = {
                     "pd_hidden": True,
                     "streaming_hidden": bool(decode_req.pd_hidden_state.streaming),
-                    "dynamic_hidden_allocation": bool(
-                        pd_hidden_dynamic_allocation
-                    ),
+                    "dynamic_hidden_allocation": bool(pd_hidden_dynamic_allocation),
                     "streaming_window_rows": int(
                         pd_hidden_window_rows
                         if pd_hidden_dynamic_allocation
@@ -1791,11 +1778,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                                 int(x) for x in pp_slice.get("dst_indices", [])
                             ],
                         }
-                        for pp_rank, pp_slice in (
-                            pd_hidden_pp_slices or {}
-                        ).items()
+                        for pp_rank, pp_slice in (pd_hidden_pp_slices or {}).items()
                     },
-                    "hidden_size": int(self.metadata_buffers.pd_hidden_pool.hidden_size),
+                    "hidden_size": int(
+                        self.metadata_buffers.pd_hidden_pool.hidden_size
+                    ),
                     "target_layer_ids": [int(x) for x in target_layer_ids],
                 }
 
@@ -2274,9 +2261,7 @@ def alloc_for_decode_prealloc(
                 prefix_lens=torch.tensor(
                     [total_prefix_len], dtype=torch.int64, device=device
                 ),
-                prefix_lens_cpu=torch.tensor(
-                    [total_prefix_len], dtype=torch.int64
-                ),
+                prefix_lens_cpu=torch.tensor([total_prefix_len], dtype=torch.int64),
                 seq_lens=torch.tensor([fill_len], dtype=torch.int64, device=device),
                 seq_lens_cpu=torch.tensor([fill_len], dtype=torch.int64),
                 last_loc=last_loc,
@@ -2345,9 +2330,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         if kv_manager is None:
             return
         pop_requests = getattr(kv_manager, "pop_pd_hidden_alloc_requests", None)
-        requeue_requests = getattr(
-            kv_manager, "requeue_pd_hidden_alloc_requests", None
-        )
+        requeue_requests = getattr(kv_manager, "requeue_pd_hidden_alloc_requests", None)
         grant_rows = getattr(kv_manager, "grant_pd_hidden_rows", None)
         if pop_requests is None or requeue_requests is None or grant_rows is None:
             return
@@ -2356,8 +2339,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         if not requests:
             return
         room_to_req = {
-            int(decode_req.req.bootstrap_room): decode_req
-            for decode_req in self.queue
+            int(decode_req.req.bootstrap_room): decode_req for decode_req in self.queue
         }
         pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
         deferred = []
@@ -2445,10 +2427,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 if dst_indices is None:
                     deferred.extend(requests[request_index:])
                     now = time.monotonic()
-                    if (
-                        now - self._last_pd_hidden_dynamic_credit_warning_time
-                        > 30
-                    ):
+                    if now - self._last_pd_hidden_dynamic_credit_warning_time > 30:
                         logger.warning(
                             "PD decode hidden pool waiting for dynamic credit: "
                             "rid=%s room=%s rows=%d free_rows=%d pool_rows=%d "
@@ -2659,10 +2638,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                         for key, allocation in dynamic_allocations.items()
                         if key[0] == int(chunk["prefill_rank"])
                         and key[1] == int(chunk["hidden_start"])
-                        and tuple(
-                            int(idx)
-                            for idx in allocation.get("dst_indices", [])
-                        )
+                        and tuple(int(idx) for idx in allocation.get("dst_indices", []))
                         == release_key
                     ),
                     None,
@@ -2872,7 +2848,9 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         dspark_pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
         if dspark_pool is None:
             raise RuntimeError("PD hidden row pool disappeared on decode.")
-        inject_chunk = getattr(self.scheduler.draft_worker, "inject_pd_hidden_chunk", None)
+        inject_chunk = getattr(
+            self.scheduler.draft_worker, "inject_pd_hidden_chunk", None
+        )
         if inject_chunk is None:
             raise RuntimeError(
                 "PD streaming hidden requires draft_worker.inject_pd_hidden_chunk."
@@ -2929,9 +2907,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 hidden,
                 hidden_chunk.hidden_start,
             )
-            submit_ack = getattr(
-                self.kv_manager, "submit_pd_hidden_chunk_ack", None
-            )
+            submit_ack = getattr(self.kv_manager, "submit_pd_hidden_chunk_ack", None)
             if submit_ack is None:
                 raise RuntimeError(
                     "PD streaming hidden backend is missing ACK completion API."

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2376,7 +2376,9 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 ):
                     deferred.append(request)
                 continue
-            if request_status in (None, KVPoll.Failed, KVPoll.Success):
+            # KV completion can race ahead of a later hidden allocation request.
+            # Keep servicing the room while its decode request is still queued.
+            if request_status in (None, KVPoll.Failed):
                 continue
             if not decode_req.pd_hidden_dynamic_allocation:
                 error_message = (

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -307,6 +307,10 @@ class DecodeRequest:
     pd_hidden_dst_indices_by_pp: Optional[Dict[int, List[int]]] = None
     pd_hidden_pp_slices: Optional[Dict[int, dict]] = None
     pd_hidden_start: int = 0
+    pd_hidden_dynamic_allocation: bool = False
+    pd_hidden_dynamic_allocations: Dict[Tuple[int, int, str], Dict[str, Any]] = field(
+        default_factory=dict
+    )
     pd_hidden_state: PDHiddenRequestState = field(
         default_factory=PDHiddenRequestState.disabled
     )
@@ -1298,6 +1302,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             pd_hidden_pp_slices = None
             pd_hidden_start = total_prefix_len
             pd_hidden_len = origin_input_len - total_prefix_len
+            pd_hidden_window_rows = 0
+            pd_hidden_dynamic_allocation = False
             state_types = self.kv_manager.kv_args.state_types
             if (
                 self.scheduler.spec_algorithm.is_dspark()
@@ -1485,42 +1491,54 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     failed_reqs.append(decode_req)
                     indices_to_remove.add(i)
                     continue
-                allocated_hidden_indices = dspark_pool.alloc(pd_hidden_window_rows)
-                if allocated_hidden_indices is None:
-                    if prefix_len > 0:
-                        self.tree_cache.dec_lock_ref(decode_req.req.last_node)
-                    now = time.monotonic()
-                    if (
-                        now - self._last_pd_hidden_recv_credit_warning_time
-                        > 30
-                    ):
-                        logger.warning(
-                            "PD decode hidden pool blocked prealloc: "
-                            "rid=%s window_rows=%d hidden_len=%d free_rows=%d pool_rows=%d "
-                            "prealloc_queue=%d transfer_queue=%d",
-                            decode_req.req.rid,
-                            pd_hidden_window_rows,
-                            pd_hidden_len,
-                            dspark_pool.available_size(),
-                            dspark_pool.size,
-                            len(self.queue),
-                            len(self.transfer_queue.queue),
-                        )
-                        self._last_pd_hidden_recv_credit_warning_time = now
-                    continue
-
                 pd_hidden_dst_indices_by_pp = {}
-                for pp_rank, pp_slice in pp_slices.items():
-                    if int(pp_slice.get("slice_len", 0)) <= 0:
+                pd_hidden_dynamic_allocation = bool(
+                    self.kv_manager.supports_pd_hidden_dynamic_allocation()
+                )
+                if pd_hidden_dynamic_allocation:
+                    # Bootstrap establishes the room, KV destination and hidden
+                    # layout only. Receive rows are granted later, in FIFO order,
+                    # after prefill has produced an actual hidden chunk.
+                    for pp_rank, pp_slice in pp_slices.items():
                         pp_slice["dst_indices"] = []
                         pd_hidden_dst_indices_by_pp[int(pp_rank)] = []
+                else:
+                    allocated_hidden_indices = dspark_pool.alloc(
+                        pd_hidden_window_rows
+                    )
+                    if allocated_hidden_indices is None:
+                        if prefix_len > 0:
+                            self.tree_cache.dec_lock_ref(decode_req.req.last_node)
+                        now = time.monotonic()
+                        if (
+                            now - self._last_pd_hidden_recv_credit_warning_time
+                            > 30
+                        ):
+                            logger.warning(
+                                "PD decode hidden pool blocked prealloc: "
+                                "rid=%s window_rows=%d hidden_len=%d free_rows=%d pool_rows=%d "
+                                "prealloc_queue=%d transfer_queue=%d",
+                                decode_req.req.rid,
+                                pd_hidden_window_rows,
+                                pd_hidden_len,
+                                dspark_pool.available_size(),
+                                dspark_pool.size,
+                                len(self.queue),
+                                len(self.transfer_queue.queue),
+                            )
+                            self._last_pd_hidden_recv_credit_warning_time = now
                         continue
-                    pp_slice["dst_indices"] = [
-                        int(x) for x in allocated_hidden_indices
-                    ]
-                    pd_hidden_dst_indices_by_pp[int(pp_rank)] = [
-                        int(x) for x in allocated_hidden_indices
-                    ]
+                    for pp_rank, pp_slice in pp_slices.items():
+                        if int(pp_slice.get("slice_len", 0)) <= 0:
+                            pp_slice["dst_indices"] = []
+                            pd_hidden_dst_indices_by_pp[int(pp_rank)] = []
+                            continue
+                        pp_slice["dst_indices"] = [
+                            int(x) for x in allocated_hidden_indices
+                        ]
+                        pd_hidden_dst_indices_by_pp[int(pp_rank)] = [
+                            int(x) for x in allocated_hidden_indices
+                        ]
                 pd_hidden_pp_slices = pp_slices
                 hidden_end = int(pd_hidden_start + pd_hidden_len)
                 decode_req.pd_hidden_state = (
@@ -1532,7 +1550,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                         int(pd_hidden_start), hidden_end
                     )
                 )
-                if pp_size == 1:
+                if pp_size == 1 and not pd_hidden_dynamic_allocation:
                     pd_hidden_dst_indices = pd_hidden_dst_indices_by_pp.get(0)
 
             dst_kv_indices = self._pre_alloc(
@@ -1545,6 +1563,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             decode_req.pd_hidden_dst_indices_by_pp = pd_hidden_dst_indices_by_pp
             decode_req.pd_hidden_pp_slices = pd_hidden_pp_slices
             decode_req.pd_hidden_start = pd_hidden_start
+            decode_req.pd_hidden_dynamic_allocation = pd_hidden_dynamic_allocation
             decode_req.prefix_match = prefix_match
             if self.scheduler.enable_decode_hicache:
                 self._start_hicache_prefetch(decode_req.req, prefix_match)
@@ -1739,8 +1758,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 spec_metadata = {
                     "pd_hidden": True,
                     "streaming_hidden": bool(decode_req.pd_hidden_state.streaming),
+                    "dynamic_hidden_allocation": bool(
+                        pd_hidden_dynamic_allocation
+                    ),
                     "streaming_window_rows": int(
-                        max(
+                        pd_hidden_window_rows
+                        if pd_hidden_dynamic_allocation
+                        else max(
                             (
                                 len(indices)
                                 for indices in (
@@ -2301,6 +2325,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         self.staging_handler = None
         self.kv_manager = None
+        self._last_pd_hidden_dynamic_credit_warning_time = 0.0
 
     def add(self, decode_req: DecodeRequest) -> None:
         self.queue.append(decode_req)
@@ -2314,6 +2339,155 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     and dr.kv_receiver.require_staging
                 ):
                     self.staging_handler.register_decode_req(dr.req.bootstrap_room, dr)
+
+    def _drain_pd_hidden_alloc_requests(self) -> None:
+        kv_manager = getattr(self, "kv_manager", None)
+        if kv_manager is None:
+            return
+        pop_requests = getattr(kv_manager, "pop_pd_hidden_alloc_requests", None)
+        requeue_requests = getattr(
+            kv_manager, "requeue_pd_hidden_alloc_requests", None
+        )
+        grant_rows = getattr(kv_manager, "grant_pd_hidden_rows", None)
+        if pop_requests is None or requeue_requests is None or grant_rows is None:
+            return
+
+        requests = pop_requests()
+        if not requests:
+            return
+        room_to_req = {
+            int(decode_req.req.bootstrap_room): decode_req
+            for decode_req in self.queue
+        }
+        pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
+        deferred = []
+        for request_index, request in enumerate(requests):
+            room = int(request["room"])
+            request_status = kv_manager.request_status.get(room)
+            decode_req = room_to_req.get(room)
+            if decode_req is None:
+                # A request can arrive just before the scheduler moves the room
+                # into this queue. Keep it only while the room is still live;
+                # late packets after clear/abort must not accumulate forever.
+                if request_status not in (
+                    None,
+                    KVPoll.Failed,
+                    KVPoll.Success,
+                ):
+                    deferred.append(request)
+                continue
+            if request_status in (None, KVPoll.Failed, KVPoll.Success):
+                continue
+            if not decode_req.pd_hidden_dynamic_allocation:
+                error_message = (
+                    "Received dynamic PD hidden allocation request for a static "
+                    f"room: rid={decode_req.req.rid}, room={room}"
+                )
+                kv_manager.record_failure(room, error_message)
+                kv_manager.update_status(room, KVPoll.Failed)
+                continue
+            if pool is None:
+                kv_manager.record_failure(
+                    room, "PD hidden row pool disappeared during dynamic allocation."
+                )
+                kv_manager.update_status(room, KVPoll.Failed)
+                continue
+
+            row_len = int(request["row_len"])
+            hidden_start = int(request["hidden_start"])
+            hidden_state = decode_req.pd_hidden_state
+            if row_len <= 0 or row_len > pool.size:
+                kv_manager.record_failure(
+                    room,
+                    "Invalid dynamic PD hidden allocation size: "
+                    f"rows={row_len}, pool_rows={pool.size}",
+                )
+                kv_manager.update_status(room, KVPoll.Failed)
+                continue
+            if hidden_start < hidden_state.next_start:
+                # Duplicate/stale request after the corresponding chunk has
+                # already advanced. It was granted previously and needs no new
+                # allocation.
+                continue
+            first_chunk_can_advance = (
+                hidden_start > hidden_state.next_start
+                and hidden_state.next_start == hidden_state.start
+            )
+            if (
+                (
+                    hidden_start != hidden_state.next_start
+                    and not first_chunk_can_advance
+                )
+                or hidden_start + row_len > hidden_state.end
+                or bool(request["is_last_hidden_chunk"])
+                != (hidden_start + row_len == hidden_state.end)
+            ):
+                kv_manager.record_failure(
+                    room,
+                    "Invalid dynamic PD hidden allocation range: "
+                    f"start={hidden_start}, rows={row_len}, "
+                    f"expected_start={hidden_state.next_start}, "
+                    f"hidden_end={hidden_state.end}, "
+                    f"is_last={request['is_last_hidden_chunk']}",
+                )
+                kv_manager.update_status(room, KVPoll.Failed)
+                continue
+            key = (
+                int(request["prefill_rank"]),
+                hidden_start,
+                str(request["session_id"]),
+            )
+            allocation = decode_req.pd_hidden_dynamic_allocations.get(key)
+            if allocation is None:
+                dst_indices = pool.alloc(row_len)
+                if dst_indices is None:
+                    deferred.extend(requests[request_index:])
+                    now = time.monotonic()
+                    if (
+                        now - self._last_pd_hidden_dynamic_credit_warning_time
+                        > 30
+                    ):
+                        logger.warning(
+                            "PD decode hidden pool waiting for dynamic credit: "
+                            "rid=%s room=%s rows=%d free_rows=%d pool_rows=%d "
+                            "ready_requests=%d transfer_queue=%d",
+                            decode_req.req.rid,
+                            room,
+                            row_len,
+                            pool.available_size(),
+                            pool.size,
+                            len(requests) - request_index,
+                            len(self.queue),
+                        )
+                        self._last_pd_hidden_dynamic_credit_warning_time = now
+                    break
+                allocation = {
+                    "request": dict(request),
+                    "dst_indices": [int(x) for x in dst_indices],
+                }
+                decode_req.pd_hidden_dynamic_allocations[key] = allocation
+            elif len(allocation["dst_indices"]) != row_len:
+                kv_manager.record_failure(
+                    room,
+                    "Conflicting dynamic PD hidden allocation request: "
+                    f"key={key}, existing_rows={len(allocation['dst_indices'])}, "
+                    f"requested_rows={row_len}",
+                )
+                kv_manager.update_status(room, KVPoll.Failed)
+                continue
+
+            try:
+                grant_rows(request, allocation["dst_indices"])
+            except Exception:
+                logger.exception(
+                    "Failed to grant dynamic PD hidden rows: room=%s key=%s",
+                    room,
+                    key,
+                )
+                deferred.extend(requests[request_index:])
+                break
+
+        requeue_requests(deferred)
 
     def _maybe_insert_dsv4_decode_radix_prompt(self, req: Req) -> None:
         if not getattr(req, "dsv4_decode_radix_cache_prompt_once", False):
@@ -2412,11 +2586,22 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 req.cache_protected_len = old_cache_protected_len
 
     def _release_pd_hidden_rows(self, decode_req: DecodeRequest) -> None:
-        wait_ack_completions = getattr(
-            self.kv_manager, "wait_pd_hidden_ack_completions", None
+        indices_by_pp = getattr(decode_req, "pd_hidden_dst_indices_by_pp", None)
+        indices = getattr(decode_req, "pd_hidden_dst_indices", None)
+        dynamic_allocations = getattr(decode_req, "pd_hidden_dynamic_allocations", {})
+        has_static_rows = bool(indices) or bool(
+            indices_by_pp
+            and any(bool(pp_indices) for pp_indices in indices_by_pp.values())
         )
-        if wait_ack_completions is not None and not wait_ack_completions(
-            decode_req.req.bootstrap_room
+        has_dynamic_rows = bool(dynamic_allocations)
+        kv_manager = getattr(self, "kv_manager", None)
+        wait_ack_completions = getattr(
+            kv_manager, "wait_pd_hidden_ack_completions", None
+        )
+        if (
+            (has_static_rows or has_dynamic_rows)
+            and wait_ack_completions is not None
+            and not wait_ack_completions(decode_req.req.bootstrap_room)
         ):
             logger.error(
                 "Timed out waiting for PD hidden ACK completion before "
@@ -2425,13 +2610,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 decode_req.req.bootstrap_room,
             )
             return
-        pop_acked_chunks = getattr(
-            self.kv_manager, "pop_pd_hidden_acked_chunks", None
-        )
-        if pop_acked_chunks is not None:
-            pop_acked_chunks(decode_req.req.bootstrap_room)
-        indices_by_pp = decode_req.pd_hidden_dst_indices_by_pp
-        indices = decode_req.pd_hidden_dst_indices
+        self._consume_pd_hidden_acked_chunks(decode_req)
         pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
         if pool is not None:
             if indices_by_pp is not None:
@@ -2444,20 +2623,57 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     pool.free(pp_indices)
             elif indices is not None:
                 pool.free(indices)
+            seen_dynamic = set()
+            for allocation in dynamic_allocations.values():
+                dynamic_indices = allocation.get("dst_indices") or []
+                key = tuple(int(idx) for idx in dynamic_indices)
+                if not key or key in seen_dynamic:
+                    continue
+                seen_dynamic.add(key)
+                pool.free(dynamic_indices)
+        dynamic_allocations.clear()
         decode_req.pd_hidden_dst_indices = None
         decode_req.pd_hidden_dst_indices_by_pp = None
         decode_req.pd_hidden_pp_slices = None
-        decode_req.pd_hidden_state.reset()
+        hidden_state = getattr(decode_req, "pd_hidden_state", None)
+        if hidden_state is not None:
+            hidden_state.reset()
 
     def _consume_pd_hidden_acked_chunks(self, decode_req: DecodeRequest) -> None:
-        pop_acked_chunks = getattr(
-            self.kv_manager, "pop_pd_hidden_acked_chunks", None
-        )
+        kv_manager = getattr(self, "kv_manager", None)
+        if kv_manager is None:
+            return
+        pop_acked_chunks = getattr(kv_manager, "pop_pd_hidden_acked_chunks", None)
         if pop_acked_chunks is None:
             return
+        dynamic_allocations = getattr(decode_req, "pd_hidden_dynamic_allocations", {})
         for chunk in pop_acked_chunks(decode_req.req.bootstrap_room):
+            release_indices = chunk.get("release_indices") or []
+            if release_indices:
+                release_key = tuple(int(idx) for idx in release_indices)
+                allocation_key = next(
+                    (
+                        key
+                        for key, allocation in dynamic_allocations.items()
+                        if key[0] == int(chunk["prefill_rank"])
+                        and key[1] == int(chunk["hidden_start"])
+                        and tuple(
+                            int(idx)
+                            for idx in allocation.get("dst_indices", [])
+                        )
+                        == release_key
+                    ),
+                    None,
+                )
+                if allocation_key is not None:
+                    pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
+                    if pool is not None:
+                        pool.free(release_indices)
+                    dynamic_allocations.pop(allocation_key, None)
             if chunk.get("is_last_hidden_chunk"):
-                decode_req.pd_hidden_state.mark_hidden_done()
+                hidden_state = getattr(decode_req, "pd_hidden_state", None)
+                if hidden_state is not None:
+                    hidden_state.mark_hidden_done()
 
     def _commit_transfer_to_req(self, decode_req: DecodeRequest):
         idx = decode_req.metadata_buffer_index
@@ -2640,8 +2856,8 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         )
 
     def _drain_pd_hidden_ready_chunks(self, decode_req: DecodeRequest) -> None:
-        hidden_state = decode_req.pd_hidden_state
-        if not hidden_state.streaming:
+        hidden_state = getattr(decode_req, "pd_hidden_state", None)
+        if hidden_state is None or not hidden_state.streaming:
             return
         pop_chunks = getattr(self.kv_manager, "pop_pd_hidden_ready_chunks", None)
         if pop_chunks is None:
@@ -2732,6 +2948,11 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 prefill_rank=int(hidden_chunk.prefill_rank),
                 hidden_start=int(hidden_chunk.hidden_start),
                 is_last_hidden_chunk=hidden_chunk.is_last_hidden_chunk,
+                release_indices=(
+                    hidden_chunk.dst_indices
+                    if decode_req.pd_hidden_dynamic_allocation
+                    else None
+                ),
             )
 
     def _init_staging_handler(self, kv_manager):
@@ -2748,6 +2969,27 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
     def pop_transferred(self, rids_to_check: Optional[List[str]] = None) -> List[Req]:
         if not self.queue:
             return []
+
+        # Reclaim rows whose CUDA injection has completed before serving new
+        # allocation requests. This is the credit handoff that guarantees a
+        # completed chunk can unblock the oldest prefill-complete chunk.
+        for decode_req in self.queue:
+            try:
+                self._consume_pd_hidden_acked_chunks(decode_req)
+            except Exception as e:
+                room = decode_req.req.bootstrap_room
+                self.kv_manager.record_failure(
+                    room,
+                    "Failed to reclaim dynamically allocated PD hidden rows: "
+                    f"rid={decode_req.req.rid}, error={e}",
+                )
+                self.kv_manager.update_status(room, KVPoll.Failed)
+
+        # Allocation requests are emitted only after Prefill has materialized a
+        # hidden chunk. Grant rows before polling transfer completion so scarce
+        # receive credit follows prefill-completion order instead of bootstrap
+        # order.
+        self._drain_pd_hidden_alloc_requests()
 
         if self.scheduler.enable_decode_hicache:
             self._process_hicache_local_restores(

--- a/python/sglang/srt/disaggregation/hidden_events.py
+++ b/python/sglang/srt/disaggregation/hidden_events.py
@@ -52,6 +52,9 @@ class PDHiddenEventManager:
             defaultdict(dict)
         )
         self.alloc_waiters = {}
+        self.alloc_waiter_timers: Dict[
+            Tuple[int, int, int], threading.Timer
+        ] = {}
         self.expected_alloc_grants: Set[Tuple[int, int, int]] = set()
         self.alloc_grant_lock = threading.Lock()
         self.ack_wakeup_endpoint: Optional[str] = None
@@ -63,6 +66,8 @@ class PDHiddenEventManager:
         return True
 
     def init_prefill_state(self) -> None:
+        for timer in self.alloc_waiter_timers.values():
+            timer.cancel()
         self.done_rooms.clear()
         self.active_rooms.clear()
         self.deferred_clear_rooms.clear()
@@ -73,6 +78,7 @@ class PDHiddenEventManager:
         self.active_transfers.clear()
         self.alloc_grants.clear()
         self.alloc_waiters.clear()
+        self.alloc_waiter_timers.clear()
         self.expected_alloc_grants.clear()
 
     def init_decode_state(self) -> None:
@@ -230,6 +236,11 @@ class PDHiddenEventManager:
                 for key in list(self.alloc_waiters)
                 if key[0] == room
             ]
+            alloc_waiter_timers = [
+                self.alloc_waiter_timers.pop(key)
+                for key in list(self.alloc_waiter_timers)
+                if key[0] == room
+            ]
             for key in list(self.alloc_grants):
                 if key[0] == room:
                     self.alloc_grants.pop(key, None)
@@ -240,6 +251,8 @@ class PDHiddenEventManager:
             transfer_queue.put(kv_chunk)
         for transfer_queue, kv_chunk in room_waiters:
             transfer_queue.put(kv_chunk)
+        for timer in alloc_waiter_timers:
+            timer.cancel()
         for transfer_queue, kv_chunk, _ in alloc_waiters:
             transfer_queue.put(kv_chunk)
 
@@ -282,32 +295,15 @@ class PDHiddenEventManager:
         expected = {str(session_id) for session_id in expected_session_ids}
         if not expected:
             return {}
-        created_waiter = False
-        with self.alloc_grant_lock:
-            grants = self.alloc_grants.get(key, {})
-            if expected.issubset(grants):
-                result = {
-                    session_id: [int(x) for x in grants[session_id]]
-                    for session_id in expected
-                }
-                self.alloc_grants.pop(key, None)
-                self.alloc_waiters.pop(key, None)
-                self.expected_alloc_grants.discard(key)
-                return result
-            if key not in self.alloc_waiters:
-                self.alloc_waiters[key] = (transfer_queue, kv_chunk, expected)
-                created_waiter = True
-
-        if not created_waiter:
-            return None
 
         def on_timeout() -> None:
             with self.alloc_grant_lock:
                 waiter = self.alloc_waiters.pop(key, None)
+                self.alloc_waiter_timers.pop(key, None)
+                if waiter is None:
+                    return
                 self.alloc_grants.pop(key, None)
                 self.expected_alloc_grants.discard(key)
-            if waiter is None:
-                return
             _, timed_out_chunk, _ = waiter
             timed_out_chunk.pd_hidden_alloc_timed_out = True
             self.owner.record_failure(
@@ -319,9 +315,29 @@ class PDHiddenEventManager:
             transfer_queue.put(timed_out_chunk)
             self.wake_ack_waiters(key[0])
 
-        timer = threading.Timer(float(timeout_s), on_timeout)
-        timer.daemon = True
-        timer.start()
+        with self.alloc_grant_lock:
+            grants = self.alloc_grants.get(key, {})
+            if expected.issubset(grants):
+                result = {
+                    session_id: [int(x) for x in grants[session_id]]
+                    for session_id in expected
+                }
+                self.alloc_grants.pop(key, None)
+                self.alloc_waiters.pop(key, None)
+                timer = self.alloc_waiter_timers.pop(key, None)
+                if timer is not None:
+                    timer.cancel()
+                self.expected_alloc_grants.discard(key)
+                return result
+            if key in self.alloc_waiters:
+                return None
+            self.alloc_waiters[key] = (transfer_queue, kv_chunk, expected)
+            timer = threading.Timer(float(timeout_s), on_timeout)
+            timer.daemon = True
+            self.alloc_waiter_timers[key] = timer
+            # Start while holding the lock so a grant cannot arrive between
+            # waiter registration and timer registration.
+            timer.start()
         return None
 
     def expect_alloc_grants(
@@ -358,6 +374,7 @@ class PDHiddenEventManager:
     ) -> None:
         key = (int(room), int(prefill_rank), int(hidden_start))
         waiter_to_wake = None
+        timer_to_cancel = None
         with self.alloc_grant_lock:
             if key not in self.expected_alloc_grants:
                 return
@@ -369,6 +386,9 @@ class PDHiddenEventManager:
                 _, _, expected = waiter
                 if expected.issubset(self.alloc_grants[key]):
                     waiter_to_wake = self.alloc_waiters.pop(key)
+                    timer_to_cancel = self.alloc_waiter_timers.pop(key, None)
+        if timer_to_cancel is not None:
+            timer_to_cancel.cancel()
         if waiter_to_wake is not None:
             transfer_queue, kv_chunk, _ = waiter_to_wake
             transfer_queue.put(kv_chunk)

--- a/python/sglang/srt/disaggregation/hidden_events.py
+++ b/python/sglang/srt/disaggregation/hidden_events.py
@@ -28,6 +28,9 @@ class PDHiddenEventManager:
         self.owner = owner
         self.done_rooms = set()
         self.done_lock = threading.Lock()
+        self.active_rooms = set()
+        self.deferred_clear_rooms = set()
+        self.active_room_lock = threading.Lock()
         self.chunk_acks = defaultdict(int)
         self.chunk_ack_cv = threading.Condition()
         self.ack_waiters = {}
@@ -49,6 +52,7 @@ class PDHiddenEventManager:
             defaultdict(dict)
         )
         self.alloc_waiters = {}
+        self.expected_alloc_grants: Set[Tuple[int, int, int]] = set()
         self.alloc_grant_lock = threading.Lock()
         self.ack_wakeup_endpoint: Optional[str] = None
         self.ack_wakeup_receiver = None
@@ -60,6 +64,8 @@ class PDHiddenEventManager:
 
     def init_prefill_state(self) -> None:
         self.done_rooms.clear()
+        self.active_rooms.clear()
+        self.deferred_clear_rooms.clear()
         self.chunk_acks.clear()
         self.ack_waiters.clear()
         self.room_waiters.clear()
@@ -67,6 +73,7 @@ class PDHiddenEventManager:
         self.active_transfers.clear()
         self.alloc_grants.clear()
         self.alloc_waiters.clear()
+        self.expected_alloc_grants.clear()
 
     def init_decode_state(self) -> None:
         self.ready_chunks.clear()
@@ -86,6 +93,7 @@ class PDHiddenEventManager:
         bootstrap_room: int,
         state_indices: Optional[List] = None,
     ) -> None:
+        self.end_request(bootstrap_room)
         with self.done_lock:
             room = int(bootstrap_room)
             if room in self.done_rooms:
@@ -109,6 +117,35 @@ class PDHiddenEventManager:
             if room not in self.done_rooms:
                 return False
             self.done_rooms.remove(room)
+            return True
+
+    def begin_request(self, bootstrap_room: int) -> None:
+        with self.active_room_lock:
+            self.active_rooms.add(int(bootstrap_room))
+
+    def end_request(self, bootstrap_room: int) -> None:
+        with self.active_room_lock:
+            self.active_rooms.discard(int(bootstrap_room))
+
+    def request_active(self, bootstrap_room: int) -> bool:
+        with self.active_room_lock:
+            return int(bootstrap_room) in self.active_rooms
+
+    def defer_clear_if_active(self, bootstrap_room: int) -> bool:
+        """Atomically defer sender cleanup while hidden transfer is live."""
+        room = int(bootstrap_room)
+        with self.active_room_lock:
+            if room not in self.active_rooms:
+                return False
+            self.deferred_clear_rooms.add(room)
+            return True
+
+    def take_deferred_clear(self, bootstrap_room: int) -> bool:
+        room = int(bootstrap_room)
+        with self.active_room_lock:
+            if room not in self.deferred_clear_rooms:
+                return False
+            self.deferred_clear_rooms.remove(room)
             return True
 
     def park_chunk_for_ack(
@@ -174,6 +211,12 @@ class PDHiddenEventManager:
 
     def wake_ack_waiters(self, room: int) -> None:
         room = int(room)
+        self.end_request(room)
+        finish_deferred_clear = getattr(
+            self.owner, "finish_deferred_sender_clear", None
+        )
+        if finish_deferred_clear is not None:
+            finish_deferred_clear(room)
         with self.chunk_ack_cv:
             waiters = [
                 self.ack_waiters.pop(key)
@@ -190,6 +233,9 @@ class PDHiddenEventManager:
             for key in list(self.alloc_grants):
                 if key[0] == room:
                     self.alloc_grants.pop(key, None)
+            self.expected_alloc_grants = {
+                key for key in self.expected_alloc_grants if key[0] != room
+            }
         for transfer_queue, kv_chunk in waiters:
             transfer_queue.put(kv_chunk)
         for transfer_queue, kv_chunk in room_waiters:
@@ -246,6 +292,7 @@ class PDHiddenEventManager:
                 }
                 self.alloc_grants.pop(key, None)
                 self.alloc_waiters.pop(key, None)
+                self.expected_alloc_grants.discard(key)
                 return result
             if key not in self.alloc_waiters:
                 self.alloc_waiters[key] = (transfer_queue, kv_chunk, expected)
@@ -258,6 +305,7 @@ class PDHiddenEventManager:
             with self.alloc_grant_lock:
                 waiter = self.alloc_waiters.pop(key, None)
                 self.alloc_grants.pop(key, None)
+                self.expected_alloc_grants.discard(key)
             if waiter is None:
                 return
             _, timed_out_chunk, _ = waiter
@@ -276,6 +324,29 @@ class PDHiddenEventManager:
         timer.start()
         return None
 
+    def expect_alloc_grants(
+        self,
+        *,
+        room: int,
+        prefill_rank: int,
+        hidden_start: int,
+    ) -> None:
+        """Register a hidden allocation independently of the KV room status."""
+        key = (int(room), int(prefill_rank), int(hidden_start))
+        with self.alloc_grant_lock:
+            self.expected_alloc_grants.add(key)
+
+    def expects_alloc_grant(
+        self,
+        *,
+        room: int,
+        prefill_rank: int,
+        hidden_start: int,
+    ) -> bool:
+        key = (int(room), int(prefill_rank), int(hidden_start))
+        with self.alloc_grant_lock:
+            return key in self.expected_alloc_grants
+
     def handle_alloc_grant(
         self,
         *,
@@ -288,6 +359,8 @@ class PDHiddenEventManager:
         key = (int(room), int(prefill_rank), int(hidden_start))
         waiter_to_wake = None
         with self.alloc_grant_lock:
+            if key not in self.expected_alloc_grants:
+                return
             self.alloc_grants[key][str(session_id)] = [
                 int(x) for x in dst_indices
             ]

--- a/python/sglang/srt/disaggregation/hidden_events.py
+++ b/python/sglang/srt/disaggregation/hidden_events.py
@@ -5,7 +5,7 @@ import queue
 import threading
 import time
 from collections import defaultdict, deque
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import torch
 import zmq
@@ -43,6 +43,13 @@ class PDHiddenEventManager:
         self.ack_completion_cv = threading.Condition()
         self.acked_chunks: Dict[int, List[dict]] = defaultdict(list)
         self.acked_lock = threading.Lock()
+        self.alloc_requests = deque()
+        self.alloc_request_lock = threading.Lock()
+        self.alloc_grants: Dict[Tuple[int, int, int], Dict[str, List[int]]] = (
+            defaultdict(dict)
+        )
+        self.alloc_waiters = {}
+        self.alloc_grant_lock = threading.Lock()
         self.ack_wakeup_endpoint: Optional[str] = None
         self.ack_wakeup_receiver = None
         self.ack_wakeup_sender = None
@@ -58,12 +65,15 @@ class PDHiddenEventManager:
         self.room_waiters.clear()
         self.inflight_chunks.clear()
         self.active_transfers.clear()
+        self.alloc_grants.clear()
+        self.alloc_waiters.clear()
 
     def init_decode_state(self) -> None:
         self.ready_chunks.clear()
         self.ack_completions = queue.SimpleQueue()
         self.ack_pending_counts.clear()
         self.acked_chunks.clear()
+        self.alloc_requests.clear()
         self.ack_wakeup_endpoint = f"inproc://pd-hidden-ack-{id(self)}"
         self.ack_wakeup_receiver = self.owner._zmq_ctx.socket(zmq.PULL)
         self.ack_wakeup_receiver.bind(self.ack_wakeup_endpoint)
@@ -171,9 +181,123 @@ class PDHiddenEventManager:
                 if key[0] == room
             ]
             room_waiters = list(self.room_waiters.pop(room, []))
+        with self.alloc_grant_lock:
+            alloc_waiters = [
+                self.alloc_waiters.pop(key)
+                for key in list(self.alloc_waiters)
+                if key[0] == room
+            ]
+            for key in list(self.alloc_grants):
+                if key[0] == room:
+                    self.alloc_grants.pop(key, None)
         for transfer_queue, kv_chunk in waiters:
             transfer_queue.put(kv_chunk)
         for transfer_queue, kv_chunk in room_waiters:
+            transfer_queue.put(kv_chunk)
+        for transfer_queue, kv_chunk, _ in alloc_waiters:
+            transfer_queue.put(kv_chunk)
+
+    def append_alloc_request(self, request: dict) -> None:
+        """Queue a prefill-complete hidden chunk for decode-side row allocation."""
+        with self.alloc_request_lock:
+            self.alloc_requests.append(dict(request))
+
+    def pop_alloc_requests(self) -> List[dict]:
+        """Pop pending allocation requests in global prefill-completion order."""
+        with self.alloc_request_lock:
+            requests = list(self.alloc_requests)
+            self.alloc_requests.clear()
+        return requests
+
+    def requeue_alloc_requests_front(self, requests: List[dict]) -> None:
+        """Restore deferred requests without changing their FIFO order."""
+        if not requests:
+            return
+        with self.alloc_request_lock:
+            self.alloc_requests.extendleft(reversed(requests))
+
+    def take_alloc_grants_or_park(
+        self,
+        *,
+        transfer_queue: FastQueue,
+        kv_chunk: TransferKVChunk,
+        prefill_rank: int,
+        expected_session_ids: Set[str],
+        timeout_s: float = 300.0,
+    ) -> Optional[Dict[str, List[int]]]:
+        """Return all destination grants, or park the chunk until they arrive."""
+        if kv_chunk.pd_hidden_start is None:
+            return {}
+        key = (
+            int(kv_chunk.room),
+            int(prefill_rank),
+            int(kv_chunk.pd_hidden_start),
+        )
+        expected = {str(session_id) for session_id in expected_session_ids}
+        if not expected:
+            return {}
+        created_waiter = False
+        with self.alloc_grant_lock:
+            grants = self.alloc_grants.get(key, {})
+            if expected.issubset(grants):
+                result = {
+                    session_id: [int(x) for x in grants[session_id]]
+                    for session_id in expected
+                }
+                self.alloc_grants.pop(key, None)
+                self.alloc_waiters.pop(key, None)
+                return result
+            if key not in self.alloc_waiters:
+                self.alloc_waiters[key] = (transfer_queue, kv_chunk, expected)
+                created_waiter = True
+
+        if not created_waiter:
+            return None
+
+        def on_timeout() -> None:
+            with self.alloc_grant_lock:
+                waiter = self.alloc_waiters.pop(key, None)
+                self.alloc_grants.pop(key, None)
+            if waiter is None:
+                return
+            _, timed_out_chunk, _ = waiter
+            timed_out_chunk.pd_hidden_alloc_timed_out = True
+            self.owner.record_failure(
+                key[0],
+                "Timed out waiting for dynamic PD hidden row grants: "
+                f"prefill_rank={key[1]}, hidden_start={key[2]}",
+            )
+            self.owner.update_status(key[0], KVPoll.Failed)
+            transfer_queue.put(timed_out_chunk)
+            self.wake_ack_waiters(key[0])
+
+        timer = threading.Timer(float(timeout_s), on_timeout)
+        timer.daemon = True
+        timer.start()
+        return None
+
+    def handle_alloc_grant(
+        self,
+        *,
+        room: int,
+        prefill_rank: int,
+        hidden_start: int,
+        session_id: str,
+        dst_indices: List[int],
+    ) -> None:
+        key = (int(room), int(prefill_rank), int(hidden_start))
+        waiter_to_wake = None
+        with self.alloc_grant_lock:
+            self.alloc_grants[key][str(session_id)] = [
+                int(x) for x in dst_indices
+            ]
+            waiter = self.alloc_waiters.get(key)
+            if waiter is not None:
+                _, _, expected = waiter
+                if expected.issubset(self.alloc_grants[key]):
+                    waiter_to_wake = self.alloc_waiters.pop(key)
+        if waiter_to_wake is not None:
+            transfer_queue, kv_chunk, _ = waiter_to_wake
             transfer_queue.put(kv_chunk)
 
     def park_chunk_behind_room(
@@ -231,6 +355,7 @@ class PDHiddenEventManager:
         prefill_rank: int,
         hidden_start: int,
         is_last_hidden_chunk: bool,
+        release_indices: Optional[List[int]] = None,
     ) -> None:
         completion = {
             "remote": remote,
@@ -239,6 +364,9 @@ class PDHiddenEventManager:
             "prefill_rank": int(prefill_rank),
             "hidden_start": int(hidden_start),
             "is_last_hidden_chunk": bool(is_last_hidden_chunk),
+            "release_indices": (
+                [int(x) for x in release_indices] if release_indices else None
+            ),
         }
         with self.ack_completion_cv:
             self.ack_pending_counts[int(room)] += 1

--- a/python/sglang/srt/disaggregation/hidden_events.py
+++ b/python/sglang/srt/disaggregation/hidden_events.py
@@ -52,9 +52,7 @@ class PDHiddenEventManager:
             defaultdict(dict)
         )
         self.alloc_waiters = {}
-        self.alloc_waiter_timers: Dict[
-            Tuple[int, int, int], threading.Timer
-        ] = {}
+        self.alloc_waiter_timers: Dict[Tuple[int, int, int], threading.Timer] = {}
         self.expected_alloc_grants: Set[Tuple[int, int, int]] = set()
         self.alloc_grant_lock = threading.Lock()
         self.ack_wakeup_endpoint: Optional[str] = None
@@ -378,9 +376,7 @@ class PDHiddenEventManager:
         with self.alloc_grant_lock:
             if key not in self.expected_alloc_grants:
                 return
-            self.alloc_grants[key][str(session_id)] = [
-                int(x) for x in dst_indices
-            ]
+            self.alloc_grants[key][str(session_id)] = [int(x) for x in dst_indices]
             waiter = self.alloc_waiters.get(key)
             if waiter is not None:
                 _, _, expected = waiter
@@ -612,7 +608,11 @@ class PDHiddenEventManager:
         if not release_indices:
             return kv_chunk.state_indices
         idx = self.state_index()
-        if idx is None or not kv_chunk.state_indices or idx >= len(kv_chunk.state_indices):
+        if (
+            idx is None
+            or not kv_chunk.state_indices
+            or idx >= len(kv_chunk.state_indices)
+        ):
             return kv_chunk.state_indices
         ret = list(kv_chunk.state_indices)
         ret[idx] = [int(x) for x in release_indices]

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -202,6 +202,8 @@ class MooncakeKVManager(CommonKVManager):
     AUX_DATA_HEADER = b"AUX_DATA"
     PD_HIDDEN_CHUNK_READY_HEADER = b"PD_HIDDEN_CHUNK_READY"
     PD_HIDDEN_CHUNK_ACK_HEADER = b"PD_HIDDEN_CHUNK_ACK"
+    PD_HIDDEN_ALLOC_REQUEST_HEADER = b"PD_HIDDEN_ALLOC_REQUEST"
+    PD_HIDDEN_ALLOC_GRANT_HEADER = b"PD_HIDDEN_ALLOC_GRANT"
 
     def __init__(
         self,
@@ -308,6 +310,80 @@ class MooncakeKVManager(CommonKVManager):
     def supports_pd_hidden_streaming(self) -> bool:
         return self.pd_hidden_events.supports_streaming()
 
+    def supports_pd_hidden_dynamic_allocation(self) -> bool:
+        return True
+
+    def pop_pd_hidden_alloc_requests(self) -> List[dict]:
+        return self.pd_hidden_events.pop_alloc_requests()
+
+    def requeue_pd_hidden_alloc_requests(self, requests: List[dict]) -> None:
+        self.pd_hidden_events.requeue_alloc_requests_front(requests)
+
+    def take_pd_hidden_alloc_grants_or_park(
+        self,
+        *,
+        transfer_queue: FastQueue,
+        kv_chunk: TransferKVChunk,
+        prefill_rank: int,
+        expected_session_ids: set[str],
+    ) -> Optional[dict[str, List[int]]]:
+        return self.pd_hidden_events.take_alloc_grants_or_park(
+            transfer_queue=transfer_queue,
+            kv_chunk=kv_chunk,
+            prefill_rank=prefill_rank,
+            expected_session_ids=expected_session_ids,
+        )
+
+    def request_pd_hidden_rows(
+        self,
+        *,
+        remote: str,
+        dst_port: int,
+        room: int,
+        prefill_rank: int,
+        hidden_start: int,
+        row_len: int,
+        is_last_hidden_chunk: bool,
+        session_id: str,
+    ) -> None:
+        na = NetworkAddress(remote, dst_port)
+        self._send_multipart(
+            na.to_tcp(),
+            [
+                self.PD_HIDDEN_ALLOC_REQUEST_HEADER,
+                str(room).encode("ascii"),
+                str(prefill_rank).encode("ascii"),
+                str(hidden_start).encode("ascii"),
+                str(row_len).encode("ascii"),
+                b"1" if is_last_hidden_chunk else b"0",
+                str(session_id).encode("utf-8"),
+                self.local_ip.encode("ascii"),
+                str(self.rank_port).encode("ascii"),
+            ],
+            is_ipv6=na.is_ipv6,
+        )
+
+    def grant_pd_hidden_rows(
+        self, request: dict, dst_indices: List[int]
+    ) -> None:
+        na = NetworkAddress(request["reply_host"], int(request["reply_port"]))
+        self._send_multipart(
+            na.to_tcp(),
+            [
+                self.PD_HIDDEN_ALLOC_GRANT_HEADER,
+                str(request["room"]).encode("ascii"),
+                str(request["prefill_rank"]).encode("ascii"),
+                str(request["hidden_start"]).encode("ascii"),
+                str(request["session_id"]).encode("utf-8"),
+                struct.pack(
+                    f"<{len(dst_indices)}i", *[int(x) for x in dst_indices]
+                )
+                if dst_indices
+                else b"",
+            ],
+            is_ipv6=na.is_ipv6,
+        )
+
     def mark_pd_hidden_request_done(
         self,
         bootstrap_room: int,
@@ -377,6 +453,7 @@ class MooncakeKVManager(CommonKVManager):
         prefill_rank: int,
         hidden_start: int,
         is_last_hidden_chunk: bool,
+        release_indices: Optional[List[int]] = None,
     ) -> None:
         self.pd_hidden_events.submit_chunk_ack(
             event=event,
@@ -386,6 +463,7 @@ class MooncakeKVManager(CommonKVManager):
             prefill_rank=prefill_rank,
             hidden_start=hidden_start,
             is_last_hidden_chunk=is_last_hidden_chunk,
+            release_indices=release_indices,
         )
 
     def _drain_pd_hidden_ack_completions(self) -> None:
@@ -2317,6 +2395,7 @@ class MooncakeKVManager(CommonKVManager):
         prefill_state_indices: List,
         packet_idx: int,
         executor: concurrent.futures.ThreadPoolExecutor,
+        dst_indices_override: Optional[List[int]] = None,
     ) -> Tuple[int, bool]:
         state_idx = self._pd_hidden_state_index()
         if state_idx is None or state_idx >= len(prefill_state_indices):
@@ -2325,6 +2404,33 @@ class MooncakeKVManager(CommonKVManager):
         if indices is None:
             return 0, True
         src_indices = np.asarray(indices, dtype=np.int32)
+        if dst_indices_override is not None:
+            dst_indices = np.asarray(dst_indices_override, dtype=np.int32)
+            if len(src_indices) != len(dst_indices):
+                raise RuntimeError(
+                    "Dynamic PD_HIDDEN state index length mismatch: "
+                    f"room={req.room}, prefill={len(src_indices)}, "
+                    f"dst={len(dst_indices)}"
+                )
+            target_rank_registration_info = self.decode_kv_args_table[
+                req.mooncake_session_id
+            ]
+            dst_data_ptrs = (
+                target_rank_registration_info.dst_state_data_ptrs[state_idx]
+                if state_idx < len(target_rank_registration_info.dst_state_data_ptrs)
+                else []
+            )
+            rc = self._send_kvcache_generic(
+                mooncake_session_id=req.mooncake_session_id,
+                src_data_ptrs=self.kv_args.state_data_ptrs[state_idx],
+                dst_data_ptrs=dst_data_ptrs,
+                item_lens=self.kv_args.state_item_lens[state_idx],
+                prefill_data_indices=src_indices,
+                dst_data_indices=dst_indices,
+                executor=executor,
+                state_type=StateType.PD_HIDDEN,
+            )
+            return rc, True
         dynamic_dst = (req.spec_metadata or {}).get("pp_slice", {}).get("dynamic_dst")
         if not dynamic_dst:
             if packet_idx > 0:
@@ -2604,6 +2710,8 @@ class MooncakeKVManager(CommonKVManager):
                 staging_deferred = False
                 pd_hidden_deferred = False
                 pd_hidden_failed = False
+                pd_hidden_dynamic_allocation = False
+                pd_hidden_expected_sessions = set()
                 if (
                     not kv_chunk.pd_hidden_sent
                     and kv_chunk.state_indices
@@ -2621,6 +2729,15 @@ class MooncakeKVManager(CommonKVManager):
                         )
                         if not skip_state:
                             pd_hidden_expected += 1
+                            pd_hidden_expected_sessions.add(req.mooncake_session_id)
+                            pd_hidden_dynamic_allocation = (
+                                pd_hidden_dynamic_allocation
+                                or bool(
+                                    (req.spec_metadata or {}).get(
+                                        "dynamic_hidden_allocation", False
+                                    )
+                                )
+                            )
 
                     waiting_for_ack = (
                         kv_chunk.pd_hidden_start is not None
@@ -2644,6 +2761,42 @@ class MooncakeKVManager(CommonKVManager):
                                 queue, kv_chunk
                             )
                             continue
+                    if (
+                        pd_hidden_dynamic_allocation
+                        and kv_chunk.pd_hidden_start is not None
+                        and not kv_chunk.pd_hidden_ready_sent
+                    ):
+                        if not kv_chunk.pd_hidden_alloc_requested:
+                            for req in reqs_to_be_processed:
+                                if (
+                                    req.is_dummy
+                                    or req.mooncake_session_id
+                                    not in pd_hidden_expected_sessions
+                                ):
+                                    continue
+                                self.request_pd_hidden_rows(
+                                    remote=req.endpoint,
+                                    dst_port=req.dst_port,
+                                    room=req.room,
+                                    prefill_rank=prefill_unique_rank,
+                                    hidden_start=int(kv_chunk.pd_hidden_start),
+                                    row_len=int(kv_chunk.pd_hidden_row_len),
+                                    is_last_hidden_chunk=bool(
+                                        kv_chunk.pd_hidden_is_last_chunk
+                                    ),
+                                    session_id=req.mooncake_session_id,
+                                )
+                            kv_chunk.pd_hidden_alloc_requested = True
+                        if kv_chunk.pd_hidden_alloc_grants is None:
+                            grants = self.take_pd_hidden_alloc_grants_or_park(
+                                transfer_queue=queue,
+                                kv_chunk=kv_chunk,
+                                prefill_rank=prefill_unique_rank,
+                                expected_session_ids=pd_hidden_expected_sessions,
+                            )
+                            if grants is None:
+                                continue
+                            kv_chunk.pd_hidden_alloc_grants = grants
                     ack_ready = False
                     if waiting_for_ack:
                         ack_ready = kv_chunk.pd_hidden_ack_ready
@@ -2681,6 +2834,15 @@ class MooncakeKVManager(CommonKVManager):
                                         kv_chunk.state_indices,
                                         kv_chunk.pd_hidden_packet_idx,
                                         executor,
+                                        (
+                                            kv_chunk.pd_hidden_alloc_grants.get(
+                                                req.mooncake_session_id
+                                            )
+                                            if pd_hidden_dynamic_allocation
+                                            and kv_chunk.pd_hidden_alloc_grants
+                                            is not None
+                                            else None
+                                        ),
                                     )
                                 )
                             finally:
@@ -2713,15 +2875,23 @@ class MooncakeKVManager(CommonKVManager):
                                 and state_idx is not None
                                 and state_idx < len(kv_chunk.state_indices)
                             ):
-                                dst_indices = (
-                                    req.dst_state_indices[state_idx]
-                                    if state_idx < len(req.dst_state_indices)
-                                    else []
-                                )
                                 row_len = int(kv_chunk.pd_hidden_row_len)
-                                chunk_dst_indices = [
-                                    int(x) for x in dst_indices[:row_len]
-                                ]
+                                if pd_hidden_dynamic_allocation:
+                                    chunk_dst_indices = [
+                                        int(x)
+                                        for x in (
+                                            kv_chunk.pd_hidden_alloc_grants or {}
+                                        ).get(req.mooncake_session_id, [])
+                                    ]
+                                else:
+                                    dst_indices = (
+                                        req.dst_state_indices[state_idx]
+                                        if state_idx < len(req.dst_state_indices)
+                                        else []
+                                    )
+                                    chunk_dst_indices = [
+                                        int(x) for x in dst_indices[:row_len]
+                                    ]
                                 self.notify_pd_hidden_chunk_ready(
                                     remote=req.endpoint,
                                     dst_port=req.dst_port,
@@ -3007,6 +3177,40 @@ class MooncakeKVManager(CommonKVManager):
                         room, prefill_rank, hidden_start
                     )
                     continue
+                if (
+                    waiting_req_bytes[0]
+                    == MooncakeKVManager.PD_HIDDEN_ALLOC_GRANT_HEADER
+                ):
+                    room = int(waiting_req_bytes[1].decode("ascii"))
+                    prefill_rank = int(waiting_req_bytes[2].decode("ascii"))
+                    hidden_start = int(waiting_req_bytes[3].decode("ascii"))
+                    session_id = waiting_req_bytes[4].decode("utf-8")
+                    if self.request_status.get(room) in (
+                        None,
+                        KVPoll.Failed,
+                        KVPoll.Success,
+                    ):
+                        # A grant may race with request completion/abort. The
+                        # decode side owns and reclaims those rows; retaining a
+                        # prefill waiter here would only leak bookkeeping.
+                        continue
+                    dst_indices = (
+                        list(
+                            np.frombuffer(
+                                waiting_req_bytes[5], dtype=np.int32
+                            ).astype(np.int64)
+                        )
+                        if waiting_req_bytes[5]
+                        else []
+                    )
+                    self.pd_hidden_events.handle_alloc_grant(
+                        room=room,
+                        prefill_rank=prefill_rank,
+                        hidden_start=hidden_start,
+                        session_id=session_id,
+                        dst_indices=dst_indices,
+                    )
+                    continue
                 room = waiting_req_bytes[0].decode("ascii")
                 # Staging: decode reports consumption watermark back to prefill
                 if room == "WATERMARK":
@@ -3139,6 +3343,20 @@ class MooncakeKVManager(CommonKVManager):
                 if self.server_socket not in events:
                     continue
                 msg = self.server_socket.recv_multipart()
+                if msg[0] == MooncakeKVManager.PD_HIDDEN_ALLOC_REQUEST_HEADER:
+                    self.pd_hidden_events.append_alloc_request(
+                        {
+                            "room": int(msg[1].decode("ascii")),
+                            "prefill_rank": int(msg[2].decode("ascii")),
+                            "hidden_start": int(msg[3].decode("ascii")),
+                            "row_len": int(msg[4].decode("ascii")),
+                            "is_last_hidden_chunk": msg[5] == b"1",
+                            "session_id": msg[6].decode("utf-8"),
+                            "reply_host": msg[7].decode("ascii"),
+                            "reply_port": int(msg[8].decode("ascii")),
+                        }
+                    )
+                    continue
                 if msg[0] == MooncakeKVManager.AUX_DATA_HEADER:
                     self._handle_aux_data(msg)
                     continue

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -205,24 +205,6 @@ class MooncakeKVManager(CommonKVManager):
     PD_HIDDEN_ALLOC_REQUEST_HEADER = b"PD_HIDDEN_ALLOC_REQUEST"
     PD_HIDDEN_ALLOC_GRANT_HEADER = b"PD_HIDDEN_ALLOC_GRANT"
 
-    def _send_multipart(
-        self, endpoint: str, frames: List[bytes], is_ipv6: bool = False
-    ) -> None:
-        """Send control frames safely across old and new CommonKVManager bases.
-
-        Some deployed images predate ``CommonKVManager._send_multipart``.  Keep the
-        endpoint-scoped send lock here as well so this feature can be backported
-        without sharing a ZMQ socket concurrently between transfer workers.
-        """
-        with self._socket_lock:
-            send_locks = getattr(self, "_socket_send_locks", None)
-            if send_locks is None:
-                send_locks = self._socket_send_locks = {}
-            send_lock = send_locks.setdefault(endpoint, threading.Lock())
-
-        with send_lock:
-            self._connect(endpoint, is_ipv6=is_ipv6).send_multipart(frames)
-
     def __init__(
         self,
         args: KVArgs,
@@ -350,6 +332,7 @@ class MooncakeKVManager(CommonKVManager):
             kv_chunk=kv_chunk,
             prefill_rank=prefill_rank,
             expected_session_ids=expected_session_ids,
+            timeout_s=float(getattr(self, "bootstrap_timeout", 300.0)),
         )
 
     def request_pd_hidden_rows(
@@ -432,8 +415,10 @@ class MooncakeKVManager(CommonKVManager):
         kv_chunk: TransferKVChunk,
         prefill_rank: int,
         expected_count: int,
-        timeout_s: float = 300.0,
+        timeout_s: Optional[float] = None,
     ) -> bool:
+        if timeout_s is None:
+            timeout_s = float(getattr(self, "bootstrap_timeout", 300.0))
         return self.pd_hidden_events.park_chunk_for_ack(
             transfer_queue=transfer_queue,
             kv_chunk=kv_chunk,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -364,9 +364,7 @@ class MooncakeKVManager(CommonKVManager):
             is_ipv6=na.is_ipv6,
         )
 
-    def grant_pd_hidden_rows(
-        self, request: dict, dst_indices: List[int]
-    ) -> None:
+    def grant_pd_hidden_rows(self, request: dict, dst_indices: List[int]) -> None:
         na = NetworkAddress(request["reply_host"], int(request["reply_port"]))
         self._send_multipart(
             na.to_tcp(),
@@ -376,11 +374,11 @@ class MooncakeKVManager(CommonKVManager):
                 str(request["prefill_rank"]).encode("ascii"),
                 str(request["hidden_start"]).encode("ascii"),
                 str(request["session_id"]).encode("utf-8"),
-                struct.pack(
-                    f"<{len(dst_indices)}i", *[int(x) for x in dst_indices]
-                )
-                if dst_indices
-                else b"",
+                (
+                    struct.pack(f"<{len(dst_indices)}i", *[int(x) for x in dst_indices])
+                    if dst_indices
+                    else b""
+                ),
             ],
             is_ipv6=na.is_ipv6,
         )
@@ -497,9 +495,7 @@ class MooncakeKVManager(CommonKVManager):
     def _has_pd_hidden_state(self, state_indices: Optional[List]) -> bool:
         return self.pd_hidden_events.has_state(state_indices)
 
-    def _without_pd_hidden_state(
-        self, state_indices: Optional[List]
-    ) -> Optional[List]:
+    def _without_pd_hidden_state(self, state_indices: Optional[List]) -> Optional[List]:
         return self.pd_hidden_events.without_state(state_indices)
 
     def _pd_hidden_release_state_indices(
@@ -559,9 +555,11 @@ class MooncakeKVManager(CommonKVManager):
                 str(hidden_start).encode("ascii"),
                 str(row_len).encode("ascii"),
                 b"1" if is_last_hidden_chunk else b"0",
-                struct.pack(f"<{len(dst_indices)}i", *[int(x) for x in dst_indices])
-                if dst_indices
-                else b"",
+                (
+                    struct.pack(f"<{len(dst_indices)}i", *[int(x) for x in dst_indices])
+                    if dst_indices
+                    else b""
+                ),
                 self.local_ip.encode("ascii"),
                 str(self.rank_port).encode("ascii"),
             ]
@@ -2302,46 +2300,6 @@ class MooncakeKVManager(CommonKVManager):
                         src_indices = src_indices[: len(dst_indices_local)]
                     else:
                         dst_indices_local = dst_indices_local[: len(src_indices)]
-                if st == StateType.PD_HIDDEN and dynamic_dst:
-                    row_chunks = dynamic_dst.get("row_chunks") or [
-                        {"row_start": 0, "row_len": len(src_indices)}
-                    ]
-                    for row_chunk in row_chunks:
-                        row_start = int(row_chunk.get("row_start", 0))
-                        row_len = int(row_chunk.get("row_len", 0))
-                        if row_len <= 0:
-                            continue
-                        row_end = row_start + row_len
-                        if row_start < 0 or row_end > len(src_indices):
-                            raise RuntimeError(
-                                "Invalid PD hidden row chunk: "
-                                f"room={req.room}, row_start={row_start}, "
-                                f"row_len={row_len}, row_count={len(src_indices)}"
-                            )
-                        if "ptr" in row_chunk:
-                            chunk_dst_data_ptrs = [int(row_chunk["ptr"])]
-                            chunk_dst_indices = list(range(row_len))
-                        else:
-                            chunk_dst_data_ptrs = dst_data_ptrs
-                            chunk_dst_indices = dst_indices_local[row_start:row_end]
-                        rc = (
-                            self._send_kvcache_generic(
-                                mooncake_session_id=req.mooncake_session_id,
-                                src_data_ptrs=src_data_ptrs,
-                                dst_data_ptrs=chunk_dst_data_ptrs,
-                                item_lens=src_item_lens,
-                                prefill_data_indices=np.array(
-                                    src_indices[row_start:row_end], dtype=np.int32
-                                ),
-                                dst_data_indices=np.array(
-                                    chunk_dst_indices, dtype=np.int32
-                                ),
-                                executor=executor,
-                                state_type=st,
-                            )
-                            or rc
-                        )
-                    continue
                 rc = (
                     self._send_kvcache_generic(
                         mooncake_session_id=req.mooncake_session_id,
@@ -2674,9 +2632,8 @@ class MooncakeKVManager(CommonKVManager):
                             self.pd_hidden_events.inflight_chunks.pop(
                                 kv_chunk.room, None
                             )
-                    if (
-                        not kv_chunk.pd_hidden_sent
-                        and self._has_pd_hidden_state(kv_chunk.state_indices)
+                    if not kv_chunk.pd_hidden_sent and self._has_pd_hidden_state(
+                        kv_chunk.state_indices
                     ):
                         self._release_or_mark_pd_hidden_done(kv_chunk)
                     if self.enable_trace:
@@ -2762,10 +2719,11 @@ class MooncakeKVManager(CommonKVManager):
                             inflight_key = self.pd_hidden_events.inflight_chunks.get(
                                 kv_chunk.room
                             )
-                        if inflight_key is not None and inflight_key != hidden_inflight_key:
-                            self._park_pd_hidden_chunk_behind_room(
-                                queue, kv_chunk
-                            )
+                        if (
+                            inflight_key is not None
+                            and inflight_key != hidden_inflight_key
+                        ):
+                            self._park_pd_hidden_chunk_behind_room(queue, kv_chunk)
                             continue
                     if (
                         pd_hidden_dynamic_allocation
@@ -2839,22 +2797,19 @@ class MooncakeKVManager(CommonKVManager):
                                 continue
                             self._begin_pd_hidden_transfer(kv_chunk.room)
                             try:
-                                ret, pd_hidden_done = (
-                                    self._send_pd_hidden_packet(
-                                        req,
-                                        kv_chunk.state_indices,
-                                        kv_chunk.pd_hidden_packet_idx,
-                                        executor,
-                                        (
-                                            kv_chunk.pd_hidden_alloc_grants.get(
-                                                req.mooncake_session_id
-                                            )
-                                            if pd_hidden_dynamic_allocation
-                                            and kv_chunk.pd_hidden_alloc_grants
-                                            is not None
-                                            else None
-                                        ),
-                                    )
+                                ret, pd_hidden_done = self._send_pd_hidden_packet(
+                                    req,
+                                    kv_chunk.state_indices,
+                                    kv_chunk.pd_hidden_packet_idx,
+                                    executor,
+                                    (
+                                        kv_chunk.pd_hidden_alloc_grants.get(
+                                            req.mooncake_session_id
+                                        )
+                                        if pd_hidden_dynamic_allocation
+                                        and kv_chunk.pd_hidden_alloc_grants is not None
+                                        else None
+                                    ),
                                 )
                             finally:
                                 self._end_pd_hidden_transfer(kv_chunk.room)
@@ -2931,9 +2886,9 @@ class MooncakeKVManager(CommonKVManager):
                     ):
                         if hidden_inflight_key is not None:
                             with self.pd_hidden_events.inflight_lock:
-                                self.pd_hidden_events.inflight_chunks[
-                                    kv_chunk.room
-                                ] = hidden_inflight_key
+                                self.pd_hidden_events.inflight_chunks[kv_chunk.room] = (
+                                    hidden_inflight_key
+                                )
                         kv_chunk.pd_hidden_ready_sent = True
                         if self.park_pd_hidden_chunk_for_ack(
                             transfer_queue=queue,
@@ -3199,9 +3154,7 @@ class MooncakeKVManager(CommonKVManager):
                     room = int(waiting_req_bytes[1].decode("ascii"))
                     prefill_rank = int(waiting_req_bytes[2].decode("ascii"))
                     hidden_start = int(waiting_req_bytes[3].decode("ascii"))
-                    self._handle_pd_hidden_chunk_ack(
-                        room, prefill_rank, hidden_start
-                    )
+                    self._handle_pd_hidden_chunk_ack(room, prefill_rank, hidden_start)
                     continue
                 if (
                     waiting_req_bytes[0]
@@ -3222,9 +3175,9 @@ class MooncakeKVManager(CommonKVManager):
                         continue
                     dst_indices = (
                         list(
-                            np.frombuffer(
-                                waiting_req_bytes[5], dtype=np.int32
-                            ).astype(np.int64)
+                            np.frombuffer(waiting_req_bytes[5], dtype=np.int32).astype(
+                                np.int64
+                            )
                         )
                         if waiting_req_bytes[5]
                         else []
@@ -3683,9 +3636,7 @@ class MooncakeKVSender(CommonKVSender):
             chunk_kv_indices = kv_indices[chunk_start:chunk_end]
             chunk_position_offset = token_position_offset + chunk_start
             chunk_state_indices = state_indices if is_last_subchunk else None
-            chunk_pd_hidden_meta = (
-                pd_hidden_chunk_meta if is_last_subchunk else None
-            )
+            chunk_pd_hidden_meta = pd_hidden_chunk_meta if is_last_subchunk else None
             chunk_source_event = source_event if chunk_start == 0 else None
 
             if not chunk_is_last:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -205,6 +205,24 @@ class MooncakeKVManager(CommonKVManager):
     PD_HIDDEN_ALLOC_REQUEST_HEADER = b"PD_HIDDEN_ALLOC_REQUEST"
     PD_HIDDEN_ALLOC_GRANT_HEADER = b"PD_HIDDEN_ALLOC_GRANT"
 
+    def _send_multipart(
+        self, endpoint: str, frames: List[bytes], is_ipv6: bool = False
+    ) -> None:
+        """Send control frames safely across old and new CommonKVManager bases.
+
+        Some deployed images predate ``CommonKVManager._send_multipart``.  Keep the
+        endpoint-scoped send lock here as well so this feature can be backported
+        without sharing a ZMQ socket concurrently between transfer workers.
+        """
+        with self._socket_lock:
+            send_locks = getattr(self, "_socket_send_locks", None)
+            if send_locks is None:
+                send_locks = self._socket_send_locks = {}
+            send_lock = send_locks.setdefault(endpoint, threading.Lock())
+
+        with send_lock:
+            self._connect(endpoint, is_ipv6=is_ipv6).send_multipart(frames)
+
     def __init__(
         self,
         args: KVArgs,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -3197,6 +3197,13 @@ class MooncakeKVManager(CommonKVManager):
                     f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
                 )
 
+    def _should_fail_sender_room_on_abort(self, room: int) -> bool:
+        if int(room) not in self.request_status:
+            return False
+        return self.check_status(int(room)) != KVPoll.Success or (
+            self.pd_hidden_events.request_active(int(room))
+        )
+
     def start_prefill_thread(self):
         def bootstrap_thread():
             """This thread recvs pre-alloc notification from the decode engine"""
@@ -3267,11 +3274,11 @@ class MooncakeKVManager(CommonKVManager):
                     room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
                     decode_ip = waiting_req_bytes[2].decode("ascii")
                     decode_port = int(waiting_req_bytes[3].decode("ascii"))
-                    # No need to abort the room if it has already succeeded
-                    if (
-                        room_to_be_aborted in self.request_status
-                        and self.check_status(room_to_be_aborted) != KVPoll.Success
-                    ):
+                    # KV completion and streaming-hidden completion have
+                    # independent lifetimes. A room whose KV status is already
+                    # Success must still be aborted while hidden chunks are
+                    # active; Decode has gone away and can no longer ACK them.
+                    if self._should_fail_sender_room_on_abort(room_to_be_aborted):
                         self.update_status(room_to_be_aborted, KVPoll.Failed)
                         self._wake_pd_hidden_ack_waiters(room_to_be_aborted)
                         logger.debug(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2757,6 +2757,9 @@ class MooncakeKVManager(CommonKVManager):
                                 )
                             )
 
+                    if pd_hidden_expected > 0:
+                        self.pd_hidden_events.begin_request(kv_chunk.room)
+
                     waiting_for_ack = (
                         kv_chunk.pd_hidden_start is not None
                         and kv_chunk.pd_hidden_ready_sent
@@ -2785,6 +2788,11 @@ class MooncakeKVManager(CommonKVManager):
                         and not kv_chunk.pd_hidden_ready_sent
                     ):
                         if not kv_chunk.pd_hidden_alloc_requested:
+                            self.pd_hidden_events.expect_alloc_grants(
+                                room=kv_chunk.room,
+                                prefill_rank=prefill_unique_rank,
+                                hidden_start=int(kv_chunk.pd_hidden_start),
+                            )
                             for req in reqs_to_be_processed:
                                 if (
                                     req.is_dummy
@@ -3170,10 +3178,18 @@ class MooncakeKVManager(CommonKVManager):
                     continue
 
                 current_status = self.request_status.get(kv_chunk.room)
-                if kv_chunk.room not in self.request_status or current_status == KVPoll.Success:
+                hidden_request_active = self.pd_hidden_events.request_active(
+                    kv_chunk.room
+                )
+                if kv_chunk.room not in self.request_status:
                     if kv_chunk.room in self.transfer_infos:
                         self.transfer_infos.pop(kv_chunk.room)
                     self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
+                elif current_status == KVPoll.Success and not hidden_request_active:
+                    if not self.finish_deferred_sender_clear(kv_chunk.room):
+                        if kv_chunk.room in self.transfer_infos:
+                            self.transfer_infos.pop(kv_chunk.room)
+                        self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
 
             except Exception as e:
                 # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
@@ -3203,14 +3219,14 @@ class MooncakeKVManager(CommonKVManager):
                     prefill_rank = int(waiting_req_bytes[2].decode("ascii"))
                     hidden_start = int(waiting_req_bytes[3].decode("ascii"))
                     session_id = waiting_req_bytes[4].decode("utf-8")
-                    if self.request_status.get(room) in (
-                        None,
-                        KVPoll.Failed,
-                        KVPoll.Success,
+                    if not self.pd_hidden_events.expects_alloc_grant(
+                        room=room,
+                        prefill_rank=prefill_rank,
+                        hidden_start=hidden_start,
                     ):
-                        # A grant may race with request completion/abort. The
-                        # decode side owns and reclaims those rows; retaining a
-                        # prefill waiter here would only leak bookkeeping.
+                        # Hidden allocation has its own lifetime. Ignore a
+                        # grant only after that lifetime has ended, regardless
+                        # of whether the independent KV status is still live.
                         continue
                     dst_indices = (
                         list(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1218,7 +1218,9 @@ class SchedulerDisaggregationPrefillMixin:
             req
             for req in batch.reqs
             if (
-                (
+                not is_aborted(req)
+                and not is_pd_hidden_transfer_failed(req)
+                and (
                     pd_hidden_state(req).src_indices
                     or pd_hidden_state(req).capture_layer_ids
                 )
@@ -1267,6 +1269,13 @@ class SchedulerDisaggregationPrefillMixin:
             extend_len = int(extend_len)
             req_hidden = hidden_states[hidden_offset : hidden_offset + extend_len]
             hidden_offset += extend_len
+
+            # An AbortReq can arrive while a PP microbatch is already in
+            # flight.  Drain that result without allocating/sending another
+            # hidden chunk; the sender abort path wakes older parked chunks so
+            # their source rows can be reclaimed.
+            if is_aborted(req) or is_pd_hidden_transfer_failed(req):
+                continue
 
             meta = pd_hidden_state(req).meta or {}
             streaming_hidden = bool(meta.get("streaming_hidden", False))
@@ -1374,7 +1383,11 @@ class SchedulerDisaggregationPrefillMixin:
         capture_reqs = [
             req
             for req in batch.reqs
-            if pd_hidden_state(req).capture_layer_ids
+            if (
+                pd_hidden_state(req).capture_layer_ids
+                and not is_aborted(req)
+                and not is_pd_hidden_transfer_failed(req)
+            )
         ]
         if not capture_reqs:
             return False

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -35,6 +35,8 @@ from sglang.srt.disaggregation.base.conn import StateType
 from sglang.srt.disaggregation.common.conn import CommonKVManager
 from sglang.srt.disaggregation.hidden_state import (
     get_pd_hidden_capture_layer_ids,
+)
+from sglang.srt.disaggregation.hidden_state import (
     get_pd_hidden_req_state as pd_hidden_state,
 )
 from sglang.srt.disaggregation.utils import (
@@ -153,9 +155,7 @@ def maybe_release_pd_hidden_rows(req: Req, pd_hidden_pool) -> None:
         clear_pd_hidden_request_state(req)
 
 
-def maybe_release_pd_hidden_rows_on_hidden_done(
-    req: Req, pd_hidden_pool
-) -> bool:
+def maybe_release_pd_hidden_rows_on_hidden_done(req: Req, pd_hidden_pool) -> bool:
     """Release source hidden rows after PD_HIDDEN finishes, before KV success."""
     indices = pd_hidden_state(req).src_indices
     if not indices or pd_hidden_pool is None:
@@ -324,7 +324,9 @@ class PrefillBootstrapQueue:
             self.scheduler.server_args,
             self.is_mla_backend,
         )
-        kv_manager.pd_hidden_pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
+        kv_manager.pd_hidden_pool = getattr(
+            self.metadata_buffers, "pd_hidden_pool", None
+        )
         # Pass KV pool tensor refs to the manager for GPU gather (staging mode)
         if (
             envs.SGLANG_DISAGG_STAGING_BUFFER.get()
@@ -416,9 +418,8 @@ class PrefillBootstrapQueue:
         )
         kv_mgr = self.kv_manager
         uses_token_level_transfer = (
-            (getattr(kv_mgr, "dcp_size", 1) or 1) > 1
-            or self._uses_dsv4_token_level_transfer(req)
-        )
+            getattr(kv_mgr, "dcp_size", 1) or 1
+        ) > 1 or self._uses_dsv4_token_level_transfer(req)
         transfer_index_count = (
             num_kv_indices_to_send if uses_token_level_transfer else num_pages
         )
@@ -567,9 +568,7 @@ class PrefillBootstrapQueue:
             return True
 
         src_indices = (
-            None
-            if plan.streaming_hidden
-            else plan.pool.alloc(plan.source_window_rows)
+            None if plan.streaming_hidden else plan.pool.alloc(plan.source_window_rows)
         )
         if src_indices is None and not plan.streaming_hidden:
             message = (
@@ -737,9 +736,7 @@ class PrefillBootstrapQueue:
             self.scheduler.attn_tp_cpu_group,
         )
 
-        metadata_credits = (
-            self.req_to_metadata_buffer_idx_allocator.available_size()
-        )
+        metadata_credits = self.req_to_metadata_buffer_idx_allocator.available_size()
         pool = getattr(self.metadata_buffers, "pd_hidden_pool", None)
         hidden_row_credits = pool.available_size() if pool is not None else 0
 
@@ -1141,9 +1138,7 @@ class SchedulerDisaggregationPrefillMixin:
         if hidden_states is None and result.pp_hidden_states_proxy_tensors is not None:
             proxy_tensors = result.pp_hidden_states_proxy_tensors.tensors
             aux_keys = sorted(
-                key
-                for key in proxy_tensors
-                if key.startswith("pd_aux_hidden_states_")
+                key for key in proxy_tensors if key.startswith("pd_aux_hidden_states_")
             )
             if aux_keys:
                 hidden_states = (
@@ -1160,9 +1155,7 @@ class SchedulerDisaggregationPrefillMixin:
         if current_indices is None:
             return None
 
-        state_types = (
-            self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
-        )
+        state_types = self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
         state_indices = []
         for st in state_types:
             if st == StateType.PD_HIDDEN:
@@ -1193,7 +1186,11 @@ class SchedulerDisaggregationPrefillMixin:
                 int(current_start),
                 int(current_rows),
                 bool(pd_hidden_state(req).current_is_last),
-                current_indices if streaming_hidden else pd_hidden_state(req).src_indices,
+                (
+                    current_indices
+                    if streaming_hidden
+                    else pd_hidden_state(req).src_indices
+                ),
             )
 
         req.disagg_kv_sender.send(np.asarray([], dtype=np.int32), state_indices)
@@ -1225,10 +1222,7 @@ class SchedulerDisaggregationPrefillMixin:
                     pd_hidden_state(req).src_indices
                     or pd_hidden_state(req).capture_layer_ids
                 )
-                and (
-                    send_owner_direct
-                    or not pd_hidden_state(req).owner_direct_sent
-                )
+                and (send_owner_direct or not pd_hidden_state(req).owner_direct_sent)
             )
         ]
         if pool is not None and needs_pd_hidden_reqs and hidden_states is None:
@@ -1309,9 +1303,7 @@ class SchedulerDisaggregationPrefillMixin:
             )
             if local_slice_len > 0 and req_hidden_to_write.shape[-1] != local_slice_len:
                 local_slice_start = (
-                    int(local_pp_slice.get("slice_start", 0))
-                    if local_pp_slice
-                    else 0
+                    int(local_pp_slice.get("slice_start", 0)) if local_pp_slice else 0
                 )
                 local_slice_end = local_slice_start + local_slice_len
                 if req_hidden_to_write.shape[-1] < local_slice_end:
@@ -1356,8 +1348,7 @@ class SchedulerDisaggregationPrefillMixin:
                     bootstrap_queue = self.disagg_prefill_bootstrap_queue
                     now = time.monotonic()
                     if (
-                        now
-                        - bootstrap_queue._last_pd_hidden_source_credit_warning_time
+                        now - bootstrap_queue._last_pd_hidden_source_credit_warning_time
                         > 30
                     ):
                         logger.warning(
@@ -1368,9 +1359,7 @@ class SchedulerDisaggregationPrefillMixin:
                             pool.available_size(),
                             pool.size,
                         )
-                        bootstrap_queue._last_pd_hidden_source_credit_warning_time = (
-                            now
-                        )
+                        bootstrap_queue._last_pd_hidden_source_credit_warning_time = now
                     timeout_s = float(
                         getattr(bootstrap_queue.kv_manager, "bootstrap_timeout", 300.0)
                     )
@@ -1393,7 +1382,9 @@ class SchedulerDisaggregationPrefillMixin:
             pd_hidden_state(req).current_start = write_start
             pd_hidden_state(req).current_row_len = rows
             pd_hidden_state(req).current_src_indices = write_indices
-            pd_hidden_state(req).current_is_last = write_end >= hidden_start + hidden_len
+            pd_hidden_state(req).current_is_last = (
+                write_end >= hidden_start + hidden_len
+            )
             written = pd_hidden_state(req).written
             if written is not None:
                 written[local_start:local_end] = [True] * rows
@@ -1419,15 +1410,11 @@ class SchedulerDisaggregationPrefillMixin:
         if any(req.pending_bootstrap for req in capture_reqs):
             return False
         if not all(
-            bool(
-                (pd_hidden_state(req).meta or {}).get("streaming_hidden", False)
-            )
+            bool((pd_hidden_state(req).meta or {}).get("streaming_hidden", False))
             for req in capture_reqs
         ):
             return False
-        self._write_pd_hidden_rows_for_batch(
-            batch, result, send_owner_direct=True
-        )
+        self._write_pd_hidden_rows_for_batch(batch, result, send_owner_direct=True)
         return True
 
     def process_batch_result_disagg_prefill(
@@ -1627,7 +1614,9 @@ class SchedulerDisaggregationPrefillMixin:
         )
 
         undone_reqs: List[Req] = []
-        terminal_rids_to_check = set(rids_to_check) if rids_to_check is not None else None
+        terminal_rids_to_check = (
+            set(rids_to_check) if rids_to_check is not None else None
+        )
         # Check .poll() for the reqs in disagg_prefill_inflight_queue. If Success, respond to the client and remove it from the queue
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
             if terminal_rids_to_check is not None:
@@ -1763,9 +1752,7 @@ class SchedulerDisaggregationPrefillMixin:
         )
 
         transferred_rids: List[str] = []
-        pd_hidden_pool = getattr(
-            self.disagg_metadata_buffers, "pd_hidden_pool", None
-        )
+        pd_hidden_pool = getattr(self.disagg_metadata_buffers, "pd_hidden_pool", None)
 
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
             maybe_release_pd_hidden_rows_on_hidden_done(req, pd_hidden_pool)
@@ -1952,8 +1939,7 @@ class SchedulerDisaggregationPrefillMixin:
         current_pd_hidden_start = pd_hidden_state(req).current_start
         current_pd_hidden_row_len = int(pd_hidden_state(req).current_row_len or 0)
         has_current_pd_hidden = (
-            current_pd_hidden_src_indices is not None
-            and current_pd_hidden_row_len > 0
+            current_pd_hidden_src_indices is not None and current_pd_hidden_row_len > 0
         )
         streaming_pd_hidden = bool(
             (pd_hidden_state(req).meta or {}).get("streaming_hidden", False)
@@ -1979,9 +1965,9 @@ class SchedulerDisaggregationPrefillMixin:
                     target_dcp_size = max(
                         target_dcp_size, getattr(target_info, "dst_dcp_size", 1) or 1
                     )
-        dsv4_dcp_transfer = isinstance(
-            token_to_kv_pool, DeepSeekV4TokenToKVPool
-        ) and (target_dcp_size > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get())
+        dsv4_dcp_transfer = isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool) and (
+            target_dcp_size > 1 or envs.SGLANG_DSV4_ENABLE_DCP.get()
+        )
         state_indices: Optional[List] = None
         if last_chunk or has_current_pd_hidden:
             if last_chunk:
@@ -2146,9 +2132,11 @@ class SchedulerDisaggregationPrefillMixin:
                 int(current_pd_hidden_start),
                 int(current_pd_hidden_row_len),
                 bool(pd_hidden_state(req).current_is_last),
-                current_pd_hidden_src_indices
-                if streaming_pd_hidden
-                else pd_hidden_state(req).src_indices,
+                (
+                    current_pd_hidden_src_indices
+                    if streaming_pd_hidden
+                    else pd_hidden_state(req).src_indices
+                ),
             )
         req.disagg_kv_sender.send(
             page_indices,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -229,6 +229,7 @@ class PrefillBootstrapQueue:
             self.scheduler.tp_worker.model_runner.effective_max_total_num_tokens
         )
         self._last_pd_hidden_credit_warning_time = 0.0
+        self._last_pd_hidden_source_credit_warning_time = 0.0
         self.transfer_backend = transfer_backend
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get() and self.is_mla_backend:
             raise RuntimeError(
@@ -1352,15 +1353,28 @@ class SchedulerDisaggregationPrefillMixin:
             if streaming_hidden:
                 write_indices = pool.alloc(rows)
                 if write_indices is None:
-                    logger.info(
-                        "PD streaming hidden source pool waiting for ACK credit: "
-                        "rid=%s rows=%d free_rows=%d pool_rows=%d",
-                        req.rid,
-                        rows,
-                        pool.available_size(),
-                        pool.size,
+                    bootstrap_queue = self.disagg_prefill_bootstrap_queue
+                    now = time.monotonic()
+                    if (
+                        now
+                        - bootstrap_queue._last_pd_hidden_source_credit_warning_time
+                        > 30
+                    ):
+                        logger.warning(
+                            "PD streaming hidden source pool waiting for ACK credit: "
+                            "rid=%s rows=%d free_rows=%d pool_rows=%d",
+                            req.rid,
+                            rows,
+                            pool.available_size(),
+                            pool.size,
+                        )
+                        bootstrap_queue._last_pd_hidden_source_credit_warning_time = (
+                            now
+                        )
+                    timeout_s = float(
+                        getattr(bootstrap_queue.kv_manager, "bootstrap_timeout", 300.0)
                     )
-                    write_indices = pool.alloc_wait(rows, timeout=300.0)
+                    write_indices = pool.alloc_wait(rows, timeout=timeout_s)
                     if write_indices is None:
                         fail_pd_hidden_transfer(
                             req,

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1352,14 +1352,25 @@ class SchedulerDisaggregationPrefillMixin:
             if streaming_hidden:
                 write_indices = pool.alloc(rows)
                 if write_indices is None:
-                    fail_pd_hidden_transfer(
-                        req,
-                        "PD streaming hidden source chunk allocation failed: "
-                        f"rid={req.rid}, rows={rows}, free_rows={pool.available_size()}, "
-                        f"pool_rows={pool.size}. Streaming source rows are released "
-                        "only after the matching hidden chunk ACK.",
+                    logger.info(
+                        "PD streaming hidden source pool waiting for ACK credit: "
+                        "rid=%s rows=%d free_rows=%d pool_rows=%d",
+                        req.rid,
+                        rows,
+                        pool.available_size(),
+                        pool.size,
                     )
-                    continue
+                    write_indices = pool.alloc_wait(rows, timeout=300.0)
+                    if write_indices is None:
+                        fail_pd_hidden_transfer(
+                            req,
+                            "Timed out waiting for PD streaming hidden source "
+                            f"pool credit: rid={req.rid}, rows={rows}, "
+                            f"free_rows={pool.available_size()}, "
+                            f"pool_rows={pool.size}. Source rows are released "
+                            "after the matching hidden chunk ACK or abort.",
+                        )
+                        continue
                 pd_hidden_state(req).src_indices = write_indices
             pool.write(
                 write_indices,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import logging
 import os
 import random
-import logging
 import threading
 from collections import deque
 from contextlib import nullcontext
@@ -19,8 +19,8 @@ from typing import (
     overload,
 )
 
-import numpy as np
 import msgspec
+import numpy as np
 import torch
 import torch.distributed as dist
 
@@ -368,17 +368,13 @@ class PDHiddenRowPool:
 
             merged = []
             existing_idx = freed_idx = 0
-            while (
-                existing_idx < len(self._free_intervals)
-                or freed_idx < len(freed_intervals)
+            while existing_idx < len(self._free_intervals) or freed_idx < len(
+                freed_intervals
             ):
-                if (
-                    freed_idx == len(freed_intervals)
-                    or (
-                        existing_idx < len(self._free_intervals)
-                        and self._free_intervals[existing_idx][0]
-                        < freed_intervals[freed_idx][0]
-                    )
+                if freed_idx == len(freed_intervals) or (
+                    existing_idx < len(self._free_intervals)
+                    and self._free_intervals[existing_idx][0]
+                    < freed_intervals[freed_idx][0]
                 ):
                     interval = self._free_intervals[existing_idx]
                     existing_idx += 1
@@ -453,7 +449,7 @@ class PDHiddenTransferPlan(msgspec.Struct):
     row_chunks: List[Dict[str, Any]]
 
     @classmethod
-    def build(cls, row_count: int, item_len: int) -> "PDHiddenTransferPlan":
+    def build(cls, row_count: int, item_len: int) -> PDHiddenTransferPlan:
         row_count = int(row_count)
         item_len = int(item_len)
         if row_count <= 0:
@@ -515,7 +511,9 @@ class PDHiddenTransferPlan(msgspec.Struct):
             return new_dynamic_dst
 
         if item_len > 0:
-            new_dynamic_dst["ptr"] = int(new_dynamic_dst.get("ptr", 0)) + offset * item_len
+            new_dynamic_dst["ptr"] = (
+                int(new_dynamic_dst.get("ptr", 0)) + offset * item_len
+            )
         plan = PDHiddenTransferPlan.build(new_row_count, item_len)
         new_dynamic_dst["row_chunks"] = plan.row_chunks
         return new_dynamic_dst

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -282,6 +282,8 @@ class PDHiddenRowPool:
         n = int(n)
         if n <= 0:
             return []
+        if n > self.size:
+            return None
         with self._credit_cv:
             if not self._credit_cv.wait_for(
                 lambda: n <= self._free_count,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -262,6 +262,7 @@ class PDHiddenRowPool:
         self._free_intervals = [(0, self.size - 1)] if self.size else []
         self._free_count = self.size
         self.lock = threading.Lock()
+        self._credit_cv = threading.Condition(self.lock)
 
     def available_size(self) -> int:
         with self.lock:
@@ -272,37 +273,55 @@ class PDHiddenRowPool:
         if n <= 0:
             return []
         with self.lock:
-            if n > self._free_count:
+            return self._alloc_locked(n)
+
+    def alloc_wait(
+        self, n: int, timeout: Optional[float] = None
+    ) -> Optional[List[int]]:
+        """Wait for row credit instead of failing on transient exhaustion."""
+        n = int(n)
+        if n <= 0:
+            return []
+        with self._credit_cv:
+            if not self._credit_cv.wait_for(
+                lambda: n <= self._free_count,
+                timeout=None if timeout is None else float(timeout),
+            ):
                 return None
+            return self._alloc_locked(n)
 
-            for interval_idx, (start, end) in enumerate(self._free_intervals):
-                if end - start + 1 < n:
-                    continue
-                allocated_end = start + n - 1
-                if allocated_end == end:
-                    self._free_intervals.pop(interval_idx)
-                else:
-                    self._free_intervals[interval_idx] = (allocated_end + 1, end)
-                self._free_count -= n
-                return list(range(start, allocated_end + 1))
+    def _alloc_locked(self, n: int) -> Optional[List[int]]:
+        if n > self._free_count:
+            return None
 
-            # Preserve the previous fallback behavior when fragmentation leaves
-            # no contiguous run: consume the lowest free rows across intervals.
-            remaining = n
-            indices = []
-            updated_intervals = []
-            for start, end in self._free_intervals:
-                if remaining == 0:
-                    updated_intervals.append((start, end))
-                    continue
-                take = min(remaining, end - start + 1)
-                indices.extend(range(start, start + take))
-                remaining -= take
-                if start + take <= end:
-                    updated_intervals.append((start + take, end))
-            self._free_intervals = updated_intervals
+        for interval_idx, (start, end) in enumerate(self._free_intervals):
+            if end - start + 1 < n:
+                continue
+            allocated_end = start + n - 1
+            if allocated_end == end:
+                self._free_intervals.pop(interval_idx)
+            else:
+                self._free_intervals[interval_idx] = (allocated_end + 1, end)
             self._free_count -= n
-            return indices
+            return list(range(start, allocated_end + 1))
+
+        # Preserve the previous fallback behavior when fragmentation leaves
+        # no contiguous run: consume the lowest free rows across intervals.
+        remaining = n
+        indices = []
+        updated_intervals = []
+        for start, end in self._free_intervals:
+            if remaining == 0:
+                updated_intervals.append((start, end))
+                continue
+            take = min(remaining, end - start + 1)
+            indices.extend(range(start, start + take))
+            remaining -= take
+            if start + take <= end:
+                updated_intervals.append((start + take, end))
+        self._free_intervals = updated_intervals
+        self._free_count -= n
+        return indices
 
     def free(self, indices: Optional[List[int]]) -> None:
         if not indices:
@@ -370,6 +389,7 @@ class PDHiddenRowPool:
                     merged.append(interval)
             self._free_intervals = merged
             self._free_count += len(to_free)
+            self._credit_cv.notify_all()
 
     def write(self, indices: List[int], hidden: torch.Tensor) -> None:
         if not indices:

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -16,6 +16,8 @@ from tqdm import tqdm
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.hidden_state import (
     get_pd_hidden_capture_layer_ids,
+)
+from sglang.srt.disaggregation.hidden_state import (
     get_pd_hidden_req_state as pd_hidden_state,
 )
 from sglang.srt.disaggregation.utils import poll_and_all_reduce_attn_cp_tp_group
@@ -1041,9 +1043,7 @@ class SchedulerPPMixin:
         if not batch or not get_pd_hidden_capture_layer_ids(batch.reqs):
             return False
         capture_reqs = [
-            req
-            for req in batch.reqs
-            if pd_hidden_state(req).capture_layer_ids
+            req for req in batch.reqs if pd_hidden_state(req).capture_layer_ids
         ]
         if not capture_reqs:
             return False
@@ -1061,9 +1061,7 @@ class SchedulerPPMixin:
         if proxy is None:
             return
         tensors = proxy.tensors
-        aux_keys = [
-            key for key in tensors if key.startswith("pd_aux_hidden_states_")
-        ]
+        aux_keys = [key for key in tensors if key.startswith("pd_aux_hidden_states_")]
         for key in aux_keys:
             tensors.pop(key, None)
 

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -245,6 +245,12 @@ class SchedulerPPMixin:
                 recv_reqs = self.request_receiver.recv_requests()
                 self.process_input_requests(recv_reqs)
 
+                # The regular and non-PP disaggregated loops consume this
+                # marker at the top of every scheduling step.  PP disagg must
+                # do the same; otherwise AbortReq only records the chunked
+                # request and the remaining prompt chunks keep running.
+                self.process_pending_chunked_abort()
+
                 if not self.pp_group.is_last_rank:
                     self._pp_commit_comm_work(self.send_req_work)
 

--- a/python/sglang/srt/speculative/dspark_components/dspark_disaggregation.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_disaggregation.py
@@ -167,9 +167,7 @@ def resolve_hidden_bootstrap_plan(
         [int(x) for x in local_pp_slice.get("layer_ids", [])]
         if local_pp_slice
         else (
-            []
-            if pp_slices
-            else [int(x) for x in metadata.get("target_layer_ids", [])]
+            [] if pp_slices else [int(x) for x in metadata.get("target_layer_ids", [])]
         )
     )
     local_slice_len = (
@@ -215,9 +213,7 @@ def resolve_hidden_bootstrap_plan(
         )
 
     streaming_hidden = bool(metadata.get("streaming_hidden", False))
-    dynamic_hidden_allocation = bool(
-        metadata.get("dynamic_hidden_allocation", False)
-    )
+    dynamic_hidden_allocation = bool(metadata.get("dynamic_hidden_allocation", False))
     dst_indices = [
         int(x)
         for x in (

--- a/python/sglang/srt/speculative/dspark_components/dspark_disaggregation.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_disaggregation.py
@@ -253,14 +253,25 @@ def resolve_hidden_bootstrap_plan(
             f"pool: pp_rank={pp_rank}, local_layer_ids={local_layer_ids}"
         )
 
-    if dynamic_hidden_allocation:
+    if dynamic_hidden_allocation and streaming_hidden:
+        # Decode's streaming window describes its receive-side capacity. The
+        # Prefill source pool is an independent, ACK-recycled credit window and
+        # may intentionally be smaller. Bootstrap therefore only needs a
+        # non-empty local source window; each produced chunk is bounded against
+        # the source pool when it is captured.
         source_window_rows = min(
             hidden_len,
             int(metadata.get("streaming_window_rows", pool.size) or pool.size),
+            pool.size,
         )
     else:
         source_window_rows = (
             min(hidden_len, len(dst_indices)) if streaming_hidden else hidden_len
+        )
+    if hidden_len > 0 and source_window_rows <= 0:
+        return None, (
+            "DSpark prefill hidden source pool has no streaming rows: "
+            f"rid={req.rid}, hidden_len={hidden_len}, pool_size={pool.size}"
         )
     if source_window_rows > pool.size:
         return None, (

--- a/python/sglang/srt/speculative/dspark_components/dspark_disaggregation.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_disaggregation.py
@@ -215,6 +215,9 @@ def resolve_hidden_bootstrap_plan(
         )
 
     streaming_hidden = bool(metadata.get("streaming_hidden", False))
+    dynamic_hidden_allocation = bool(
+        metadata.get("dynamic_hidden_allocation", False)
+    )
     dst_indices = [
         int(x)
         for x in (
@@ -224,6 +227,8 @@ def resolve_hidden_bootstrap_plan(
         )
     ]
     dst_len_valid = (
+        dynamic_hidden_allocation and streaming_hidden and not dst_indices
+    ) or (
         0 < len(dst_indices) <= hidden_len
         if streaming_hidden
         else hidden_len == len(dst_indices)
@@ -248,9 +253,15 @@ def resolve_hidden_bootstrap_plan(
             f"pool: pp_rank={pp_rank}, local_layer_ids={local_layer_ids}"
         )
 
-    source_window_rows = (
-        min(hidden_len, len(dst_indices)) if streaming_hidden else hidden_len
-    )
+    if dynamic_hidden_allocation:
+        source_window_rows = min(
+            hidden_len,
+            int(metadata.get("streaming_window_rows", pool.size) or pool.size),
+        )
+    else:
+        source_window_rows = (
+            min(hidden_len, len(dst_indices)) if streaming_hidden else hidden_len
+        )
     if source_window_rows > pool.size:
         return None, (
             "DSpark hidden rows exceed prefill hidden pool capacity: "

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -290,6 +290,43 @@ class TestPDHiddenDynamicBootstrap(CustomTestCase):
         self.assertEqual(plan.source_window_rows, 4)
         self.assertIs(plan.pool, pool)
 
+    def test_dynamic_bootstrap_clamps_decode_window_to_prefill_pool(self):
+        pool = PDHiddenRowPool(2, hidden_size=4, dtype=torch.float32)
+        req = SimpleNamespace(rid="small-source-pool", origin_input_ids=list(range(8)))
+        metadata = {
+            "hidden_start": 0,
+            "hidden_len": 8,
+            "streaming_hidden": True,
+            "dynamic_hidden_allocation": True,
+            "streaming_window_rows": 6,
+            "target_layer_ids": [3, 5],
+            "pp_slices": {
+                "0": {
+                    "layer_ids": [3, 5],
+                    "slice_len": 4,
+                    "dst_indices": [],
+                }
+            },
+        }
+        model_config = SimpleNamespace(hidden_size=2)
+        model_runner = SimpleNamespace(
+            spec_aux_config=SimpleNamespace(dflash_target_layer_ids=[3, 5])
+        )
+
+        plan, error = resolve_hidden_bootstrap_plan(
+            req=req,
+            metadata=metadata,
+            decode_prefix_len=0,
+            pp_rank=0,
+            model_config=model_config,
+            model_runner=model_runner,
+            metadata_buffers=SimpleNamespace(pd_hidden_pool=pool),
+        )
+
+        self.assertIsNone(error)
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.source_window_rows, 2)
+
 
 class TestDecodePDHiddenDynamicAllocator(CustomTestCase):
     def _make_queue(self, pool_rows: int, decode_reqs):

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -95,9 +95,7 @@ class TestPDHiddenAllocationEvents(CustomTestCase):
 
         sender.abort()
 
-        sender.kv_mgr.record_failure.assert_called_once_with(
-            9, "Aborted by AbortReq."
-        )
+        sender.kv_mgr.record_failure.assert_called_once_with(9, "Aborted by AbortReq.")
         sender.kv_mgr.update_status.assert_called_once_with(9, KVPoll.Failed)
         sender.kv_mgr._wake_pd_hidden_ack_waiters.assert_called_once_with(9)
         self.assertEqual(sender.conclude_state, KVPoll.Failed)
@@ -342,10 +340,7 @@ class TestDecodePDHiddenDynamicAllocator(CustomTestCase):
     def _make_queue(self, pool_rows: int, decode_reqs):
         manager = _FakeKVManager()
         manager.request_status.update(
-            {
-                req.req.bootstrap_room: KVPoll.Transferring
-                for req in decode_reqs
-            }
+            {req.req.bootstrap_room: KVPoll.Transferring for req in decode_reqs}
         )
         queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
         queue.queue = list(decode_reqs)
@@ -431,9 +426,7 @@ class TestDecodePDHiddenDynamicAllocator(CustomTestCase):
         self.assertEqual(pool.available_size(), 4)
 
         queue._drain_pd_hidden_alloc_requests()
-        self.assertEqual(
-            [grant[0]["room"] for grant in manager.grants], [1, 2]
-        )
+        self.assertEqual([grant[0]["room"] for grant in manager.grants], [1, 2])
         self.assertEqual(pool.available_size(), 0)
 
     def test_late_request_for_terminal_room_is_dropped(self):

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -191,6 +191,22 @@ class TestPDHiddenAllocationEvents(CustomTestCase):
         self.assertNotIn(9, manager.req_to_pd_hidden_meta)
         self.assertNotIn(9, manager.transfer_infos)
 
+    def test_abort_still_fails_kv_success_room_while_hidden_is_active(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.request_status = {9: KVPoll.Success}
+        manager.pd_hidden_events = PDHiddenEventManager(manager)
+
+        self.assertFalse(manager._should_fail_sender_room_on_abort(9))
+
+        manager.pd_hidden_events.begin_request(9)
+        self.assertTrue(manager._should_fail_sender_room_on_abort(9))
+
+        manager.request_status[9] = KVPoll.Transferring
+        manager.pd_hidden_events.end_request(9)
+        self.assertTrue(manager._should_fail_sender_room_on_abort(9))
+
+        self.assertFalse(manager._should_fail_sender_room_on_abort(10))
+
     def test_chunk_wakes_only_after_every_decode_session_grants_rows(self):
         owner = MagicMock()
         events = PDHiddenEventManager(owner)

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 import torch
 
 from sglang.srt.disaggregation.base import KVPoll
+from sglang.srt.disaggregation.common.conn import CommonKVSender
 from sglang.srt.disaggregation.common.utils import (
     FastQueue,
     PDHiddenRequestState,
@@ -87,6 +88,21 @@ class _FakeKVManager:
 
 
 class TestPDHiddenAllocationEvents(CustomTestCase):
+    def test_sender_abort_wakes_hidden_waiters(self):
+        sender = CommonKVSender.__new__(CommonKVSender)
+        sender.bootstrap_room = 9
+        sender.conclude_state = None
+        sender.kv_mgr = MagicMock()
+
+        sender.abort()
+
+        sender.kv_mgr.record_failure.assert_called_once_with(
+            9, "Aborted by AbortReq."
+        )
+        sender.kv_mgr.update_status.assert_called_once_with(9, KVPoll.Failed)
+        sender.kv_mgr._wake_pd_hidden_ack_waiters.assert_called_once_with(9)
+        self.assertEqual(sender.conclude_state, KVPoll.Failed)
+
     def test_mooncake_control_send_supports_legacy_common_manager(self):
         socket = MagicMock()
         manager = SimpleNamespace(

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -236,6 +236,26 @@ class TestDecodePDHiddenDynamicAllocator(CustomTestCase):
         self.assertEqual(len(manager.grants), 1)
         self.assertEqual(manager.grants[0][1], [0, 1, 2, 3])
 
+    def test_live_room_accepts_hidden_request_after_kv_success(self):
+        decode_req = _decode_req(room=1, hidden_end=8)
+        queue, manager = self._make_queue(4, [decode_req])
+        manager.request_status[1] = KVPoll.Success
+        manager.alloc_requests.append(
+            _alloc_request(1, 4, hidden_start=4, hidden_end=8)
+        )
+
+        queue._drain_pd_hidden_alloc_requests()
+
+        self.assertEqual(len(manager.grants), 1)
+        self.assertEqual(manager.grants[0][0]["hidden_start"], 4)
+        self.assertEqual(manager.grants[0][1], [0, 1, 2, 3])
+        self.assertEqual(
+            decode_req.pd_hidden_dynamic_allocations[(0, 4, "session-1")][
+                "dst_indices"
+            ],
+            [0, 1, 2, 3],
+        )
+
     def test_oldest_completed_prefill_chunk_cannot_be_bypassed(self):
         first_req = _decode_req(room=1, hidden_end=4)
         second_req = _decode_req(room=2, hidden_end=1)

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import threading
 import unittest
 from collections import defaultdict, deque
 from types import SimpleNamespace
@@ -103,25 +102,6 @@ class TestPDHiddenAllocationEvents(CustomTestCase):
         sender.kv_mgr._wake_pd_hidden_ack_waiters.assert_called_once_with(9)
         self.assertEqual(sender.conclude_state, KVPoll.Failed)
 
-    def test_mooncake_control_send_supports_legacy_common_manager(self):
-        socket = MagicMock()
-        manager = SimpleNamespace(
-            _socket_lock=threading.Lock(),
-            _connect=MagicMock(return_value=socket),
-        )
-
-        MooncakeKVManager._send_multipart(
-            manager,
-            "tcp://127.0.0.1:12345",
-            [b"header", b"payload"],
-        )
-
-        manager._connect.assert_called_once_with(
-            "tcp://127.0.0.1:12345", is_ipv6=False
-        )
-        socket.send_multipart.assert_called_once_with([b"header", b"payload"])
-        self.assertIn("tcp://127.0.0.1:12345", manager._socket_send_locks)
-
     def test_allocation_requests_preserve_prefill_completion_order(self):
         events = PDHiddenEventManager(MagicMock())
         first = _alloc_request(1, 4)
@@ -221,6 +201,8 @@ class TestPDHiddenAllocationEvents(CustomTestCase):
             expected_session_ids={"decode-a", "decode-b"},
         )
         self.assertIsNone(grants)
+        key = (9, 3, 32)
+        timer = events.alloc_waiter_timers[key]
 
         events.handle_alloc_grant(
             room=9,
@@ -239,6 +221,11 @@ class TestPDHiddenAllocationEvents(CustomTestCase):
             dst_indices=[8, 9],
         )
         self.assertIs(transfer_queue.get(), chunk)
+        self.assertTrue(timer.finished.is_set())
+        self.assertNotIn(key, events.alloc_waiter_timers)
+        # A callback that was already racing with cancel must not discard the
+        # completed grants before the transfer worker consumes them.
+        timer.function()
         self.assertEqual(
             events.take_alloc_grants_or_park(
                 transfer_queue=transfer_queue,
@@ -248,6 +235,29 @@ class TestPDHiddenAllocationEvents(CustomTestCase):
             ),
             {"decode-a": [4, 5], "decode-b": [8, 9]},
         )
+
+    def test_abort_cancels_hidden_allocation_wait_timer(self):
+        events = PDHiddenEventManager(MagicMock())
+        transfer_queue = FastQueue()
+        chunk = SimpleNamespace(room=9, pd_hidden_start=32)
+        events.expect_alloc_grants(room=9, prefill_rank=3, hidden_start=32)
+
+        self.assertIsNone(
+            events.take_alloc_grants_or_park(
+                transfer_queue=transfer_queue,
+                kv_chunk=chunk,
+                prefill_rank=3,
+                expected_session_ids={"decode-a"},
+            )
+        )
+        key = (9, 3, 32)
+        timer = events.alloc_waiter_timers[key]
+
+        events.wake_ack_waiters(9)
+
+        self.assertTrue(timer.finished.is_set())
+        self.assertNotIn(key, events.alloc_waiter_timers)
+        self.assertIs(transfer_queue.get(), chunk)
 
 
 class TestPDHiddenDynamicBootstrap(CustomTestCase):

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import unittest
 from collections import defaultdict, deque
 from types import SimpleNamespace
@@ -16,6 +17,7 @@ from sglang.srt.disaggregation.common.utils import (
 )
 from sglang.srt.disaggregation.decode import DecodeTransferQueue
 from sglang.srt.disaggregation.hidden_events import PDHiddenEventManager
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
 from sglang.srt.disaggregation.utils import PDHiddenRowPool
 from sglang.srt.speculative.dspark_components.dspark_disaggregation import (
     resolve_hidden_bootstrap_plan,
@@ -85,6 +87,25 @@ class _FakeKVManager:
 
 
 class TestPDHiddenAllocationEvents(CustomTestCase):
+    def test_mooncake_control_send_supports_legacy_common_manager(self):
+        socket = MagicMock()
+        manager = SimpleNamespace(
+            _socket_lock=threading.Lock(),
+            _connect=MagicMock(return_value=socket),
+        )
+
+        MooncakeKVManager._send_multipart(
+            manager,
+            "tcp://127.0.0.1:12345",
+            [b"header", b"payload"],
+        )
+
+        manager._connect.assert_called_once_with(
+            "tcp://127.0.0.1:12345", is_ipv6=False
+        )
+        socket.send_multipart.assert_called_once_with([b"header", b"payload"])
+        self.assertIn("tcp://127.0.0.1:12345", manager._socket_send_locks)
+
     def test_allocation_requests_preserve_prefill_completion_order(self):
         events = PDHiddenEventManager(MagicMock())
         first = _alloc_request(1, 4)

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -120,11 +120,67 @@ class TestPDHiddenAllocationEvents(CustomTestCase):
         events.requeue_alloc_requests_front([first, second])
         self.assertEqual(events.pop_alloc_requests(), [first, second, third])
 
+    def test_prefill_accepts_expected_hidden_grant_after_kv_room_clear(self):
+        events = PDHiddenEventManager(MagicMock())
+        events.expect_alloc_grants(room=9, prefill_rank=3, hidden_start=32)
+
+        events.handle_alloc_grant(
+            room=9,
+            prefill_rank=3,
+            hidden_start=32,
+            session_id="decode-a",
+            dst_indices=[4, 5],
+        )
+
+        self.assertEqual(
+            events.take_alloc_grants_or_park(
+                transfer_queue=FastQueue(),
+                kv_chunk=SimpleNamespace(room=9, pd_hidden_start=32),
+                prefill_rank=3,
+                expected_session_ids={"decode-a"},
+            ),
+            {"decode-a": [4, 5]},
+        )
+
+    def test_prefill_drops_unexpected_stale_hidden_grant(self):
+        events = PDHiddenEventManager(MagicMock())
+
+        events.handle_alloc_grant(
+            room=9,
+            prefill_rank=3,
+            hidden_start=32,
+            session_id="decode-a",
+            dst_indices=[4, 5],
+        )
+
+        self.assertEqual(dict(events.alloc_grants), {})
+
+    def test_prefill_sender_cleanup_waits_for_active_hidden_room(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.request_status = {9: KVPoll.Success}
+        manager.req_to_decode_prefix_len = {9: 0}
+        manager.req_to_pd_hidden_meta = {9: {"streaming_hidden": True}}
+        manager.transfer_infos = {9: {"decode-a": MagicMock()}}
+        manager.pd_hidden_events = PDHiddenEventManager(manager)
+        manager.pd_hidden_events.begin_request(9)
+
+        self.assertFalse(manager.clear_sender_room(9))
+        self.assertIn(9, manager.request_status)
+        self.assertIn(9, manager.transfer_infos)
+
+        manager.pd_hidden_events.end_request(9)
+        self.assertTrue(manager.finish_deferred_sender_clear(9))
+        self.assertNotIn(9, manager.request_status)
+        self.assertNotIn(9, manager.req_to_decode_prefix_len)
+        self.assertNotIn(9, manager.req_to_pd_hidden_meta)
+        self.assertNotIn(9, manager.transfer_infos)
+
     def test_chunk_wakes_only_after_every_decode_session_grants_rows(self):
         owner = MagicMock()
         events = PDHiddenEventManager(owner)
         transfer_queue = FastQueue()
         chunk = SimpleNamespace(room=9, pd_hidden_start=32)
+        events.expect_alloc_grants(room=9, prefill_rank=3, hidden_start=32)
 
         grants = events.take_alloc_grants_or_park(
             transfer_queue=transfer_queue,

--- a/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_dynamic_allocation.py
@@ -1,0 +1,277 @@
+"""Unit tests for completion-driven PD hidden row allocation."""
+
+from __future__ import annotations
+
+import unittest
+from collections import defaultdict, deque
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.disaggregation.base import KVPoll
+from sglang.srt.disaggregation.common.utils import (
+    FastQueue,
+    PDHiddenRequestState,
+)
+from sglang.srt.disaggregation.decode import DecodeTransferQueue
+from sglang.srt.disaggregation.hidden_events import PDHiddenEventManager
+from sglang.srt.disaggregation.utils import PDHiddenRowPool
+from sglang.srt.speculative.dspark_components.dspark_disaggregation import (
+    resolve_hidden_bootstrap_plan,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _alloc_request(
+    room: int,
+    rows: int,
+    *,
+    hidden_start: int = 0,
+    hidden_end: int | None = None,
+) -> dict:
+    hidden_end = hidden_start + rows if hidden_end is None else hidden_end
+    return {
+        "room": room,
+        "prefill_rank": 0,
+        "hidden_start": hidden_start,
+        "row_len": rows,
+        "is_last_hidden_chunk": hidden_start + rows == hidden_end,
+        "session_id": f"session-{room}",
+        "reply_host": "127.0.0.1",
+        "reply_port": 12345,
+    }
+
+
+def _decode_req(room: int, hidden_end: int):
+    return SimpleNamespace(
+        req=SimpleNamespace(rid=f"rid-{room}", bootstrap_room=room),
+        pd_hidden_dynamic_allocation=True,
+        pd_hidden_dynamic_allocations={},
+        pd_hidden_state=PDHiddenRequestState.streaming_state(0, hidden_end),
+    )
+
+
+class _FakeKVManager:
+    def __init__(self):
+        self.request_status = {}
+        self.alloc_requests = deque()
+        self.grants = []
+        self.acked_chunks = defaultdict(list)
+        self.failures = []
+
+    def pop_pd_hidden_alloc_requests(self):
+        requests = list(self.alloc_requests)
+        self.alloc_requests.clear()
+        return requests
+
+    def requeue_pd_hidden_alloc_requests(self, requests):
+        self.alloc_requests.extendleft(reversed(requests))
+
+    def grant_pd_hidden_rows(self, request, dst_indices):
+        self.grants.append((dict(request), list(dst_indices)))
+
+    def pop_pd_hidden_acked_chunks(self, room):
+        return self.acked_chunks.pop(room, [])
+
+    def record_failure(self, room, reason):
+        self.failures.append((room, reason))
+
+    def update_status(self, room, status):
+        self.request_status[room] = status
+
+
+class TestPDHiddenAllocationEvents(CustomTestCase):
+    def test_allocation_requests_preserve_prefill_completion_order(self):
+        events = PDHiddenEventManager(MagicMock())
+        first = _alloc_request(1, 4)
+        second = _alloc_request(2, 2)
+        third = _alloc_request(3, 1)
+
+        events.append_alloc_request(first)
+        events.append_alloc_request(second)
+        self.assertEqual(events.pop_alloc_requests(), [first, second])
+
+        events.append_alloc_request(third)
+        events.requeue_alloc_requests_front([first, second])
+        self.assertEqual(events.pop_alloc_requests(), [first, second, third])
+
+    def test_chunk_wakes_only_after_every_decode_session_grants_rows(self):
+        owner = MagicMock()
+        events = PDHiddenEventManager(owner)
+        transfer_queue = FastQueue()
+        chunk = SimpleNamespace(room=9, pd_hidden_start=32)
+
+        grants = events.take_alloc_grants_or_park(
+            transfer_queue=transfer_queue,
+            kv_chunk=chunk,
+            prefill_rank=3,
+            expected_session_ids={"decode-a", "decode-b"},
+        )
+        self.assertIsNone(grants)
+
+        events.handle_alloc_grant(
+            room=9,
+            prefill_rank=3,
+            hidden_start=32,
+            session_id="decode-a",
+            dst_indices=[4, 5],
+        )
+        self.assertEqual(len(transfer_queue._buf), 0)
+
+        events.handle_alloc_grant(
+            room=9,
+            prefill_rank=3,
+            hidden_start=32,
+            session_id="decode-b",
+            dst_indices=[8, 9],
+        )
+        self.assertIs(transfer_queue.get(), chunk)
+        self.assertEqual(
+            events.take_alloc_grants_or_park(
+                transfer_queue=transfer_queue,
+                kv_chunk=chunk,
+                prefill_rank=3,
+                expected_session_ids={"decode-a", "decode-b"},
+            ),
+            {"decode-a": [4, 5], "decode-b": [8, 9]},
+        )
+
+
+class TestPDHiddenDynamicBootstrap(CustomTestCase):
+    def test_dynamic_bootstrap_accepts_layout_without_reserved_dst_rows(self):
+        pool = PDHiddenRowPool(4, hidden_size=4, dtype=torch.float32)
+        req = SimpleNamespace(rid="dynamic-bootstrap", origin_input_ids=list(range(8)))
+        metadata = {
+            "hidden_start": 0,
+            "hidden_len": 8,
+            "streaming_hidden": True,
+            "dynamic_hidden_allocation": True,
+            "streaming_window_rows": 4,
+            "target_layer_ids": [3, 5],
+            "pp_slices": {
+                "0": {
+                    "layer_ids": [3, 5],
+                    "slice_len": 4,
+                    "dst_indices": [],
+                }
+            },
+        }
+        model_config = SimpleNamespace(hidden_size=2)
+        model_runner = SimpleNamespace(
+            spec_aux_config=SimpleNamespace(dflash_target_layer_ids=[3, 5])
+        )
+
+        plan, error = resolve_hidden_bootstrap_plan(
+            req=req,
+            metadata=metadata,
+            decode_prefix_len=0,
+            pp_rank=0,
+            model_config=model_config,
+            model_runner=model_runner,
+            metadata_buffers=SimpleNamespace(pd_hidden_pool=pool),
+        )
+
+        self.assertIsNone(error)
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.dst_indices, [])
+        self.assertEqual(plan.source_window_rows, 4)
+        self.assertIs(plan.pool, pool)
+
+
+class TestDecodePDHiddenDynamicAllocator(CustomTestCase):
+    def _make_queue(self, pool_rows: int, decode_reqs):
+        manager = _FakeKVManager()
+        manager.request_status.update(
+            {
+                req.req.bootstrap_room: KVPoll.Transferring
+                for req in decode_reqs
+            }
+        )
+        queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+        queue.queue = list(decode_reqs)
+        queue.kv_manager = manager
+        queue.metadata_buffers = SimpleNamespace(
+            pd_hidden_pool=PDHiddenRowPool(
+                pool_rows, hidden_size=1, dtype=torch.float32
+            )
+        )
+        queue._last_pd_hidden_dynamic_credit_warning_time = 0.0
+        return queue, manager
+
+    def test_rows_are_allocated_only_after_prefill_requests_them(self):
+        decode_req = _decode_req(room=1, hidden_end=4)
+        queue, manager = self._make_queue(4, [decode_req])
+        pool = queue.metadata_buffers.pd_hidden_pool
+
+        self.assertEqual(pool.available_size(), 4)
+        manager.alloc_requests.append(_alloc_request(1, 4))
+        queue._drain_pd_hidden_alloc_requests()
+
+        self.assertEqual(pool.available_size(), 0)
+        self.assertEqual(len(manager.grants), 1)
+        self.assertEqual(manager.grants[0][1], [0, 1, 2, 3])
+
+    def test_oldest_completed_prefill_chunk_cannot_be_bypassed(self):
+        first_req = _decode_req(room=1, hidden_end=4)
+        second_req = _decode_req(room=2, hidden_end=1)
+        queue, manager = self._make_queue(4, [first_req, second_req])
+
+        first = _alloc_request(1, 4)
+        second = _alloc_request(2, 1)
+        manager.alloc_requests.extend([first, second])
+        queue._drain_pd_hidden_alloc_requests()
+
+        self.assertEqual([grant[0]["room"] for grant in manager.grants], [1])
+        self.assertEqual(list(manager.alloc_requests), [second])
+
+    def test_ack_reclaims_rows_for_the_next_completed_chunk(self):
+        first_req = _decode_req(room=1, hidden_end=8)
+        second_req = _decode_req(room=2, hidden_end=4)
+        queue, manager = self._make_queue(4, [first_req, second_req])
+        pool = queue.metadata_buffers.pd_hidden_pool
+
+        manager.alloc_requests.extend(
+            [
+                _alloc_request(1, 4, hidden_end=8),
+                _alloc_request(2, 4),
+            ]
+        )
+        queue._drain_pd_hidden_alloc_requests()
+        self.assertEqual([grant[0]["room"] for grant in manager.grants], [1])
+
+        manager.acked_chunks[1].append(
+            {
+                "prefill_rank": 0,
+                "hidden_start": 0,
+                "is_last_hidden_chunk": False,
+                "release_indices": [0, 1, 2, 3],
+            }
+        )
+        queue._consume_pd_hidden_acked_chunks(first_req)
+        self.assertEqual(pool.available_size(), 4)
+
+        queue._drain_pd_hidden_alloc_requests()
+        self.assertEqual(
+            [grant[0]["room"] for grant in manager.grants], [1, 2]
+        )
+        self.assertEqual(pool.available_size(), 0)
+
+    def test_late_request_for_terminal_room_is_dropped(self):
+        decode_req = _decode_req(room=1, hidden_end=2)
+        queue, manager = self._make_queue(2, [decode_req])
+        manager.request_status[1] = KVPoll.Failed
+        manager.alloc_requests.append(_alloc_request(1, 2))
+
+        queue._drain_pd_hidden_alloc_requests()
+
+        self.assertEqual(queue.metadata_buffers.pd_hidden_pool.available_size(), 2)
+        self.assertEqual(manager.grants, [])
+        self.assertEqual(list(manager.alloc_requests), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_pd_hidden_state.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_state.py
@@ -8,6 +8,10 @@ from sglang.srt.disaggregation.common.utils import (
     PDHiddenRequestState,
 )
 from sglang.srt.disaggregation.utils import PDHiddenRowPool
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
 def _chunk(start: int, rows: int, is_last: bool = False) -> PDHiddenChunk:
@@ -21,7 +25,7 @@ def _chunk(start: int, rows: int, is_last: bool = False) -> PDHiddenChunk:
     )
 
 
-class TestPDHiddenRequestState(unittest.TestCase):
+class TestPDHiddenRequestState(CustomTestCase):
     def test_disabled_state_is_done_for_hidden_but_not_kv(self):
         state = PDHiddenRequestState.disabled()
 
@@ -135,7 +139,7 @@ class TestPDHiddenRequestState(unittest.TestCase):
         self.assertEqual(chunk.ack_port, 12345)
 
 
-class TestPDHiddenRowPool(unittest.TestCase):
+class TestPDHiddenRowPool(CustomTestCase):
     def test_alloc_prefers_contiguous_rows_and_merges_frees(self):
         pool = PDHiddenRowPool(8, 1, torch.float32)
 

--- a/test/registered/unit/disaggregation/test_pd_hidden_state.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_state.py
@@ -1,3 +1,4 @@
+import threading
 import unittest
 
 import torch
@@ -163,6 +164,34 @@ class TestPDHiddenRowPool(unittest.TestCase):
 
         self.assertEqual(pool.available_size(), 4)
         self.assertEqual(pool.alloc(4), [0, 1, 2, 3])
+
+    def test_waiting_allocation_wakes_when_rows_are_freed(self):
+        pool = PDHiddenRowPool(2, 1, torch.float32)
+        allocated = pool.alloc(2)
+        self.assertEqual(allocated, [0, 1])
+
+        started = threading.Event()
+        result = []
+
+        def allocate_after_credit():
+            started.set()
+            result.append(pool.alloc_wait(1, timeout=1.0))
+
+        waiter = threading.Thread(target=allocate_after_credit)
+        waiter.start()
+        self.assertTrue(started.wait(timeout=1.0))
+        self.assertTrue(waiter.is_alive())
+
+        pool.free([allocated[0]])
+        waiter.join(timeout=1.0)
+
+        self.assertFalse(waiter.is_alive())
+        self.assertEqual(result, [[0]])
+
+    def test_waiting_allocation_times_out_without_credit(self):
+        pool = PDHiddenRowPool(1, 1, torch.float32)
+        self.assertEqual(pool.alloc(1), [0])
+        self.assertIsNone(pool.alloc_wait(1, timeout=0.01))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_pd_hidden_state.py
+++ b/test/registered/unit/disaggregation/test_pd_hidden_state.py
@@ -193,6 +193,10 @@ class TestPDHiddenRowPool(unittest.TestCase):
         self.assertEqual(pool.alloc(1), [0])
         self.assertIsNone(pool.alloc_wait(1, timeout=0.01))
 
+    def test_waiting_allocation_rejects_request_larger_than_pool(self):
+        pool = PDHiddenRowPool(1, 1, torch.float32)
+        self.assertIsNone(pool.alloc_wait(2, timeout=1.0))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_scheduler_pp_disagg_prefill_abort.py
+++ b/test/registered/unit/managers/test_scheduler_pp_disagg_prefill_abort.py
@@ -24,13 +24,9 @@ class TestPPDisaggPrefillAbort(CustomTestCase):
             ps=SimpleNamespace(pp_size=1),
             running_mbs=[MagicMock()],
             last_mbs=[None],
-            request_receiver=SimpleNamespace(
-                recv_requests=MagicMock(return_value=[])
-            ),
+            request_receiver=SimpleNamespace(recv_requests=MagicMock(return_value=[])),
             process_input_requests=MagicMock(),
-            process_pending_chunked_abort=MagicMock(
-                side_effect=AbortConsumed
-            ),
+            process_pending_chunked_abort=MagicMock(side_effect=AbortConsumed),
             init_pp_loop_state=MagicMock(),
         )
 

--- a/test/registered/unit/managers/test_scheduler_pp_disagg_prefill_abort.py
+++ b/test/registered/unit/managers/test_scheduler_pp_disagg_prefill_abort.py
@@ -1,0 +1,44 @@
+"""Regression tests for PP disaggregated chunked-prefill cancellation."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestPPDisaggPrefillAbort(CustomTestCase):
+    def test_pp_loop_consumes_pending_abort_before_scheduling(self):
+        class AbortConsumed(Exception):
+            pass
+
+        scheduler = SimpleNamespace(
+            pp_loop_size=1,
+            ps=SimpleNamespace(pp_size=1),
+            running_mbs=[MagicMock()],
+            last_mbs=[None],
+            request_receiver=SimpleNamespace(
+                recv_requests=MagicMock(return_value=[])
+            ),
+            process_input_requests=MagicMock(),
+            process_pending_chunked_abort=MagicMock(
+                side_effect=AbortConsumed
+            ),
+            init_pp_loop_state=MagicMock(),
+        )
+
+        with self.assertRaises(AbortConsumed):
+            SchedulerPPMixin.event_loop_pp_disagg_prefill.__wrapped__(scheduler)
+
+        scheduler.process_pending_chunked_abort.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR changes PD hidden-row allocation from bootstrap-time preallocation to completion-driven allocation.

Decode now allocates destination hidden rows only when Prefill has completed a chunk and is ready to transfer it. This prevents unfinished long-context requests from exhausting the hidden pool and blocking completed requests.

## Changes

- Add PD hidden allocation request/grant control messages.
- Allocate Decode hidden rows when Prefill chunks become ready.
- Release hidden rows after ACK, abort, or transfer failure.
- Stop PP Prefill promptly after request cancellation.
- Support allocation/grant handling after KV room completion.
- Cancel allocation timers on grant and cleanup.
- Use `SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT` instead of hard-coded timeouts.
- Rate-limit hidden-pool credit warnings.
- Preserve the existing preallocation path for unsupported backends.

## Expected result

Hidden-pool usage now scales with active transferable chunks rather than the total length of all bootstrapped requests, avoiding the `PD decode hidden pool blocked prealloc` deadlock.

## Tests

```
ChatCompletionSampler initialized with self.system_message=None self.temperature=0.0 self.max_tokens=128000 self.reasoning_effort='max' self.extra_body=None
100%|██████████| 32/32 [06:56<00:00, 13.03s/it]
Total latency: 416.967 s
Score: 0.938
Output throughput: 912.890 token/s
[METRIC] gpqa_score=0.9375 labels={"model": "/data/models/DeepSeek-V4-Flash-0731-FP8", "eval": "gpqa"}
[METRIC] gpqa_latency=416.9671610277146 labels={"model": "/data/models/DeepSeek-V4-Flash-0731-FP8", "eval": "gpqa"}
Writing report to /tmp/gpqa__data_models_DeepSeek-V4-Flash-0731-FP8.html
{'chars': np.float64(432.375), 'chars:std': np.float64(221.1558768719475), 'score:std': np.float64(0.24206145913796356), 'score': np.float64(0.9375), 'latency': 416.9671610277146, 'output_throughput': 912.8896363488434}
Writing results to /tmp/gpqa__data_models_DeepSeek-V4-Flash-0731-FP8.json
```





<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->