### PR TITLE
fix(dsv4): persist C128 prefill plan page indices

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/c_plan.cuh
@@ -308,8 +308,8 @@ __global__ void plan_compress_prefill_kernel_1(const Prefill1Params params) {
         const auto state_loc_1 = params.f2s_ptr[raw_loc_1];
         plan_c.read_page_0 = compute_loc(state_loc_0) / params.compress_ratio;
         plan_c.read_page_1 = compute_loc(state_loc_1) / params.compress_ratio;
-        params.plan_c[idx] = plan_c;
       }
+      params.plan_c[idx] = plan_c;
     }
   } else if (idx < params.num_c_padded) {
     params.plan_c[idx] = PlanC::invalid();

--- a/test/registered/jit/deepseek_v4/test_c128_v2.py
+++ b/test/registered/jit/deepseek_v4/test_c128_v2.py
@@ -226,6 +226,31 @@ def test_prefill_then_extend(mode: str, prefix_len: int, extend_len: int) -> Non
         )
 
 
+def test_prefill_plan_resolves_speculative_c128_ring_pages() -> None:
+    """GPU prefill planning must replace batch-id placeholders with C128 pages."""
+    ctx = make_paged_context(
+        bs=2,
+        compress_ratio=RATIO,
+        head_dim=HEAD_DIM,
+        ring_size=256,
+    )
+    ctx.req_pool_indices.copy_(
+        torch.tensor([5, 2], dtype=torch.int64, device=get_device())
+    )
+
+    seq_lens = torch.tensor([128, 256], dtype=torch.int64, device=get_device())
+    extend_lens = torch.full((2,), 3, dtype=torch.int64, device=get_device())
+    plan = ctx.make_prefill_plan(seq_lens, extend_lens, num_q_tokens=6)
+
+    plan_raw = plan.plan_c.view(torch.int32)
+    valid_plans = plan_raw[plan_raw[:, 0] > 0].cpu()
+    valid_plans = valid_plans[torch.argsort(valid_plans[:, 0])]
+
+    assert valid_plans[:, 0].tolist() == [128, 256]
+    assert valid_plans[:, 2].tolist() == [10, 4]
+    assert valid_plans[:, 3].tolist() == [10, 5]
+
+
 @pytest.mark.parametrize("mode", ["legacy", "paged"])
 def test_prefill_multibatch(mode: str) -> None:
     """Multi-batch prefill, each batch ending at a different chunk count."""


### PR DESCRIPTION
## Summary

- persist the C128 `PlanC` after the prefill planner resolves its page indices
- prevent stage-0 batch-id placeholders from reaching the non-online-compression C128 forward path
- add a GPU regression test with a speculative-size ring and non-identity request IDs

## Root cause

`plan_compress_prefill_kernel_1` updated `read_page_0` and `read_page_1` for C128 only in its local `plan_c` value, while the writeback to `params.plan_c[idx]` was scoped to the C4 branch. The C128 consumer could therefore observe the stage-0 placeholder values (`read_page_0 = -1`, `read_page_1 = batch_id`) instead of request-scoped ring pages, causing the accuracy regression under EAGLE speculative decoding.

## Test plan

- `PYTHONPYCACHEPREFIX=/private/tmp/sglang-pycache python3 -m py_compile test/registered/jit/deepseek_v4/test_c128_v2.py`
- `git diff --check`
- GPU: `python3 -m pytest -q /tmp/test_c128_v2_regression.py -k test_prefill_plan_resolves_speculative_c128_ring_pages` (`1 passed, 26 deselected`)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31003454937](https://github.com/bytedance-iaas/sglang/actions/runs/31003454937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31003454455](https://github.com/bytedance-iaas/sglang/actions/runs/31003454455)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->