### PR TITLE
fix(router): return concurrency tokens on cancellation

### DIFF
--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -46,37 +46,54 @@ use crate::{
     },
 };
 
-/// A body wrapper that holds a token and returns it when the body is fully consumed or dropped.
-/// This ensures that for streaming responses, the token is only returned after the entire
-/// stream has been sent to the client.
-pub struct TokenGuardBody {
-    inner: Body,
-    /// The token bucket to return tokens to. Uses Option so we can take() on drop.
-    token_bucket: Option<Arc<TokenBucket>>,
-    /// Number of tokens to return.
+/// An owned concurrency permit that returns its tokens when dropped.
+///
+/// The permit is created immediately after token acquisition so cancellation is safe even
+/// before a response body is constructed. It can also be transferred through the request queue;
+/// if the receiver has gone away, dropping the failed send returns the tokens automatically.
+struct TokenPermit {
+    token_bucket: Arc<TokenBucket>,
     tokens: f64,
 }
 
-impl TokenGuardBody {
-    /// Create a new TokenGuardBody that will return tokens when dropped.
-    pub fn new(inner: Body, token_bucket: Arc<TokenBucket>, tokens: f64) -> Self {
+impl TokenPermit {
+    fn new(token_bucket: Arc<TokenBucket>, tokens: f64) -> Self {
         Self {
-            inner,
-            token_bucket: Some(token_bucket),
+            token_bucket,
             tokens,
         }
     }
 }
 
-impl Drop for TokenGuardBody {
+impl Drop for TokenPermit {
     fn drop(&mut self) {
-        if let Some(bucket) = self.token_bucket.take() {
-            debug!(
-                "TokenGuardBody: stream ended, returning {} tokens to bucket",
-                self.tokens
-            );
-            // Use lock-free sync return - no runtime needed, guaranteed token return
-            bucket.return_tokens_sync(self.tokens);
+        debug!(
+            "TokenPermit: request ended, returning {} tokens to bucket",
+            self.tokens
+        );
+        // Use lock-free sync return - no runtime needed, guaranteed token return
+        self.token_bucket.return_tokens_sync(self.tokens);
+    }
+}
+
+/// A body wrapper that holds a permit until the body is fully consumed or dropped.
+/// This ensures that for streaming responses, the token is only returned after the entire
+/// stream has been sent to the client.
+pub struct TokenGuardBody {
+    inner: Body,
+    _permit: TokenPermit,
+}
+
+impl TokenGuardBody {
+    /// Create a new TokenGuardBody that will return tokens when dropped.
+    pub fn new(inner: Body, token_bucket: Arc<TokenBucket>, tokens: f64) -> Self {
+        Self::from_permit(inner, TokenPermit::new(token_bucket, tokens))
+    }
+
+    fn from_permit(inner: Body, permit: TokenPermit) -> Self {
+        Self {
+            inner,
+            _permit: permit,
         }
     }
 }
@@ -383,7 +400,7 @@ pub struct QueuedRequest {
     /// Time when the request was queued
     queued_at: Instant,
     /// Channel to send the permit back when acquired
-    permit_tx: oneshot::Sender<Result<(), StatusCode>>,
+    permit_tx: oneshot::Sender<Result<TokenPermit, StatusCode>>,
 }
 
 /// Queue metrics for monitoring
@@ -434,7 +451,8 @@ impl QueueProcessor {
             if self.token_bucket.try_acquire(1.0).await.is_ok() {
                 // Got token immediately
                 debug!("Queue: acquired token immediately for queued request");
-                let _ = queued.permit_tx.send(Ok(()));
+                let permit = TokenPermit::new(self.token_bucket.clone(), 1.0);
+                let _ = queued.permit_tx.send(Ok(permit));
             } else {
                 // Need to wait for token
                 let token_bucket = self.token_bucket.clone();
@@ -447,7 +465,8 @@ impl QueueProcessor {
                         .is_ok()
                     {
                         debug!("Queue: acquired token after waiting");
-                        let _ = queued.permit_tx.send(Ok(()));
+                        let permit = TokenPermit::new(token_bucket, 1.0);
+                        let _ = queued.permit_tx.send(Ok(permit));
                     } else {
                         warn!("Queue: request timed out waiting for token");
                         let _ = queued.permit_tx.send(Err(StatusCode::REQUEST_TIMEOUT));
@@ -534,13 +553,14 @@ pub async fn concurrency_limit_middleware(
     if token_bucket.try_acquire(1.0).await.is_ok() {
         debug!("Acquired token immediately");
         Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_ALLOWED);
+        let permit = TokenPermit::new(token_bucket, 1.0);
         let response = next.run(request).await;
 
         // Wrap the response body with TokenGuardBody to return token when stream ends
         // This ensures that for streaming responses, the token is only returned
         // after the entire stream has been sent to the client.
         let (parts, body) = response.into_parts();
-        let guarded_body = TokenGuardBody::new(body, token_bucket, 1.0);
+        let guarded_body = TokenGuardBody::from_permit(body, permit);
         Response::from_parts(parts, Body::new(guarded_body))
     } else {
         // No tokens available, try to queue if enabled
@@ -565,7 +585,7 @@ pub async fn concurrency_limit_middleware(
 
                     // Wait for token from queue processor
                     match permit_rx.await {
-                        Ok(Ok(())) => {
+                        Ok(Ok(permit)) => {
                             debug!("Acquired token from queue");
                             Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_ALLOWED);
                             // Dequeue for embeddings
@@ -577,7 +597,7 @@ pub async fn concurrency_limit_middleware(
 
                             // Wrap the response body with TokenGuardBody to return token when stream ends
                             let (parts, body) = response.into_parts();
-                            let guarded_body = TokenGuardBody::new(body, token_bucket, 1.0);
+                            let guarded_body = TokenGuardBody::from_permit(body, permit);
                             Response::from_parts(parts, Body::new(guarded_body))
                         }
                         Ok(Err(status)) => {
@@ -982,6 +1002,30 @@ pub async fn wasm_middleware(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_queue_processor_returns_permit_when_receiver_is_dropped() {
+        let token_bucket = Arc::new(TokenBucket::new(1, 0));
+        let (limiter, processor) =
+            ConcurrencyLimiter::new(Some(token_bucket.clone()), 1, Duration::from_secs(1));
+        let queue_tx = limiter.queue_tx.as_ref().unwrap().clone();
+        let (permit_tx, permit_rx) = oneshot::channel();
+
+        drop(permit_rx);
+        queue_tx
+            .send(QueuedRequest {
+                queued_at: Instant::now(),
+                permit_tx,
+            })
+            .await
+            .unwrap();
+        drop(queue_tx);
+        drop(limiter);
+
+        processor.unwrap().run().await;
+
+        assert_eq!(token_bucket.available_tokens().await, 1.0);
+    }
 
     #[test]
     fn test_normalize_path_no_ids() {

--- a/sgl-model-gateway/tests/reliability/rate_limiting_test.rs
+++ b/sgl-model-gateway/tests/reliability/rate_limiting_test.rs
@@ -260,4 +260,67 @@ mod rate_limiting_tests {
 
         ctx.shutdown().await;
     }
+
+    /// Test that cancelling a request before response headers does not leak a pure-concurrency
+    /// token. This covers the window between token acquisition and response body construction.
+    #[tokio::test]
+    async fn test_cancelled_request_returns_pure_concurrency_token() {
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .round_robin_policy()
+            .host("127.0.0.1")
+            .port(3404)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(1)
+            .rate_limit_tokens_per_second(0)
+            .queue_size(0)
+            .queue_timeout_secs(1)
+            .build_unchecked();
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![TestWorkerConfig::slow(19304, 500)]).await;
+        let app = ctx.create_app().await;
+        let token_bucket = ctx.app_context.rate_limiter.as_ref().unwrap().clone();
+        let payload = json!({"text": "cancel me", "stream": false});
+        let req = Request::builder()
+            .method("POST")
+            .uri("/generate")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let request_task = tokio::spawn(app.oneshot(req));
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if token_bucket.available_tokens().await == 0.0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("request did not acquire the concurrency token");
+
+        request_task.abort();
+        assert!(
+            request_task.await.unwrap_err().is_cancelled(),
+            "request task completed instead of being cancelled"
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if token_bucket.available_tokens().await == 1.0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled request leaked its concurrency token");
+
+        ctx.shutdown().await;
+    }
 }


### PR DESCRIPTION
## Summary

- create an RAII concurrency permit immediately after a token is acquired
- transfer permit ownership through the request queue so a disconnected waiter returns its token
- keep the permit alive in the response body for streaming requests, preserving existing behavior

## Root cause

With a zero refill rate, tokens are only restored explicitly. The middleware previously acquired a token before awaiting the downstream handler, but did not install the response-body guard until that await completed. Cancelling the request in that window leaked the token permanently. Queue workers could also acquire a token after the request receiver was dropped and lose it when the permit notification failed.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p sgl-model-gateway test_queue_processor_returns_permit_when_receiver_is_dropped --no-fail-fast`
- `cargo test --test reliability_tests rate_limiting_tests --no-fail-fast`

Follow-up to #695.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->