### PR TITLE
asym_gemm: drive AsymGEMM's live VRAM expert-cache refresh

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -430,6 +430,30 @@ class Envs:
     # Empty = always quantize online. On any missing file or shape mismatch the
     # affected layer transparently falls back to online quantization.
     SGLANG_ASYMGEMM_UNIFIED_INT8_PATH = EnvStr("")
+    # Phase-1 live VRAM expert-cache refresh (asym_gemm.unified_moe.runtime.
+    # refresh_gpu_caches): every N replayed decode steps, re-pick each
+    # unified-MoE layer's cached experts from live routing counts, taking a
+    # blocking barrier only if a residency actually changes. <= 0 (default)
+    # disables this — the cache stays exactly as built at layer-construction
+    # time. N counts *replayed decode steps only* — the passes this hook
+    # actually sees. Eager passes (prefill, or a decode batch not yet
+    # graph-captured) still accumulate routing counts inside Layer.forward(),
+    # but never trigger a refresh, so the cadence does not drift with the
+    # workload's prefill:decode mix.
+    #
+    # This var arms the *trigger*, and is the only one whose *value* sets the
+    # cadence. AsymGEMM-side ASYMGEMM_CACHE_TRACK_ROUTING arms the *counters*
+    # (a boolean: Layer.__init__ allocates _live_counts only when it is set).
+    # A third, pre-existing var is required too: ASYMGEMM_GPU_CACHED_EXPERTS
+    # must be strictly between 0 and num_experts, since with no VRAM cache
+    # there is no residency to re-pick. All three are needed; any one missing
+    # silently yields static residency.
+    #
+    # Use a value in the hundreds, not single digits. Evicting one expert
+    # costs real PCIe bytes (4.5 MiB at Qwen3-30B-A3B shapes), and the live
+    # counters need enough routed tokens to be more than noise. AsymGEMM-side
+    # ASYMGEMM_CACHE_{MAX_SWAP,SWAP_MARGIN,COUNT_DECAY} bound the churn.
+    SGLANG_ASYMGEMM_CACHE_REFRESH_INTERVAL = EnvInt(0)
 
     # DeepSeek MHA Optimization
     SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD = EnvInt(8192)

--- a/python/sglang/srt/layers/moe/moe_runner/asym_gemm_unified.py
+++ b/python/sglang/srt/layers/moe/moe_runner/asym_gemm_unified.py
@@ -76,6 +76,50 @@ def has_unified_asym_gemm_layer(layer: torch.nn.Module) -> bool:
     return getattr(layer, _UNIFIED_LAYER_ATTR, None) is not None
 
 
+_refresh_replay_steps = 0
+
+
+def maybe_refresh_gpu_caches() -> None:
+    """Pre-graph-replay hook for AsymGEMM's Phase-1 live VRAM-cache refresh.
+
+    Call only from the can_run_graph branch of ModelRunner._forward_raw,
+    immediately before graph_runner.replay(). No-op unless the unified MoE path is
+    enabled and SGLANG_ASYMGEMM_CACHE_REFRESH_INTERVAL > 0.
+    """
+    global _refresh_replay_steps
+
+    if not unified_asym_gemm_enabled():
+        return
+    interval = envs.SGLANG_ASYMGEMM_CACHE_REFRESH_INTERVAL.get()
+    if interval <= 0:
+        return
+    if torch.cuda.is_current_stream_capturing():
+        return
+
+    # Cadence is counted in *replayed decode steps*, which is what this hook
+    # sees -- not in forward_pass_id. forward_pass_id also advances on eager
+    # prefill passes, which never reach here, so `forward_pass_id % interval`
+    # samples the id space sparsely and can miss every multiple of it: on a
+    # prefill-heavy workload the refresh silently never fired at all. Counting
+    # our own calls makes the env var mean what it says, one refresh per
+    # `interval` replayed decode steps, independent of the prefill:decode mix.
+    _refresh_replay_steps += 1
+    if _refresh_replay_steps % interval != 0:
+        return
+
+    from asym_gemm.unified_moe.runtime import refresh_gpu_caches
+
+    # Coarse Phase-1 barrier: block for in-flight GPU work before mutating
+    # cache tensors the upcoming graph replay will read. sync_before_mutate
+    # makes refresh_gpu_caches take it *lazily* — at most once, and only if
+    # some layer's residency actually changes. Syncing here unconditionally
+    # (the original form) stalled the pipeline on every interval boundary
+    # even when the refresh turned out to be a no-op, which is the common
+    # case once the counters settle. A non-blocking event-gated version is
+    # still deferred to a later phase.
+    refresh_gpu_caches(sync_before_mutate=True)
+
+
 # --------------------------------------------------------------------------- #
 # INT8 preload: when an offline INT8 slab covers a layer, its BF16 expert
 # master weights are pure waste — they would be allocated (pinned), read from

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -3408,6 +3408,11 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 
         # Replay cuda graph if applicable
         if can_run_graph:
+            from sglang.srt.layers.moe.moe_runner.asym_gemm_unified import (
+                maybe_refresh_gpu_caches,
+            )
+
+            maybe_refresh_gpu_caches()
             ret = self.graph_runner.replay(
                 forward_batch,
                 skip_attn_backend_init=skip_attn_backend_init,


### PR DESCRIPTION
## What this does

Drives AsymGEMM's live VRAM expert-cache refresh (companion PR: bytedance-iaas/AsymGEMM#77). The refresh must run *between* graph replays, and AsymGEMM has no visibility into that boundary — which is why this half lives here.

Three files, +69 lines, no deletions.

## Fully separate codepath, dormant unless explicitly enabled

Stated up front because it is the main thing to check in review. **With the new parameter unset, none of this runs and behavior is byte-for-byte the existing static residency.**

`SGLANG_ASYMGEMM_CACHE_REFRESH_INTERVAL` defaults to `0`, so `maybe_refresh_gpu_caches` returns on its second check, the VRAM cache stays exactly as `Layer.__init__` built it, and an unset environment reproduces current sglang exactly.

The hook is additive in every sense:

- **One call site**, in the `can_run_graph` branch of `_forward_raw`. Nothing else in sglang calls it.
- **Three guards before any work**: unified MoE path enabled, `interval > 0`, and not currently capturing.
- **The AsymGEMM import is inside the function**, after the guards — a build without AsymGEMM installed never attempts it.
- **No existing code was modified.** Three files, +69 lines, **zero deletions**.

## Parameters introduced

One new parameter here, but **three settings are required in total** to actually enable dynamic residency. Miss any one and you silently get static behavior:

| Parameter | Repo | Default | Arms | New? |
|---|---|---|---|---|
| `SGLANG_ASYMGEMM_CACHE_REFRESH_INTERVAL` | sglang (this PR) | `0` = off | the **trigger** | new |
| `ASYMGEMM_CACHE_TRACK_ROUTING` | AsymGEMM (companion PR) | unset = off | the **counters** (boolean) | new |
| `ASYMGEMM_GPU_CACHED_EXPERTS` | AsymGEMM | `0` = no cache | the **cache itself** | pre-existing |

The third is easy to overlook. With no VRAM cache there is no residency to re-pick: `cache_n = 0` leaves `_live_counts` unallocated and `refresh_gpu_caches()` returns 0 even with both interval vars set. It must also be strictly between 0 and `num_experts` — a fully-cached layer has nothing to swap in and is skipped too.

Confirm it engaged with `grep -c 'live cache refresh' <server.log>`. Zero means a missing setting, or too few decode steps to reach the interval — never "no swaps were needed".

No new CLI flags, and no changes to existing ones. `--moe-runner-backend asym_gemm` and `SGLANG_ASYMGEMM_UNIFIED_MOE` are pre-existing requirements of the unified MoE path, not introduced here. Optional AsymGEMM-side tuning knobs (`ASYMGEMM_CACHE_{COUNT_DECAY,MAX_SWAP,SWAP_MARGIN}`) all have working defaults and are documented in the companion PR.

## Changes

- **`environ.py`** — declares `SGLANG_ASYMGEMM_CACHE_REFRESH_INTERVAL` (`EnvInt(0)`).
- **`layers/moe/moe_runner/asym_gemm_unified.py`** — `maybe_refresh_gpu_caches()`: three guards, then a self-counted cadence, then the call into AsymGEMM.
- **`model_executor/model_runner.py`** — one call site, in the `can_run_graph` branch immediately before `graph_runner.replay()`, so the mutated cache tensors are correct when the pre-recorded kernels read them. No recapture.

## Cadence is counted in replayed decode steps, not `forward_pass_id`

This is the part worth reviewing closely. `forward_pass_id` also advances on eager prefill passes, which never reach this hook, so `forward_pass_id % interval` samples the id space sparsely — it undercounts on ordinary workloads and misfires on unlucky prefill:decode ratios. On a prefill-heavy workload the refresh silently never fires at all.

Counting the hook's own calls makes the interval mean what the env var says regardless of workload mix. Verified: a run with ~3400 decode passes at interval 100 fires **exactly 34 times**.

The two-variable pairing above is documented at the declaration in `environ.py`, because missing it cost us a full benchmark run to notice.

## Minor notes

- `sync_before_mutate=True` asks AsymGEMM to take its barrier lazily — at most once per refresh, and only when some layer's residency actually changes — rather than unconditionally on every interval boundary. See the scaling note below for how often that condition is actually met.
- The `is_current_stream_capturing()` guard is defensive: this path already only runs on full-graph decode replays, since `disable_piecewise_cuda_graph` is forced on for the unified MoE path (`server_args.py`).

## Choosing the interval

The interval counts **decode steps, not time**, so refresh frequency scales linearly with decode throughput while the refresh cost (~31 ms for 48 layers) stays fixed:

| Decode rate | Refresh every | Overhead at `interval=100` |
|---|---|---|
| 7 steps/s (benchmarked here) | 14.2 s | 0.2% |
| 100 steps/s | 1.0 s | ~3% |
| 1000 steps/s | 0.1 s | ~31% |

`100` is tuned for the benchmarked operating point and is **not a universal default**. Decode rate is `output tokens/s ÷ concurrent requests`; anything that raises it — more resident experts, faster interconnect, smaller model, lower concurrency — wants a proportionally larger interval.

Easy check on any run: `grep 'live cache refresh' <server.log>` and look at timestamp spacing. Seconds apart is fine; sub-second means raise the interval.

Two related caveats, measured rather than assumed. The lazy barrier **did not get skipped at steady state** — over 34 refreshes, all 34 changed some layer's residency (minimum 2, never 0), so the sync was taken every time. That matters under overlap scheduling, which is on by default: a full device sync collapses CPU/GPU overlap for that step. And the always-paid counting cost is ~250 us per decode step across 48 layers, flat in batch size — negligible against a ~141 ms decode step here, but not against a fast one. Full cost breakdown in the companion PR.

## Result

+10.9% total token throughput over arbitrary static residency on Qwen3-Coder-30B-A3B-Instruct (128-in/512-out, concurrency 16, two runs per config), statistically indistinguishable from a hand-tuned offline profile. Full numbers in the AsymGEMM PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
