### PR TITLE
[Speculative] Add MiniMax-M3 DSPARK support

### DIFF
--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -296,12 +296,34 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         else:
             idx_k_cache, idx_v_cache = self.kv_pool.get_index_kv_buffer(layer.layer_id)
 
+        extend_seq_lens = forward_batch.extend_seq_lens
+        extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
+
+        if extend_seq_lens is None and forward_batch.forward_mode.is_target_verify():
+            spec_info = forward_batch.spec_info
+            if spec_info is None:
+                raise ValueError(
+                    "MiniMax sparse TARGET_VERIFY requires spec_info when "
+                    "extend_seq_lens is absent."
+                )
+            verify_len = spec_info.draft_token_num
+            extend_seq_lens = torch.full(
+                (forward_batch.batch_size,),
+                verify_len,
+                dtype=torch.int32,
+                device=q.device,
+            )
+            extend_seq_lens_cpu = [verify_len] * forward_batch.batch_size
+
+        if extend_seq_lens is None:
+            raise ValueError(
+                "MiniMax sparse forward_extend requires extend_seq_lens."
+            )
+
         cu_seqlens = torch.cat(
             [
-                torch.zeros(
-                    1, dtype=torch.int32, device=forward_batch.extend_seq_lens.device
-                ),
-                forward_batch.extend_seq_lens.to(torch.int32).cumsum(0).to(torch.int32),
+                torch.zeros(1, dtype=torch.int32, device=extend_seq_lens.device),
+                extend_seq_lens.to(torch.int32).cumsum(0).to(torch.int32),
             ]
         )
         seq_lens = forward_batch.seq_lens.to(torch.int32)
@@ -312,8 +334,8 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
 
         # DP attention pads q beyond the real token count for collective alignment;
         # trim to actual tokens so the sparse kernel sees consistent shapes.
-        if forward_batch.extend_seq_lens_cpu is not None:
-            actual_num_tokens = int(sum(forward_batch.extend_seq_lens_cpu))
+        if extend_seq_lens_cpu is not None:
+            actual_num_tokens = int(sum(extend_seq_lens_cpu))
         else:
             actual_num_tokens = int(cu_seqlens[-1].item())
         original_num_tokens = q.shape[0]
@@ -345,7 +367,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             score_type=self.score_type,
             disable_index_value=disable_value,
             use_msa=self.use_msa,
-            seqlens_cpu=forward_batch.extend_seq_lens_cpu,
+            seqlens_cpu=extend_seq_lens_cpu,
         )
 
         if actual_num_tokens < original_num_tokens:

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -1503,6 +1503,19 @@ class MiniMaxM3SparseForCausalLM(nn.Module):
         else:
             self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
+    def set_dspark_layers_to_capture(self, layer_ids: List[int]) -> None:
+        if not self.pp_group.is_last_rank:
+            return
+        if layer_ids is None:
+            raise ValueError(
+                "DSPARK requires explicit layer_ids for aux hidden capture."
+            )
+        self.capture_aux_hidden_states = True
+        self.model.layers_to_capture = [val + 1 for val in layer_ids]
+        for layer_id in self.model.layers_to_capture:
+            if self.model.start_layer <= layer_id < self.model.end_layer:
+                setattr(self.model.layers[layer_id], "_is_layer_to_capture", True)
+
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 

--- a/python/sglang/srt/models/minimax_m3_vl.py
+++ b/python/sglang/srt/models/minimax_m3_vl.py
@@ -121,6 +121,7 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
         )
 
         self.logits_processor = LogitsProcessor(text_config)
+        self.capture_aux_hidden_states = False
 
     def _determine_num_fused_shared_experts(self) -> None:
         text_config = self.config.text_config
@@ -174,6 +175,19 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
             text_config
         )
 
+    def set_dspark_layers_to_capture(self, layer_ids: List[int]) -> None:
+        if not self.pp_group.is_last_rank:
+            return
+        if layer_ids is None:
+            raise ValueError(
+                "DSPARK requires explicit layer_ids for aux hidden capture."
+            )
+        self.capture_aux_hidden_states = True
+        self.model.layers_to_capture = [val + 1 for val in layer_ids]
+        for layer_id in self.model.layers_to_capture:
+            if self.model.start_layer <= layer_id < self.model.end_layer:
+                setattr(self.model.layers[layer_id], "_is_layer_to_capture", True)
+
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         return MultiModalityDataPaddingPatternMultimodalTokens().pad_input_tokens(
             input_ids, mm_inputs
@@ -208,12 +222,17 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
             pp_proxy_tensors=pp_proxy_tensors,
         )
 
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = hidden_states
+
         if self.pp_group.is_last_rank and not get_embedding:
             return self.logits_processor(
                 input_ids,
                 hidden_states,
                 self.lm_head,
                 forward_batch,
+                aux_hidden_states,
             )
         return hidden_states
 

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -50,9 +50,6 @@ elif is_hip():
     from sglang.kernels.ops.sampling.renorm_triton import (
         top_k_renorm_probs_triton as top_k_renorm_prob,
     )
-    from sglang.kernels.ops.sampling.renorm_triton import (
-        top_p_renorm_probs_triton as top_p_renorm_prob,
-    )
 
     _DFLASH_SAMPLING_VERIFY_AVAILABLE = True
 else:

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -12,8 +12,8 @@ import torch.nn.functional as F
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.layers.sampler import apply_custom_logit_processor
 from sglang.srt.managers.schedule_batch import Req
-from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.utils import is_cuda, is_musa
+from sglang.srt.speculative.spec_utils import _sample_simulated_acc_len
+from sglang.srt.utils import is_cuda, is_hip, is_musa
 
 DEFAULT_DFLASH_MASK_TOKEN = "<|MASK|>"
 
@@ -46,6 +46,15 @@ if is_cuda() or is_musa():
         top_k_renorm_prob = None
         top_p_renorm_prob = None
         tree_speculative_sampling_target_only = None
+elif is_hip():
+    from sglang.kernels.ops.sampling.renorm_triton import (
+        top_k_renorm_probs_triton as top_k_renorm_prob,
+    )
+    from sglang.kernels.ops.sampling.renorm_triton import (
+        top_p_renorm_probs_triton as top_p_renorm_prob,
+    )
+
+    _DFLASH_SAMPLING_VERIFY_AVAILABLE = True
 else:
     top_k_renorm_prob = None
     top_p_renorm_prob = None
@@ -146,7 +155,7 @@ def apply_dflash_verify_logits_adjustments(
 
     acc_linear_penalties = getattr(sampling_info, "acc_linear_penalties", None)
     penalizer = getattr(sampling_info, "penalizer_orchestrator", None)
-    vocab_mask = getattr(sampling_info, "vocab_mask", None)
+    grammar_mask = getattr(sampling_info, "grammar_mask", None)
     logit_bias = getattr(sampling_info, "logit_bias", None)
 
     logits_3d: Optional[torch.Tensor] = None
@@ -162,7 +171,7 @@ def apply_dflash_verify_logits_adjustments(
     # broadcast over the verify block without materializing a repeated buffer.
     if (
         penalizer is not None and penalizer.is_required and acc_linear_penalties is None
-    ) or vocab_mask is not None:
+    ) or grammar_mask is not None:
         linear_penalty = torch.zeros(
             (bs, next_token_logits.shape[1]),
             dtype=torch.float32,
@@ -317,6 +326,21 @@ def get_dflash_attention_sliding_window_size(config: Any) -> Optional[int]:
     sliding_window = _cfg_get(
         text_config, "sliding_window", _cfg_get(config, "sliding_window")
     )
+
+    if sliding_window is None:
+        try:
+            import json
+            from pathlib import Path
+
+            model_path = _cfg_get(config, "_name_or_path")
+            if model_path:
+                config_path = Path(model_path) / "config.json"
+                if config_path.exists():
+                    raw_config = json.loads(config_path.read_text())
+                    sliding_window = raw_config.get("sliding_window")
+        except Exception:
+            sliding_window = None
+
     if sliding_window is None:
         raise ValueError(
             "DFLASH sliding_attention layers require config.sliding_window."
@@ -586,6 +610,43 @@ def compute_dflash_correct_drafts_and_bonus(
     return correct_len, bonus.to(torch.int64)
 
 
+def apply_dflash_simulated_acceptance(
+    *,
+    candidates: torch.Tensor,
+    target_predict: Optional[torch.Tensor],
+    accept_len: torch.Tensor,
+    commit_lens: torch.Tensor,
+    bonus: torch.Tensor,
+    out_tokens: torch.Tensor,
+    simulate_acc_len: float,
+    simulate_acc_method: str,
+    simulate_acc_token_mode: str,
+    fixed_token_id: int = 100,
+) -> None:
+    """Forces the DFlash acceptance length (SGLANG_SIMULATE_ACC_LEN benchmark knob)."""
+    block_size = candidates.shape[1]
+
+    # _sample_simulated_acc_len clamps to [1, block_size].
+    forced_commit_len = _sample_simulated_acc_len(
+        simulate_acc_len, simulate_acc_method, block_size
+    )
+    forced_accept_len = forced_commit_len - 1
+
+    accept_len.fill_(forced_accept_len)
+    commit_lens.fill_(forced_commit_len)
+
+    if simulate_acc_token_mode != "real-draft-token":
+        bonus.fill_(fixed_token_id)
+        out_tokens.fill_(fixed_token_id)
+        return
+
+    out_tokens.zero_()
+    if forced_accept_len > 0:
+        out_tokens[:, :forced_accept_len].copy_(candidates[:, 1:forced_commit_len])
+    bonus.copy_(target_predict[:, forced_accept_len].to(dtype=bonus.dtype))
+    out_tokens[:, forced_accept_len].copy_(bonus.to(dtype=out_tokens.dtype))
+
+
 def compute_dflash_sampling_correct_drafts_and_bonus(
     *,
     candidates: torch.Tensor,
@@ -635,13 +696,13 @@ def compute_dflash_sampling_correct_drafts_and_bonus(
         )
 
     if threshold_single is None:
-        from sglang.srt.runtime_context import get_server_args
+        from sglang.srt.runtime_context import get_spec
 
-        threshold_single = get_server_args().speculative_accept_threshold_single
+        threshold_single = get_spec().speculative_accept_threshold_single
     if threshold_acc is None:
-        from sglang.srt.runtime_context import get_server_args
+        from sglang.srt.runtime_context import get_spec
 
-        threshold_acc = get_server_args().speculative_accept_threshold_acc
+        threshold_acc = get_spec().speculative_accept_threshold_acc
     threshold_single = float(threshold_single)
     threshold_acc = max(float(threshold_acc), 1e-9)
 
@@ -794,26 +855,11 @@ def build_dflash_verify_target_probs(
     return target_probs.view(bs, draft_token_num, -1).contiguous()
 
 
-def validate_dflash_request(
-    req: Req, enable_overlap: bool, spec_algorithm: SpeculativeAlgorithm
-) -> Optional[str]:
+def validate_dflash_request(req: Req, enable_overlap: bool) -> Optional[str]:
     if req.return_logprob:
         return "DFLASH speculative decoding does not support return_logprob yet."
 
     if enable_overlap and req.return_hidden_states:
         return "DFLASH speculative decoding does not support return_hidden_states yet."
-
-    # Grammar support in this family is the verify-time bitmask plus the grammar
-    # barrier, so the capability that gates the barrier also gates admission.
-    if not spec_algorithm.supports_grammar_overlap() and (
-        req.sampling_params.json_schema is not None
-        or req.sampling_params.regex is not None
-        or req.sampling_params.ebnf is not None
-        or req.sampling_params.structural_tag is not None
-    ):
-        return (
-            f"{spec_algorithm.name} speculative decoding does not support "
-            "grammar-constrained decoding yet."
-        )
 
     return None


### PR DESCRIPTION
## Summary

This PR adds DSPARK speculative decoding support for MiniMax-M3 with MiniMax-M3-DSpark as the draft model.

MiniMax-M3-DSpark is a draft model and cannot be served standalone. When it is used with MiniMax-M3 as the target model, the current MiniMax-M3 path misses several DSPARK-specific integration points:

- MiniMax-M3 target model does not expose the required DSPARK auxiliary hidden-state capture hook.
- MiniMax-M3 VL wrapper does not forward auxiliary hidden states to the logits processor.
- MiniMax sparse attention assumes `extend_seq_lens` is always available in extend mode, while TARGET_VERIFY CUDA graph capture may not provide it.
- MiniMax-M3-DSpark's raw config contains `sliding_window`, but the loaded Transformers config may expose it as `None`.

This PR fixes these issues and enables two-node TP16 serving with MiniMax-M3 + MiniMax-M3-DSpark.

## Changes

### MiniMax-M3 target model

- Add `set_dspark_layers_to_capture` to `MiniMaxM3SparseForCausalLM`.
- Add `set_dspark_layers_to_capture` to `MiniMaxM3SparseForConditionalGeneration`.
- Mark requested target layers with `_is_layer_to_capture` so the existing MiniMax-M3 forward path can collect auxiliary hidden states.

### MiniMax-M3 VL wrapper

- Add `capture_aux_hidden_states` state.
- Unpack `(hidden_states, aux_hidden_states)` when auxiliary capture is enabled.
- Pass `aux_hidden_states` to `logits_processor`.

### MiniMax sparse attention

- Handle `ForwardMode.TARGET_VERIFY` when `extend_seq_lens` is absent.
- Synthesize uniform verify lengths from `forward_batch.spec_info.draft_token_num`.
- Use the synthesized lengths to build `cu_seqlens` for sparse attention.

### DFLASH / DSPARK config handling

- Add a fallback to read `sliding_window` from raw `config.json` when the loaded config exposes it as `None`.

## Error cases fixed

This PR fixes the following errors observed when launching MiniMax-M3 with MiniMax-M3-DSpark:

```text
ValueError: DFLASH sliding_attention layers require config.sliding_window.
```

```text
ValueError: Model MiniMaxM3SparseForConditionalGeneration implements neither set_dspark_layers_to_capture nor set_dflash_layers_to_capture, one of which is required for DFLASH/DSPARK.
```

```text
AttributeError: 'NoneType' object has no attribute 'device'
```

```text
ValueError: DFLASH target_hidden feature dim mismatch. Expected shape [N, 36864] (num_context_features=6, hidden_size=6144), but got shape=(..., 6144).
```

## Validation

### Static checks

```bash
python3 -m py_compile \
  python/sglang/srt/layers/attention/minimax_sparse_backend.py \
  python/sglang/srt/speculative/dflash_utils.py \
  python/sglang/srt/models/minimax_m3_vl.py \
  python/sglang/srt/models/minimax_m3.py
```

### Two-node TP16 serving

Validated with MiniMax-M3 as the target model and MiniMax-M3-DSpark as the DSPARK draft model:

```bash
python3 -m sglang.launch_server \
  --model-path /models/MiniMax-M3 \
  --served-model-name MiniMax-M3 \
  --reasoning-parser auto \
  --tool-call-parser auto \
  --trust-remote-code \
  --tp-size 16 \
  --nnodes 2 \
  --node-rank <0-or-1> \
  --dist-init-addr 192.168.1.81:20000 \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path /models/MiniMax-M3-DSpark \
  --speculative-dspark-block-size 8 \
  --chunked-prefill-size 8192 \
  --mem-fraction-static 0.80 \
  --dtype bfloat16 \
  --host 0.0.0.0 \
  --port 31000
```


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->