### PR TITLE
Add hybridgemm MoE runner backend

### DIFF
--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -84,6 +84,7 @@ class MoeRunnerBackend(Enum):
     MARLIN = "marlin"
     AITER = "aiter"
     ASYM_GEMM = "asym_gemm"
+    HYBRIDGEMM = "hybridgemm"
 
     def is_auto(self):
         return self == MoeRunnerBackend.AUTO
@@ -122,7 +123,16 @@ class MoeRunnerBackend(Enum):
         return self == MoeRunnerBackend.AITER
 
     def is_asym_gemm(self):
-        return self == MoeRunnerBackend.ASYM_GEMM
+        # hybridgemm is an asym_gemm variant: same INT8 grouped-GEMM runner
+        # core, weight residency and unified-MoE wiring — it only differs in
+        # which AsymGEMM kernel the unified layer launches (see
+        # is_hybridgemm() / ASYMGEMM_HYBRID_KERNEL). Every is_asym_gemm()
+        # call site (weight loading, runner selection, unified-layer
+        # creation) is meant to cover it too.
+        return self in (MoeRunnerBackend.ASYM_GEMM, MoeRunnerBackend.HYBRIDGEMM)
+
+    def is_hybridgemm(self):
+        return self == MoeRunnerBackend.HYBRIDGEMM
 
 
 class DeepEPMode(Enum):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -201,6 +201,7 @@ MOE_RUNNER_BACKEND_CHOICES = [
     "aiter",
     "marlin",
     "asym_gemm",
+    "hybridgemm",
 ]
 
 MOE_A2A_BACKEND_CHOICES = [
@@ -1365,14 +1366,18 @@ class ServerArgs:
         # 16. Context parallel
         if self.attn_cp_size > 1:
             self.disable_piecewise_cuda_graph = True
-        # 17. Unified asym_gemm MoE. Piecewise (prefill) capture is not
-        # supported: the imperative unified path cannot record into a graph,
-        # and there is no fallback — the BF16/FP8 master weights are released
-        # after INT8 conversion. Prefill runs on the eager unified path (also
-        # measured ~2x faster than the piecewise BF16 fallback it replaces).
-        # Decode graphs are unaffected: every cuda_graph_bs entry gets a
-        # pre-allocated capturable buffer.
-        if (
+        # 17. Unified asym_gemm/hybridgemm MoE. Piecewise (prefill) capture is
+        # not supported: the imperative unified path cannot record into a
+        # graph, and there is no fallback — the BF16/FP8 master weights are
+        # released after INT8 conversion. Prefill runs on the eager unified
+        # path (also measured ~2x faster than the piecewise BF16 fallback it
+        # replaces). Decode graphs are unaffected: every cuda_graph_bs entry
+        # gets a pre-allocated capturable buffer. hybridgemm always runs the
+        # unified path (_handle_moe_kernel_config forces
+        # SGLANG_ASYMGEMM_UNIFIED_MOE on for it, but that runs *after* this
+        # method — so hybridgemm is checked unconditionally here rather than
+        # via the env var, which wouldn't be set yet).
+        if self.moe_runner_backend == "hybridgemm" or (
             self.moe_runner_backend == "asym_gemm"
             and envs.SGLANG_ASYMGEMM_UNIFIED_MOE.get()
         ):
@@ -3192,6 +3197,38 @@ class ServerArgs:
             assert (
                 self.ep_size == 1
             ), "FP8/MXFP8 Cutlass MoE is only supported with ep_size == 1"
+
+        if self.moe_runner_backend == "hybridgemm":
+            assert is_sm90_supported(), (
+                "'hybridgemm' MoE runner backend requires an SM90 (Hopper) "
+                "GPU — the fused host+HBM kernel it uses is Hopper-only. Use "
+                "'asym_gemm' on other architectures."
+            )
+            assert self.quantization in (None, "fp8", "modelopt_fp8"), (
+                f"Invalid quantization {self.quantization!r} for 'hybridgemm' "
+                "MoE runner backend: like 'asym_gemm', it quantizes MoE "
+                "experts to INT8 internally (from BF16 masters, or "
+                "'fp8'/'modelopt_fp8' block-scaled masters via a "
+                "pre-quantized INT8 slab)."
+            )
+            # hybridgemm only exists inside the unified CPU+GPU MoE path — a
+            # plain AsymGemmRunnerCore forward would silently behave exactly
+            # like 'asym_gemm' (same runner core, see MoeRunnerBackend.
+            # is_asym_gemm()) and never touch the hybrid kernel at all.
+            if not envs.SGLANG_ASYMGEMM_UNIFIED_MOE.get():
+                envs.SGLANG_ASYMGEMM_UNIFIED_MOE.set(True)
+                logger.info(
+                    "'hybridgemm' MoE runner backend selected: enabling "
+                    "SGLANG_ASYMGEMM_UNIFIED_MOE."
+                )
+            # AsymGEMM's unified runtime reads this directly (not through
+            # sglang's env registry) to fuse the cached (HBM) and streamed
+            # (pinned-host) GPU-bucket partitions into one hybrid kernel
+            # launch per projection instead of two separate launches — see
+            # AsymGEMM's hybridGEMM_usage.md §8. ASYMGEMM_HYBRID_S_HOST is
+            # settable directly by the user to override the CTA-split
+            # heuristic; sglang does not wrap it.
+            os.environ.setdefault("ASYMGEMM_HYBRID_KERNEL", "1")
 
         # TODO(yuwei): Fix piecewise cuda graph support for bypassed topk MoE backends.
         # Exception: GptOssForCausalLM wraps the entire MoE block in its own


### PR DESCRIPTION
## Summary
- Adds `--moe-runner-backend hybridgemm` as a sibling of `asym_gemm`: same INT8 grouped-GEMM runner core, weight residency, and unified-MoE wiring, since `MoeRunnerBackend.is_asym_gemm()` now covers both (hybridgemm only differs in which AsymGEMM kernel the unified layer launches).
- Selecting it forces `SGLANG_ASYMGEMM_UNIFIED_MOE` and `ASYMGEMM_HYBRID_KERNEL` on, and asserts SM90 + a compatible quantization, since the fused kernel only exists inside the unified CPU+GPU MoE path and is Hopper-only.
- Companion AsymGEMM-side PR (Layer.forward wiring for the hybrid kernel, with a staging-safety gate): https://github.com/bytedance-iaas/AsymGEMM/pull/76

## Test plan
- [x] Enum/CLI logic verified directly (`MoeRunnerBackend('hybridgemm').is_asym_gemm()` / `.is_hybridgemm()`, `"hybridgemm" in MOE_RUNNER_BACKEND_CHOICES`)
- [x] `_handle_moe_kernel_config` env-forcing logic exercised in isolation (`SGLANG_ASYMGEMM_UNIFIED_MOE` gets set, `ASYMGEMM_HYBRID_KERNEL=1` gets exported) on an SM90 host
- [x] Live `sglang.launch_server --moe-runner-backend hybridgemm` + `bench_serving` comparison against `asym_gemm` (Qwen3-Coder-30B-A3B-Instruct, `ASYMGEMM_GPU_CACHED_EXPERTS=16 ASYMGEMM_STAGE_STREAMED=0` on both): hybridgemm modestly ahead across throughput/latency/TTFT
- [ ] No dedicated unit test added for the CLI validation block, matching this codebase's existing convention (asym_gemm's own equivalent validation has no unit test either -- that class of behavior is covered by GPU integration tests under test/registered/moe/, which need a real model checkpoint)

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->