### PR TITLE
[HiCache][DSV4] Let the read result override a phantom EIC hit

### DIFF
--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -4,6 +4,7 @@ import os
 import queue
 import threading
 import time
+from collections import OrderedDict
 from enum import IntEnum
 from typing import List, Optional, Tuple
 
@@ -32,6 +33,7 @@ REMOTE_EIC_YAML_ENV_VAR = "REMOTE_EIC_YAML"
 # GDR Bounce Buffer
 G_GDRBounceBufferSize = 1 * 1024 * 1024 * 1024
 G_GDRBounceTensorCount = 128  # calculated by G_GDRBounceBufferSize / kvcache_size
+MISSING_KEY_CAP = 1 << 15
 
 # gpu direct rdma for kv set
 G_EnableKVSetGPUDirect = False
@@ -214,8 +216,13 @@ class EICKVClient:
         eic_instance_id = config.get("eic_instance_id", "")
         logger.info(f"eic instance_id: {eic_instance_id}")
 
-        eic_thread_num = config.get("eic_thread_num", 1)
-        logger.info(f"eic thread_num: {eic_thread_num}")
+        if "eic_thread_num" in config:
+            # The sdk takes the io thread count from InitAdvancedOption, which
+            # Client.init does not accept, so this key never reaches the client.
+            logger.warning(
+                "eic_thread_num is ignored; set --eic_client_default_io_thread_num "
+                "in eic_flag_file instead (it defaults to 3)"
+            )
 
         eic_log_dir = config.get("eic_log_dir", "/tmp/eic-client-log")
         logger.info(f"eic log_dir: {eic_log_dir}")
@@ -326,6 +333,7 @@ class EICKVClient:
             exit(1)
 
         self.device = device
+        self.missing_keys = OrderedDict()
         self.trans_type = eic.TransportType(eic_trans_type)
         self.kv_cache_shape = kv_cache_shape
         self.kv_cache_dtype = kv_cache_dtype
@@ -488,9 +496,25 @@ class EICKVClient:
             logger.error(f"eic exists {len(keys)} failed, status_code {status_code}")
             return [False] * len(keys)
         res = []
-        for err_code in exist_outcome.status_codes:
-            res.append(err_code == eic.StatusCode.SUCCESS)
+        for key, err_code in zip(keys, exist_outcome.status_codes):
+            hit = err_code == eic.StatusCode.SUCCESS
+            res.append(hit and key not in self.missing_keys)
         return res
+
+    def mark_missing(self, keys: List[str]) -> None:
+        # A value is stored as independently evicted slices and mexist only probes
+        # the first one, so a key whose head slice survived keeps reporting a hit
+        # while the value can no longer be assembled. Remember what the read
+        # actually found so the next exists stops handing out that phantom.
+        for key in keys:
+            self.missing_keys.pop(key, None)
+            self.missing_keys[key] = None
+        while len(self.missing_keys) > MISSING_KEY_CAP:
+            self.missing_keys.popitem(last=False)
+
+    def clear_missing(self, keys: List[str]) -> None:
+        for key in keys:
+            self.missing_keys.pop(key, None)
 
     def allocate_eic_read_buffer(self, count):
         registered = True
@@ -552,6 +576,7 @@ class EICKVClient:
             device_copy = True
 
         fail_count = 0
+        stale_keys = []
         if status_code != eic.StatusCode.SUCCESS:
             if status_code == eic.StatusCode.PARTIAL_FAILED:
                 for i, err_code in enumerate(get_outcome.status_codes):
@@ -564,6 +589,8 @@ class EICKVClient:
                         )
                         success_mask[i] = False
                         fail_count += 1
+                        if err_code == eic.StatusCode.KEY_NOT_EXIST:
+                            stale_keys.append(keys[i])
             else:
                 logger.error(
                     f"eic mget {len(keys)} keys failed, status_code {status_code}"
@@ -577,6 +604,8 @@ class EICKVClient:
             logger.warning(
                 f"eic mget {len(keys)} keys failed, fail count {fail_count}, success count {count - fail_count}"
             )
+        if stale_keys:
+            self.mark_missing(stale_keys)
         if device_copy:
             suc_count = 0
             for mask in success_mask:
@@ -703,6 +732,7 @@ class EICKVClient:
             )
             return False
 
+        self.clear_missing(keys)
         logger.debug(f"set data key {len(keys)} success")
         return True
 
@@ -750,6 +780,7 @@ class EICKVClient:
                 failed[0],
             )
             return False
+        self.clear_missing(keys)
         return status_code == eic.StatusCode.SUCCESS
 
 

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+from collections import OrderedDict
 from queue import Queue
 from types import SimpleNamespace
 from unittest import mock
@@ -762,6 +763,117 @@ class TestEICHiCacheRegression(unittest.TestCase):
     def test_reconciler_epoch_never_reused(self):
         r = self._make_reconciler(0, self.FakeStore())
         self.assertEqual([r.bump_epoch("r"), r.bump_epoch("r")], [1, 2])
+
+
+class EICMissingKeyTest(unittest.TestCase):
+    """A value whose head slice outlived its data slices keeps passing mexist, so
+    every later round re-admits it, re-loads it and fails again. The read result
+    must override that phantom until a write puts the value back."""
+
+    class _Buffers(list):
+        def append(self, *args):
+            list.append(self, args)
+
+    def _fake_eic(self):
+        return SimpleNamespace(
+            StatusCode=SimpleNamespace(
+                SUCCESS=0, FAILED=1, PARTIAL_FAILED=2, TIMEOUT=3, KEY_NOT_EXIST=5
+            ),
+            StringVector=list,
+            IOBuffers=self._Buffers,
+            GetOption=SimpleNamespace,
+            ExistOption=SimpleNamespace,
+        )
+
+    def _client(self, fake_eic):
+        from sglang.srt.mem_cache import eic_memory_pool
+
+        client = object.__new__(eic_memory_pool.EICKVClient)
+        client.eic_namespace = "poc"
+        client.missing_keys = OrderedDict()
+        client.connection = mock.Mock()
+        client.allocate_eic_read_buffer = lambda count: (
+            [
+                SimpleNamespace(
+                    data_ptr=lambda: 0, element_size=lambda: 1, numel=lambda: 1
+                )
+                for _ in range(count)
+            ],
+            None,
+            None,
+            False,
+        )
+        return client
+
+    def _get(self, client, fake_eic, keys, per_key_codes):
+        client.connection.mget.return_value = (
+            fake_eic.StatusCode.PARTIAL_FAILED,
+            None,
+            SimpleNamespace(status_codes=list(per_key_codes)),
+        )
+        return client.batch_get(keys)[1]
+
+    def _exists(self, client, fake_eic, keys):
+        client.connection.mexist.return_value = (
+            fake_eic.StatusCode.SUCCESS,
+            SimpleNamespace(status_codes=[fake_eic.StatusCode.SUCCESS] * len(keys)),
+        )
+        return client.exists_batch(keys)
+
+    def test_read_result_overrides_a_phantom_exists(self):
+        from sglang.srt.mem_cache import eic_memory_pool
+
+        fake_eic = self._fake_eic()
+        keys = ["k0", "k1", "k2"]
+        with mock.patch.object(eic_memory_pool, "eic", fake_eic):
+            client = self._client(fake_eic)
+            self.assertEqual(self._exists(client, fake_eic, keys), [True] * 3)
+
+            mask = self._get(client, fake_eic, keys, [0, 5, 0])
+            self.assertEqual(mask, [True, False, True])
+            self.assertEqual(list(client.missing_keys), ["k1"])
+
+            # The backend still claims a hit; only the read result knows better.
+            self.assertEqual(
+                self._exists(client, fake_eic, keys), [True, False, True]
+            )
+
+    def test_transient_failures_do_not_suppress(self):
+        from sglang.srt.mem_cache import eic_memory_pool
+
+        fake_eic = self._fake_eic()
+        keys = ["k0", "k1", "k2"]
+        with mock.patch.object(eic_memory_pool, "eic", fake_eic):
+            client = self._client(fake_eic)
+            mask = self._get(client, fake_eic, keys, [0, 3, 1])
+            self.assertEqual(mask, [True, False, False])
+            self.assertEqual(list(client.missing_keys), [])
+            self.assertEqual(self._exists(client, fake_eic, keys), [True] * 3)
+
+    def test_a_later_write_restores_the_key(self):
+        # The failure triggers a recompute whose write_through stores the value
+        # again; suppressing it past that point would recompute it forever.
+        from sglang.srt.mem_cache import eic_memory_pool
+
+        fake_eic = self._fake_eic()
+        with mock.patch.object(eic_memory_pool, "eic", fake_eic):
+            client = self._client(fake_eic)
+            client.mark_missing(["k1"])
+            client.clear_missing(["k1"])
+            self.assertEqual(
+                self._exists(client, fake_eic, ["k0", "k1"]), [True, True]
+            )
+
+    def test_missing_set_is_bounded(self):
+        from sglang.srt.mem_cache import eic_memory_pool
+
+        with mock.patch.object(eic_memory_pool, "eic", self._fake_eic()):
+            client = self._client(self._fake_eic())
+            cap = eic_memory_pool.MISSING_KEY_CAP
+            client.mark_missing([f"k{i}" for i in range(cap + 100)])
+            self.assertEqual(len(client.missing_keys), cap)
+            self.assertNotIn("k0", client.missing_keys)
+            self.assertIn(f"k{cap + 99}", client.missing_keys)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

EIC stores a value as slices named `<key>-<slice_size>-<idx>`. The agent uses that
slice key directly as the cache entry key, so every slice is an independent entry
with its own LRU position, and eviction picks one entry at a time without ever
looking at its siblings. A partially resident value is the normal steady state,
not an anomaly.

`mexist` probes only the head slice. A key whose head slice happens to survive
keeps reporting a hit while the value can no longer be assembled. Today that
costs a full round every time the key is touched:

1. `batch_find_longest_prefix_in_eic` admits the prefix and the tree gains a
   remote node,
2. device slots are reserved and the page load is issued,
3. the load comes back short and `loading_check` truncates the tree,
4. nothing records the outcome, so the next round starts again at step 1.

Production evidence from the prefill logs: every `KvCheck` slice task carries
index 0 (1484 of 1484), while `KvGet` on the same values spans all 64 indices.

## Fix

`batch_get` already receives a per-key status code from `mget`. Remember the keys
reported as `KEY_NOT_EXIST` in a bounded per-process set and have `exists_batch`
treat them as misses. The phantom is then handed out once instead of every round.

A successful write of the same key clears the entry. That is exactly the moment
the value is whole again: the failed load triggers a recompute whose
`write_through` stores it, and suppressing it past that point would recompute the
same prefix forever.

### Why not delete the key

Deleting remotely is the obvious alternative and it is wrong. The same
recompute-then-rewrite path means a concurrent writer can restore the value
between our failed read and our delete, so the delete lands on good data and
turns a one-round loss into a permanent hole for that prefix. Worse, it is
self-inflicted: the failure itself is what schedules the rewrite it races
against.

Transient codes (`TIMEOUT`, `EIC_IO_BUSY`, `NETWORK_ERROR`, whole-batch failure)
are left alone for the same reason — a congestion blip must not suppress good
entries.

### Consistency

Both `exists_batch` consumers are already reduced across ranks:
`batch_find_longest_prefix_in_eic` feeds the MIN over CP/TP+PP in
`match_from_remote`, and `load_back_check` all-reduces its verdict. A rank whose
set holds a key others have not seen yet can only shorten the admitted prefix,
never fork it.

## Second, unrelated one-liner

`eic_thread_num` in `remote-eic.yaml` was read and logged but never used. The sdk
takes the io thread count from `InitAdvancedOption`, which `Client.init` does not
accept, so the client silently runs `--eic_client_default_io_thread_num`, whose
default is 3. Deployments that set `eic_thread_num: 16` have been running 3 io
threads. The log now says so and points at the flag.

## Validation

`test/registered/unit/mem_cache/test_eic_hicache_regression.py` in the
`eic-fix-test` container: 31 passed. Four new cases:

- `test_read_result_overrides_a_phantom_exists` — the backend still claims a hit
  after the failed read; `exists_batch` no longer does.
- `test_transient_failures_do_not_suppress` — a timeout or generic failure
  produces a miss but leaves the set empty.
- `test_a_later_write_restores_the_key` — a write clears the suppression.
- `test_missing_set_is_bounded` — the set stays at `MISSING_KEY_CAP`, oldest out.

## Scope

This bounds the cost of an incomplete value; it does not stop them from forming.
Value-level atomicity has to come from the EIC client and agent: a whole-value
existence check, uniform slice length so the tail slice stops landing in a
different size class, and shared LRU lifetime across a key's slices. Those are
tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
