### PR TITLE
fix(router): honor zero token refill rate

### DIFF
--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -378,7 +378,7 @@ impl AppContextBuilder {
             n => {
                 let rate_limit_tokens = config
                     .rate_limit_tokens_per_second
-                    .filter(|&t| t > 0)
+                    .filter(|&t| t >= 0)
                     .unwrap_or(n);
                 Some(Arc::new(TokenBucket::new(
                     n as usize,
@@ -528,5 +528,33 @@ impl AppContextBuilder {
 impl Default for AppContextBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_zero_refill_rate_enables_pure_concurrency_limiting() {
+        let config = RouterConfig::builder()
+            .regular_mode(vec!["http://worker:8000".to_string()])
+            .max_concurrent_requests(100)
+            .rate_limit_tokens_per_second(0)
+            .build()
+            .unwrap();
+        let builder = AppContextBuilder::new().maybe_rate_limiter(&config);
+        let limiter = builder.rate_limiter.unwrap();
+
+        for _ in 0..100 {
+            assert!(limiter.try_acquire(1.0).await.is_ok());
+        }
+        assert!(limiter.try_acquire(1.0).await.is_err());
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(limiter.try_acquire(1.0).await.is_err());
+
+        limiter.return_tokens(1.0).await;
+        assert!(limiter.try_acquire(1.0).await.is_ok());
     }
 }

--- a/sgl-model-gateway/tests/common/mod.rs
+++ b/sgl-model-gateway/tests/common/mod.rs
@@ -297,7 +297,7 @@ pub async fn create_test_context(config: RouterConfig) -> Arc<AppContext> {
         n => {
             let rate_limit_tokens = config
                 .rate_limit_tokens_per_second
-                .filter(|&t| t > 0)
+                .filter(|&t| t >= 0)
                 .unwrap_or(n);
             Some(Arc::new(TokenBucket::new(
                 n as usize,
@@ -416,7 +416,7 @@ pub async fn create_test_context_with_parsers(config: RouterConfig) -> Arc<AppCo
         n => {
             let rate_limit_tokens = config
                 .rate_limit_tokens_per_second
-                .filter(|&t| t > 0)
+                .filter(|&t| t >= 0)
                 .unwrap_or(n);
             Some(Arc::new(TokenBucket::new(
                 n as usize,
@@ -545,7 +545,7 @@ pub async fn create_test_context_with_mcp_config(
         n => {
             let rate_limit_tokens = config
                 .rate_limit_tokens_per_second
-                .filter(|&t| t > 0)
+                .filter(|&t| t >= 0)
                 .unwrap_or(n);
             Some(Arc::new(TokenBucket::new(
                 n as usize,

--- a/sgl-model-gateway/tests/common/test_app.rs
+++ b/sgl-model-gateway/tests/common/test_app.rs
@@ -32,7 +32,7 @@ pub fn create_test_app(
         n => {
             let rate_limit_tokens = router_config
                 .rate_limit_tokens_per_second
-                .filter(|&t| t > 0)
+                .filter(|&t| t >= 0)
                 .unwrap_or(n);
             Some(Arc::new(TokenBucket::new(
                 n as usize,


### PR DESCRIPTION
## Summary

- honor `--rate-limit-tokens-per-second 0` as pure concurrency limiting
- keep Router test helpers consistent with production rate-limiter construction
- add a regression test proving tokens do not refill until a request returns one

## Testing

- `cargo +nightly fmt -- --check`
- `cargo +nightly test test_zero_refill_rate_enables_pure_concurrency_limiting --lib`
- pre-commit on all changed files

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->