### PR TITLE
[DSV4][HiCache] Support built-in EAGLE and external EAGLE3 L2 replay on 0731

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -34,16 +34,20 @@ def apply_deepseek_v4_defaults(server_args: "ServerArgs", model_arch: str) -> No
     ], f"{server_args.kv_cache_dtype} is not supported for {model_arch}"
 
     if server_args.speculative_algorithm is not None:
-        assert (
-            server_args.speculative_algorithm == "EAGLE"
-        ), f"Only EAGLE speculative algorithm is supported for {model_arch}"
+        assert server_args.speculative_algorithm in (
+            "EAGLE",
+            "EAGLE3",
+        ), f"Only EAGLE/EAGLE3 speculative algorithms are supported for {model_arch}"
         assert (
             server_args.speculative_eagle_topk == 1
-        ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
+        ), (
+            "Only EAGLE/EAGLE3 speculative algorithm with topk == 1 is "
+            f"supported for {model_arch}"
+        )
 
         if not envs.SGLANG_ENABLE_SPEC_V2.get():
             envs.SGLANG_ENABLE_SPEC_V2.set(True)
-            logger.warning("Spec v2 is enabled for EAGLE speculative decoding.")
+            logger.warning("Spec v2 is enabled for EAGLE/EAGLE3 decoding.")
 
     if server_args.swa_full_tokens_ratio == ServerArgs.swa_full_tokens_ratio:
         server_args.swa_full_tokens_ratio = 0.1

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -429,6 +429,13 @@ class Scheduler(
         if (t := envs.SGLANG_TEST_STUCK_SCHEDULER_INIT.get()) > 0:
             time.sleep(t)
 
+        hicache_draft_plan = kv_cache_builder.prepare_hicache_draft_plan(
+            target_worker=self.tp_worker,
+            draft_worker=self.draft_worker,
+            spec_algorithm=self.spec_algorithm,
+            server_args=self.server_args,
+        )
+
         # Init cache and memory pool
         result = kv_cache_builder.build_kv_cache(
             server_args=self.server_args,
@@ -450,6 +457,7 @@ class Scheduler(
             pp_group=self.pp_group,
             enable_hierarchical_cache=self.enable_hierarchical_cache,
             enable_eic_cache=self.enable_eic_cache,
+            hicache_draft_plan=hicache_draft_plan,
         )
         self.is_hybrid_swa = result.is_hybrid_swa
         self.is_hybrid_ssm = result.is_hybrid_ssm
@@ -484,16 +492,13 @@ class Scheduler(
         else:
             self.decode_offload_manager = None
 
-        # Register draft KV pool (when spec + HiCache co-enabled).
-        kv_cache_builder.maybe_register_hicache_draft(
-            tree_cache=self.tree_cache,
-            draft_worker=self.draft_worker,
-            spec_algorithm=self.spec_algorithm,
-            server_args=self.server_args,
-            enable_hierarchical_cache=self.enable_hierarchical_cache,
-            enable_overlap=self.enable_overlap,
-            page_size=self.page_size,
-        )
+        if self.enable_hierarchical_cache and hicache_draft_plan is not None:
+            kv_cache_builder.maybe_register_hicache_draft(
+                tree_cache=self.tree_cache,
+                draft_plan=hicache_draft_plan,
+                server_args=self.server_args,
+                page_size=self.page_size,
+            )
 
         # Init running status
         self.init_running_status()

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -45,3 +45,5 @@ class CacheInitParams:
     cache_ttl_seconds: Optional[float] = None
 
     tree_components: Optional[tuple[ComponentType, ...]] = None
+
+    mtp_draft_device_pools: tuple[object, ...] = ()

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -65,6 +65,11 @@ class PoolName(str, Enum):
     DEEPSEEK_V4_C4_INDEXER_STATE = "deepseek_v4_c4_indexer_state"
     DEEPSEEK_V4_C128_STATE = "deepseek_v4_c128_state"
 
+    # Draft KV pools attached to the target HiCache operation.
+    DRAFT = "draft"
+    DRAFT_INDEXER = "draft_indexer"
+    DRAFT_SWA = "draft_swa"
+
     def __str__(self) -> str:
         return self.value
 

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -199,6 +199,9 @@ class HybridCacheController(BaseHiCacheController):
             self.layer_num = transfer_layer_num
             self.layer_done_counter = LayerDoneCounter(self.layer_num)
 
+        self.has_mtp_draft = False
+        self.mtp_draft_device_pools = ()
+
         if startup_storage_backend is not None:
             self.attach_storage_backend(
                 storage_backend=startup_storage_backend,
@@ -207,6 +210,10 @@ class HybridCacheController(BaseHiCacheController):
                 storage_backend_extra_config=storage_backend_extra_config,
                 host_pools=getattr(mem_pool_host, "entries", None),
             )
+
+    def set_mtp_draft_pools(self, device_pools) -> None:
+        self.mtp_draft_device_pools = tuple(device_pools)
+        self.has_mtp_draft = bool(self.mtp_draft_device_pools)
 
     def _start_storage_threads(self):
         super()._start_storage_threads()
@@ -494,6 +501,16 @@ class HybridCacheController(BaseHiCacheController):
                     self.io_backend,
                     pool_transfers=resolved_pool_transfers,
                 )
+                if self.has_mtp_draft and i < len(self.mtp_draft_device_pools):
+                    self.mem_pool_host.load_to_device_per_layer(
+                        self.mtp_draft_device_pools[i],
+                        host_indices,
+                        device_indices,
+                        self.layer_num + i,
+                        self.io_backend,
+                        pool_transfers=resolved_pool_transfers,
+                        is_draft=True,
+                    )
                 producer_event.complete(i)
             self._record_transfer_indices_on_stream(
                 self.load_stream,

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -30,7 +30,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     PoolTransfer,
     PoolTransferResult,
 )
-from sglang.srt.mem_cache.memory_pool_host import PoolEntry
+from sglang.srt.mem_cache.memory_pool_host import HostPoolGroup, PoolEntry
 from sglang.srt.utils import get_device_module
 
 if TYPE_CHECKING:
@@ -228,6 +228,15 @@ class HybridCacheController(BaseHiCacheController):
         )
 
         for entry in host_pools or []:
+            self.storage_backend.register_mem_host_pool_v2(entry.host_pool, entry.name)
+
+    def register_host_pool_entry(self, entry: PoolEntry) -> None:
+        if not isinstance(self.mem_pool_host, HostPoolGroup):
+            raise TypeError("Dynamic HiCache sidecars require HostPoolGroup.")
+        self.mem_pool_host.add_entry(entry)
+        if not entry.is_primary_index_anchor:
+            self.extra_host_mem_release_queues.setdefault(entry.name, Queue())
+        if self.enable_storage and self.storage_backend is not None:
             self.storage_backend.register_mem_host_pool_v2(entry.host_pool, entry.name)
 
     @staticmethod

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -47,6 +47,19 @@ def _make_layer_mapper(
     return mapper
 
 
+def _with_mtp_layer_mapping(
+    layer_mapping: dict[int, int],
+    *,
+    transfer_layer_start: int,
+    target_device_layer_num: int,
+    draft_layer_num: int,
+) -> dict[int, int]:
+    return layer_mapping | {
+        transfer_layer_start + depth: target_device_layer_num + depth
+        for depth in range(draft_layer_num)
+    }
+
+
 def build_kv_host_pool(
     *,
     kv_pool: Any,
@@ -296,6 +309,17 @@ def build_deepseek_v4_hicache_stack(
             f"{transfer_layer_num} local layers"
         )
     swa_layer_mapping = {layer_id: layer_id for layer_id in range(transfer_layer_num)}
+    mtp_swa_device_buffers = [
+        buffer
+        for pool in params.mtp_draft_device_pools
+        for buffer in pool.swa_kv_pool.kv_buffer
+    ]
+    swa_layer_mapping = _with_mtp_layer_mapping(
+        swa_layer_mapping,
+        transfer_layer_start=transfer_layer_num,
+        target_device_layer_num=transfer_layer_num,
+        draft_layer_num=len(mtp_swa_device_buffers),
+    )
 
     c4_layer_mapping = {}
     c128_layer_mapping = {}
@@ -326,7 +350,10 @@ def build_deepseek_v4_hicache_stack(
     logical_host_pool = LogicalHostPool(num_host_pages * page_size, page_size)
     swa_host_pool = DeepSeekV4PagedHostPool(
         pool_name=str(PoolName.SWA),
-        device_buffers=kvcache.swa_kv_pool.kv_buffer,
+        device_buffers=[
+            *kvcache.swa_kv_pool.kv_buffer,
+            *mtp_swa_device_buffers,
+        ],
         item_bytes=kvcache.swa_kv_pool.bytes_per_page_padded,
         num_host_pages=swa_num_host_pages,
         slot_page_size=kvcache.swa_page_size,
@@ -348,7 +375,7 @@ def build_deepseek_v4_hicache_stack(
             host_pool=swa_host_pool,
             device_pool=kvcache.swa_kv_pool,
             layer_mapping=swa_layer_mapping,
-            transfer_layer_num=transfer_layer_num,
+            transfer_layer_num=transfer_layer_num + len(mtp_swa_device_buffers),
             host_evict_fn=host_swa_evict_fn,
             device_evict_fn=device_swa_evict_fn,
             device_alloc_fn=swa_attn_allocator.alloc,
@@ -477,6 +504,8 @@ def build_deepseek_v4_hicache_stack(
         transfer_layer_num=transfer_layer_num,
         enable_storage_metrics=enable_storage_metrics,
     )
+    if mtp_swa_device_buffers:
+        cache_controller.set_mtp_draft_pools(mtp_swa_device_buffers)
     return host_pool_group, cache_controller
 
 

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
-from sglang.srt.mem_cache.hicache_storage import PoolName, SidecarPoolSpec
+from sglang.srt.mem_cache.hicache_storage import (
+    PoolHitPolicy,
+    PoolName,
+    SidecarPoolSpec,
+)
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
@@ -626,6 +630,156 @@ def build_anchor_sidecar_stack(
         enable_storage_metrics=enable_storage_metrics,
     )
     return host_pool_group, cache_controller
+
+
+def _build_draft_host_pool(
+    *,
+    pool: Any,
+    host_to_device_ratio: float,
+    page_size: int,
+    layout: str,
+    allocator_type: Optional[str],
+):
+    from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+    kwargs = dict(
+        host_to_device_ratio=host_to_device_ratio,
+        host_size=0,
+        page_size=page_size,
+        layout=layout,
+        allocator_type=allocator_type,
+    )
+    if isinstance(pool, MHATokenToKVPool):
+        return MHATokenToKVPoolHost(pool, **kwargs)
+    return MLATokenToKVPoolHost(
+        pool,
+        override_kv_cache_dim=pool.kv_cache_dim,
+        **kwargs,
+    )
+
+
+def build_full_draft_pools(
+    *,
+    draft_kv_pool: Any,
+    tree_cache: Any,
+    server_args: ServerArgs,
+) -> tuple[list[SidecarPoolSpec], list[PoolEntry]]:
+    """Build a draft KV sidecar whose indices follow target full KV."""
+    pool = draft_kv_pool
+    if pool.layer_num == 0:
+        return [], []
+
+    controller = tree_cache.cache_controller
+    host_pool_group = controller.mem_pool_host
+    draft_host_pool = _build_draft_host_pool(
+        pool=pool,
+        host_to_device_ratio=host_pool_group.size / pool.size,
+        page_size=controller.page_size,
+        layout=server_args.hicache_mem_layout,
+        allocator_type=server_args.hicache_storage_backend,
+    )
+    layer_mapping = {i: i for i in range(pool.layer_num)}
+    return (
+        [
+            SidecarPoolSpec(
+                pool_name=PoolName.DRAFT,
+                indices_from_pool=PoolName.KV,
+            )
+        ],
+        [
+            build_pool_entry(
+                name=PoolName.DRAFT,
+                host_pool=draft_host_pool,
+                device_pool=pool,
+                layer_mapping=layer_mapping,
+                transfer_layer_num=draft_host_pool.layer_num,
+            )
+        ],
+    )
+
+
+def build_swa_draft_pools(
+    *,
+    draft_kv_pool: Any,
+    tree_cache: Any,
+    server_args: ServerArgs,
+) -> tuple[list[SidecarPoolSpec], list[PoolEntry]]:
+    """Build a draft SWA sidecar whose indices follow target SWA."""
+    draft_swa_pool = draft_kv_pool.swa_kv_pool
+    if draft_swa_pool is None:
+        raise NotImplementedError(
+            "HiCache draft SWA sidecar requires a non-unified draft SWA pool."
+        )
+    if draft_swa_pool.layer_num == 0:
+        return [], []
+
+    controller = tree_cache.cache_controller
+    target_swa_host_pool = controller.mem_pool_host.entry_map[PoolName.SWA].host_pool
+    if isinstance(target_swa_host_pool, DeepSeekV4PagedHostPool):
+        draft_host_pool = DeepSeekV4PagedHostPool(
+            pool_name=str(PoolName.DRAFT_SWA),
+            device_buffers=draft_swa_pool.kv_buffer,
+            item_bytes=draft_swa_pool.bytes_per_page_padded,
+            num_host_pages=target_swa_host_pool.num_host_pages,
+            slot_page_size=draft_swa_pool.page_size,
+            layout=target_swa_host_pool.layout,
+            allocator_type=server_args.hicache_storage_backend,
+        )
+    else:
+        draft_host_pool = _build_draft_host_pool(
+            pool=draft_swa_pool,
+            host_to_device_ratio=target_swa_host_pool.size / draft_swa_pool.size,
+            page_size=target_swa_host_pool.page_size,
+            layout=target_swa_host_pool.layout,
+            allocator_type=server_args.hicache_storage_backend,
+        )
+
+    layer_mapping = {i: i for i in range(draft_swa_pool.layer_num)}
+    return (
+        [
+            SidecarPoolSpec(
+                pool_name=PoolName.DRAFT_SWA,
+                indices_from_pool=PoolName.SWA,
+                hit_policy=PoolHitPolicy.TRAILING_PAGES,
+            )
+        ],
+        [
+            build_pool_entry(
+                name=PoolName.DRAFT_SWA,
+                host_pool=draft_host_pool,
+                device_pool=draft_swa_pool,
+                layer_mapping=layer_mapping,
+                transfer_layer_num=draft_host_pool.layer_num,
+            )
+        ],
+    )
+
+
+def build_hicache_draft_sidecars(
+    *,
+    draft_device_pools: tuple[Any, ...],
+    tree_cache: Any,
+    server_args: ServerArgs,
+) -> tuple[list[SidecarPoolSpec], list[PoolEntry]]:
+    """Build the upstream sidecar path for an external EAGLE/EAGLE3 draft."""
+    from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
+
+    if len(draft_device_pools) != 1:
+        raise ValueError(
+            "HiCache sidecar mode expects exactly one primary draft KV pool, "
+            f"got {len(draft_device_pools)}."
+        )
+    draft_kv_pool = draft_device_pools[0]
+    builder = (
+        build_swa_draft_pools
+        if isinstance(draft_kv_pool, BaseSWAKVPool)
+        else build_full_draft_pools
+    )
+    return builder(
+        draft_kv_pool=draft_kv_pool,
+        tree_cache=tree_cache,
+        server_args=server_args,
+    )
 
 
 def attach_hybrid_pool_to_unified_cache(

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -46,6 +46,35 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
+def get_draft_kv_pool(
+    *,
+    draft_worker: "BaseTpWorker",
+    spec_algorithm: "SpeculativeAlgorithm",
+    server_args: "ServerArgs",
+    enable_overlap: bool,
+):
+    """Resolve the primary draft pool and model config for PD metadata.
+
+    The DeepSeek-V4 fork still initializes disaggregation metadata through this
+    compatibility interface, while HiCache draft registration uses the newer
+    ``HiCacheDraftPlan`` path below. Keep the two responsibilities separate.
+    """
+    if draft_worker is None or spec_algorithm.is_ngram():
+        return None, None
+
+    if spec_algorithm.supports_spec_v2() and enable_overlap:
+        if server_args.enable_multi_layer_eagle:
+            draft_runner = draft_worker.draft_worker.draft_runner_list[0]
+        else:
+            draft_runner = draft_worker.draft_worker.draft_runner
+        return draft_runner.token_to_kv_pool, draft_runner.model_config
+
+    return (
+        draft_worker.model_runner.token_to_kv_pool,
+        draft_worker.model_config,
+    )
+
+
 def maybe_register_hicache_draft(
     *,
     tree_cache: "BasePrefixCache",

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -93,6 +93,31 @@ def maybe_register_hicache_draft(
     if draft_kv_pool is None:
         return
 
+    from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+
+    # #30393 uses sidecars for standalone EAGLE/EAGLE3 draft models, while
+    # built-in NextN/EAGLE models use its separate packed path.  This fork does
+    # not have the packed-plan infrastructure yet, so keep its existing EAGLE
+    # registration unchanged and enable the sidecar path only for EAGLE3.
+    if isinstance(tree_cache, UnifiedRadixCache) and spec_algorithm.is_eagle3():
+        if server_args.hicache_storage_backend is not None:
+            raise NotImplementedError(
+                "This DeepSeek-V4 backport supports external EAGLE/EAGLE3 "
+                "draft sidecars for HiCache L2 only; L3 draft storage requires "
+                "the remaining upstream #30393 storage-backend changes."
+            )
+        from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
+            build_hicache_draft_sidecars,
+        )
+
+        specs, entries = build_hicache_draft_sidecars(
+            draft_device_pools=(draft_kv_pool,),
+            tree_cache=tree_cache,
+            server_args=server_args,
+        )
+        tree_cache.register_hicache_draft_pools(specs, entries)
+        return
+
     from sglang.srt.mem_cache.memory_pool import (
         HybridLinearKVPool,
         MHATokenToKVPool,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -42,64 +42,26 @@ if TYPE_CHECKING:
     from sglang.srt.managers.tp_worker import BaseTpWorker
     from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
     from sglang.srt.server_args import ServerArgs
+    from sglang.srt.speculative.base_spec_worker import HiCacheDraftPlan
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-
-
-def get_draft_kv_pool(
-    *,
-    draft_worker: "BaseTpWorker",
-    spec_algorithm: SpeculativeAlgorithm,
-    server_args: ServerArgs,
-    enable_overlap: bool,
-):
-    """Return (draft_token_to_kv_pool, draft_model_config) for the current
-    draft worker, or (None, None) when no draft KV pool is available."""
-    if draft_worker is None or spec_algorithm.is_ngram():
-        return None, None
-
-    if spec_algorithm.supports_spec_v2() and enable_overlap:
-        if server_args.enable_multi_layer_eagle:
-            draft_runner = draft_worker.draft_worker.draft_runner_list[0]
-        else:
-            draft_runner = draft_worker.draft_worker.draft_runner
-        return draft_runner.token_to_kv_pool, draft_runner.model_config
-
-    return (
-        draft_worker.model_runner.token_to_kv_pool,
-        draft_worker.model_config,
-    )
 
 
 def maybe_register_hicache_draft(
     *,
     tree_cache: "BasePrefixCache",
-    draft_worker: "BaseTpWorker",
-    spec_algorithm: SpeculativeAlgorithm,
+    draft_plan: "HiCacheDraftPlan",
     server_args: ServerArgs,
-    enable_hierarchical_cache: bool,
-    enable_overlap: bool,
     page_size: int,
 ) -> None:
-    """Register draft KV pool with HiCacheController for piggyback L2/L3 ops."""
-    if not enable_hierarchical_cache:
-        return
+    """Register non-packed draft pools after the target cache is constructed."""
+    from sglang.srt.speculative.base_spec_worker import HiCacheDraftMode
 
-    draft_kv_pool, _ = get_draft_kv_pool(
-        draft_worker=draft_worker,
-        spec_algorithm=spec_algorithm,
-        server_args=server_args,
-        enable_overlap=enable_overlap,
-    )
-    if draft_kv_pool is None:
+    if draft_plan.mode != HiCacheDraftMode.SIDECAR:
         return
 
     from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 
-    # #30393 uses sidecars for standalone EAGLE/EAGLE3 draft models, while
-    # built-in NextN/EAGLE models use its separate packed path.  This fork does
-    # not have the packed-plan infrastructure yet, so keep its existing EAGLE
-    # registration unchanged and enable the sidecar path only for EAGLE3.
-    if isinstance(tree_cache, UnifiedRadixCache) and spec_algorithm.is_eagle3():
+    if isinstance(tree_cache, UnifiedRadixCache):
         if server_args.hicache_storage_backend is not None:
             raise NotImplementedError(
                 "This DeepSeek-V4 backport supports external EAGLE/EAGLE3 "
@@ -111,7 +73,7 @@ def maybe_register_hicache_draft(
         )
 
         specs, entries = build_hicache_draft_sidecars(
-            draft_device_pools=(draft_kv_pool,),
+            draft_device_pools=draft_plan.device_pools,
             tree_cache=tree_cache,
             server_args=server_args,
         )
@@ -128,7 +90,7 @@ def maybe_register_hicache_draft(
         MLATokenToKVPoolHost,
     )
 
-    pool = draft_kv_pool
+    pool = draft_plan.device_pools[0]
     if isinstance(pool, HybridLinearKVPool):
         pool = pool.full_kv_pool
 
@@ -153,6 +115,42 @@ def maybe_register_hicache_draft(
         return
 
     tree_cache.cache_controller.set_draft_kv_pool(pool, draft_host_pool)
+
+
+def prepare_hicache_draft_plan(
+    *,
+    target_worker: "BaseTpWorker",
+    draft_worker: "BaseTpWorker",
+    spec_algorithm: SpeculativeAlgorithm,
+    server_args: ServerArgs,
+) -> "HiCacheDraftPlan":
+    from sglang.srt.speculative.base_spec_worker import (
+        HiCacheDraftPlan,
+        build_hicache_draft_plan,
+    )
+
+    if (
+        draft_worker is None
+        or not spec_algorithm.is_eagle()
+        or spec_algorithm.is_frozen_kv_mtp()
+    ):
+        target_worker.model_runner.mtp_draft_device_pools = ()
+        return HiCacheDraftPlan()
+
+    if hasattr(draft_worker, "init_hicache_draft_plan"):
+        draft_worker.init_hicache_draft_plan()
+        return draft_worker.hicache_draft_plan
+
+    draft_runners = tuple(
+        draft_worker.model_runner_list
+        if server_args.enable_multi_layer_eagle
+        else [draft_worker.model_runner]
+    )
+    return build_hicache_draft_plan(
+        target_model_runner=target_worker.model_runner,
+        draft_runners=draft_runners,
+        server_args=server_args,
+    )
 
 
 def is_supported_dsv4_decode_radix_mtp(
@@ -185,6 +183,7 @@ def build_kv_cache(
     pp_group: "GroupCoordinator",
     enable_hierarchical_cache: bool,
     enable_eic_cache: bool = False,
+    hicache_draft_plan: Optional["HiCacheDraftPlan"] = None,
 ) -> "KVCacheBuildResult":
     sliding_window_size: Optional[int] = None
     full_tokens_per_layer: Optional[int] = None
@@ -296,6 +295,12 @@ def build_kv_cache(
         pp_size=ps.pp_size,
         chunked_prefill_size=effective_chunked_prefill_size,
         sliding_window_size=sliding_window_size,
+        mtp_draft_device_pools=(
+            hicache_draft_plan.device_pools
+            if hicache_draft_plan is not None
+            and hicache_draft_plan.mode.value == "packed"
+            else ()
+        ),
     )
 
     if effective_chunked_prefill_size is not None and disable_radix_cache:

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -2516,6 +2516,12 @@ class HostPoolGroup:
         self.device = self.anchor_entry.host_pool.device
         self.size = self.anchor_entry.host_pool.size
 
+    def add_entry(self, entry: PoolEntry) -> None:
+        if entry.name in self.entry_map:
+            raise ValueError(f"Host pool {entry.name} is already registered.")
+        self.entries.append(entry)
+        self.entry_map[entry.name] = entry
+
     @property
     def kv_buffer(self):
         return self.anchor_entry.host_pool.kv_buffer

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -2018,7 +2018,14 @@ class DeepSeekV4PagedHostPool(HostKVCache):
             )
 
     def load_to_device_per_layer(
-        self, device_pool, host_indices, device_indices, layer_id, io_backend
+        self,
+        device_pool,
+        host_indices,
+        device_indices,
+        layer_id,
+        io_backend,
+        *,
+        is_draft: bool = False,
     ):
         if host_indices is None or device_indices is None:
             return
@@ -2585,17 +2592,21 @@ class HostPoolGroup:
         layer_id,
         io_backend,
         pool_transfers: Optional[list] = None,
+        *,
+        is_draft: bool = False,
     ) -> None:
         # 1. Anchor (KV) transfer
         anchor = self.anchor_entry
         local_layer_id = anchor.layer_mapper(layer_id)
         if local_layer_id is not None and host_indices.numel() > 0:
+            kwargs = {"is_draft": True} if is_draft else {}
             anchor.host_pool.load_to_device_per_layer(
-                anchor.device_pool,
+                device_pool if is_draft else anchor.device_pool,
                 host_indices,
                 device_indices,
                 local_layer_id,
                 io_backend,
+                **kwargs,
             )
 
         # 2. Extra pool transfers
@@ -2606,12 +2617,14 @@ class HostPoolGroup:
             local_layer_id = entry.layer_mapper(layer_id)
             if local_layer_id is None:
                 continue
+            kwargs = {"is_draft": True} if is_draft else {}
             entry.host_pool.load_to_device_per_layer(
-                entry.device_pool,
+                device_pool if is_draft else entry.device_pool,
                 transfer.host_indices,
                 transfer.device_indices,
                 local_layer_id,
                 io_backend,
+                **kwargs,
             )
 
     def backup_from_device_all_layer(

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -60,6 +60,7 @@ from sglang.srt.session.streaming_session import StreamingSession
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+    from sglang.srt.mem_cache.memory_pool_host import PoolEntry
     from sglang.srt.server_args import ServerArgs
 
 
@@ -621,6 +622,15 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def register_sidecar_pool(self, spec: SidecarPoolSpec) -> None:
         self.sidecar_pool_specs.append(spec)
+
+    def register_hicache_draft_pools(
+        self, specs: list[SidecarPoolSpec], entries: list[PoolEntry]
+    ) -> None:
+        if self.cache_controller is None:
+            raise RuntimeError("HiCache controller is not attached.")
+        for spec, entry in zip(specs, entries, strict=True):
+            self.cache_controller.register_host_pool_entry(entry)
+            self.register_sidecar_pool(spec)
 
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         result = self.session.try_match_prefix(params)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -2232,6 +2232,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             logger.warning(
                 f"Overriding draft attention backend to {draft_attn_backend}."
             )
+            draft_attn_backend = self._fallback_dsv4_backend_for_draft(
+                draft_attn_backend
+            )
             return self._get_attention_backend_from_str(
                 draft_attn_backend,
                 init_new_workspace=init_new_workspace,
@@ -2241,6 +2244,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             self.prefill_attention_backend_str,
             self.decode_attention_backend_str,
         ) = self.server_args.get_attention_backends()
+        if self.is_draft_worker:
+            self.prefill_attention_backend_str = (
+                self._fallback_dsv4_backend_for_draft(
+                    self.prefill_attention_backend_str
+                )
+            )
+            self.decode_attention_backend_str = self._fallback_dsv4_backend_for_draft(
+                self.decode_attention_backend_str
+            )
 
         if self.decode_attention_backend_str != self.prefill_attention_backend_str:
             from sglang.srt.layers.attention.hybrid_attn_backend import (
@@ -2278,6 +2290,27 @@ class ModelRunner(ModelRunnerKVCacheMixin):
             get_global_server_args().decode_attention_backend,
         ) = (self.prefill_attention_backend_str, self.decode_attention_backend_str)
         return attn_backend
+
+    def _fallback_dsv4_backend_for_draft(self, backend: str) -> str:
+        """Keep DSV4's fixed-shape backend away from other draft models."""
+        if backend != "dsv4":
+            return backend
+
+        from sglang.srt.configs.model_config import is_deepseek_v4
+
+        if is_deepseek_v4(self.model_config.hf_config):
+            return backend
+
+        fallback = self.server_args._get_default_attn_backend(
+            use_mla_backend=self.use_mla_backend,
+            model_config=self.model_config,
+        )
+        logger.warning(
+            "Draft model is not DeepSeekV4, falling back attention backend "
+            "from 'dsv4' to '%s'.",
+            fallback,
+        )
+        return fallback
 
     def _get_attention_backend_from_str(
         self, backend_str: str, init_new_workspace: bool = False

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -385,6 +385,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
         self.page_size = server_args.page_size
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        self.mtp_draft_device_pools = ()
         self.is_hybrid_swa = model_config.is_hybrid_swa
         self.is_hybrid_swa_compress = getattr(
             model_config, "is_hybrid_swa_compress", False

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1000,6 +1000,7 @@ class DeepseekV4Model(nn.Module):
         self.nsa_enable_prefill_cp = is_nsa_enable_prefill_cp()
         if self.nsa_enable_prefill_cp:
             self.cp_size = get_attention_cp_size()
+        self.layers_to_capture: List[int] = []
 
     def hc_head(
         self,
@@ -1061,6 +1062,12 @@ class DeepseekV4Model(nn.Module):
             input_ids_global = input_ids
 
         if nsa_use_prefill_cp(forward_batch):
+            if self.layers_to_capture:
+                raise NotImplementedError(
+                    "EAGLE3 auxiliary hidden-state capture is not supported "
+                    "together with DeepSeek-V4 prefill context parallelism "
+                    "(attn_cp_size > 1)."
+                )
             if self.pp_group.is_first_rank:
                 hidden_states = cp_split_and_rebuild_data(forward_batch, hidden_states)
             positions = cp_split_and_rebuild_position(forward_batch, positions)
@@ -1073,7 +1080,17 @@ class DeepseekV4Model(nn.Module):
         # forks alt-streams; later per-layer calls become no-ops.
         forward_batch.attn_backend._maybe_upgrade_forward_metadata()
 
+        eagle3_aux_hidden_states: List[torch.Tensor] = []
         for i in range(self.start_layer, self.end_layer):
+            if i in self.layers_to_capture:
+                eagle3_aux_hidden_states.append(
+                    self.hc_head(
+                        hidden_states,
+                        self.hc_head_fn,
+                        self.hc_head_scale,
+                        self.hc_head_base,
+                    )
+                )
             layer = self.layers[i]
             hidden_states = layer(
                 positions=positions,
@@ -1103,6 +1120,8 @@ class DeepseekV4Model(nn.Module):
         )
         hidden_states = self.norm(hidden_states)
 
+        if self.layers_to_capture:
+            return (hidden_states, pre_hc_head), eagle3_aux_hidden_states
         return hidden_states, pre_hc_head
 
 
@@ -1173,6 +1192,17 @@ class DeepseekV4ForCausalLM(nn.Module):
             "DeepSeek V4 requires different clamping for shared and routed experts. "
             "Shared experts fusion optimization is disabled.",
         )
+
+    def set_eagle3_layers_to_capture(self, layer_ids: Optional[List[int]] = None):
+        if not self.pp_group.is_last_rank:
+            return
+        self.capture_aux_hidden_states = True
+        if layer_ids is None:
+            num_layers = self.config.num_hidden_layers
+            self.model.layers_to_capture = [2, num_layers // 2, num_layers - 3]
+        else:
+            # Capture runs before layer(i), so capture output of layer N at N+1.
+            self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -1,13 +1,80 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sglang.srt.managers.tp_worker import TpModelWorker
+    from sglang.srt.model_executor.model_runner import ModelRunner
+    from sglang.srt.server_args import ServerArgs
+
+
+class HiCacheDraftMode(str, Enum):
+    NONE = "none"
+    PACKED = "packed"
+    SIDECAR = "sidecar"
+
+
+@dataclass(frozen=True, slots=True)
+class HiCacheDraftPlan:
+    mode: HiCacheDraftMode = HiCacheDraftMode.NONE
+    device_pools: tuple[object, ...] = ()
+
+
+def build_hicache_draft_plan(
+    *,
+    target_model_runner: ModelRunner,
+    draft_runners: tuple[ModelRunner, ...],
+    server_args: ServerArgs,
+) -> HiCacheDraftPlan:
+    target_model_runner.mtp_draft_device_pools = ()
+    if not server_args.enable_hierarchical_cache or not draft_runners:
+        return HiCacheDraftPlan()
+
+    draft_pools = tuple(runner.token_to_kv_pool for runner in draft_runners)
+    spec_algorithm = target_model_runner.spec_algorithm
+    is_dsv4_nextn_mtp = (
+        spec_algorithm.is_eagle()
+        and not spec_algorithm.is_eagle3()
+        and all(
+            runner.model_config.num_nextn_predict_layers
+            and "DeepseekV4ForCausalLMNextN"
+            in runner.model_config.hf_config.architectures
+            for runner in draft_runners
+        )
+    )
+    if is_dsv4_nextn_mtp:
+        if server_args.enable_eic_cache:
+            raise NotImplementedError(
+                "Packed DeepSeek-V4 NextN draft cache currently supports "
+                "standard HiCache L2 only; EIC integration is not included."
+            )
+        if server_args.hicache_storage_backend is not None:
+            raise NotImplementedError(
+                "This DeepSeek-V4 backport supports packed built-in NextN "
+                "draft cache for HiCache L2 only; L3 draft storage requires "
+                "the remaining upstream #30393 storage-backend changes."
+            )
+        target_model_runner.mtp_draft_device_pools = draft_pools
+        return HiCacheDraftPlan(
+            mode=HiCacheDraftMode.PACKED,
+            device_pools=draft_pools,
+        )
+
+    return HiCacheDraftPlan(
+        mode=HiCacheDraftMode.SIDECAR,
+        device_pools=draft_pools[:1],
+    )
 
 
 class BaseDraftWorker(ABC):
+    @property
+    def draft_runners(self) -> list[ModelRunner]:
+        """Return every draft runner participating in speculative decoding."""
+        return getattr(self, "draft_runner_list", [self.draft_runner])
+
     @abstractmethod
     def draft():
         pass
@@ -18,6 +85,38 @@ class BaseDraftWorker(ABC):
 
 
 class BaseSpecWorker(ABC):
+    _hicache_draft_plan = HiCacheDraftPlan()
+
+    @property
+    def hicache_draft_plan(self) -> HiCacheDraftPlan:
+        return self._hicache_draft_plan
+
+    def _draft_model_runners(self) -> tuple[ModelRunner, ...]:
+        spec_algorithm = self.target_worker.model_runner.spec_algorithm
+        draft_worker = self.draft_worker
+        if (
+            draft_worker is None
+            or spec_algorithm.is_ngram()
+            or spec_algorithm.is_frozen_kv_mtp()
+        ):
+            return ()
+        return tuple(draft_worker.draft_runners)
+
+    @property
+    def primary_draft_kv_pool(self) -> object | None:
+        draft_runners = self._draft_model_runners()
+        return draft_runners[0].token_to_kv_pool if draft_runners else None
+
+    def _build_hicache_draft_plan(self) -> HiCacheDraftPlan:
+        return build_hicache_draft_plan(
+            target_model_runner=self.target_worker.model_runner,
+            draft_runners=self._draft_model_runners(),
+            server_args=self.server_args,
+        )
+
+    def init_hicache_draft_plan(self) -> None:
+        self._hicache_draft_plan = self._build_hicache_draft_plan()
+
     @property
     @abstractmethod
     def target_worker(self) -> TpModelWorker:

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -31,6 +31,16 @@ class DraftBackendFactory:
         if backend_type is None:
             backend_type = self.server_args.attention_backend
 
+        if backend_type == "dsv4":
+            from sglang.srt.configs.model_config import is_deepseek_v4
+
+            draft_hf_config = self.draft_model_runner.model_config.hf_config
+            if not is_deepseek_v4(draft_hf_config):
+                backend_type = self.server_args._get_default_attn_backend(
+                    use_mla_backend=self.draft_model_runner.use_mla_backend,
+                    model_config=self.draft_model_runner.model_config,
+                )
+
         if backend_type not in backend_map:
             raise ValueError(error_template.format(backend_type=backend_type))
 

--- a/test/registered/unit/mem_cache/test_dsv4_eagle3_hicache.py
+++ b/test/registered/unit/mem_cache/test_dsv4_eagle3_hicache.py
@@ -1,22 +1,83 @@
-"""Focused CPU tests for the DSV4 EAGLE3 HiCache backport."""
+"""Focused CPU tests for DSV4 built-in EAGLE and EAGLE3 HiCache."""
 
+import contextlib
 import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import torch
 from sglang.srt.mem_cache.hicache_storage import PoolName
 from sglang.srt.mem_cache.hybrid_cache import hybrid_pool_assembler
-from sglang.srt.mem_cache.kv_cache_builder import maybe_register_hicache_draft
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    CacheOperation,
+    HybridCacheController,
+)
+from sglang.srt.mem_cache.kv_cache_builder import (
+    maybe_register_hicache_draft,
+    prepare_hicache_draft_plan,
+)
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
 from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
+from sglang.srt.speculative.base_spec_worker import (
+    HiCacheDraftMode,
+    HiCacheDraftPlan,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestDSV4Eagle3HiCache(unittest.TestCase):
+    def test_builtin_dsv4_nextn_uses_packed_hicache_plan(self):
+        draft_pool = object()
+        draft_runner = SimpleNamespace(
+            token_to_kv_pool=draft_pool,
+            model_config=SimpleNamespace(
+                num_nextn_predict_layers=1,
+                hf_config=SimpleNamespace(architectures=["DeepseekV4ForCausalLMNextN"]),
+            ),
+        )
+        target_runner = SimpleNamespace(
+            spec_algorithm=SimpleNamespace(
+                is_eagle=mock.Mock(return_value=True),
+                is_eagle3=mock.Mock(return_value=False),
+                is_frozen_kv_mtp=mock.Mock(return_value=False),
+            ),
+            mtp_draft_device_pools=(),
+        )
+        target_worker = SimpleNamespace(model_runner=target_runner)
+        draft_worker = SimpleNamespace(model_runner=draft_runner)
+        spec_algorithm = target_runner.spec_algorithm
+        server_args = SimpleNamespace(
+            enable_hierarchical_cache=True,
+            enable_eic_cache=False,
+            enable_multi_layer_eagle=False,
+            hicache_storage_backend=None,
+        )
+
+        plan = prepare_hicache_draft_plan(
+            target_worker=target_worker,
+            draft_worker=draft_worker,
+            spec_algorithm=spec_algorithm,
+            server_args=server_args,
+        )
+
+        self.assertEqual(plan.mode, HiCacheDraftMode.PACKED)
+        self.assertEqual(plan.device_pools, (draft_pool,))
+        self.assertEqual(target_runner.mtp_draft_device_pools, (draft_pool,))
+
+    def test_packed_layer_mapping_appends_draft_after_target(self):
+        mapping = hybrid_pool_assembler._with_mtp_layer_mapping(
+            {0: 0, 1: 1},
+            transfer_layer_start=2,
+            target_device_layer_num=2,
+            draft_layer_num=1,
+        )
+
+        self.assertEqual(mapping, {0: 0, 1: 1, 2: 2})
+
     def test_external_draft_falls_back_from_dsv4_backend(self):
         fallback = mock.Mock(return_value="fa3")
         holder = SimpleNamespace(
@@ -102,15 +163,9 @@ class TestDSV4Eagle3HiCache(unittest.TestCase):
 
     def test_unified_cache_registers_sidecar_instead_of_legacy_piggyback(self):
         draft_pool = object()
-        draft_runner = SimpleNamespace(
-            token_to_kv_pool=draft_pool,
-            model_config=object(),
-        )
-        draft_worker = SimpleNamespace(model_runner=draft_runner)
-        spec_algorithm = SimpleNamespace(
-            is_ngram=mock.Mock(return_value=False),
-            is_eagle3=mock.Mock(return_value=True),
-            supports_spec_v2=mock.Mock(return_value=False),
+        draft_plan = HiCacheDraftPlan(
+            mode=HiCacheDraftMode.SIDECAR,
+            device_pools=(draft_pool,),
         )
         tree_cache = object.__new__(UnifiedRadixCache)
         tree_cache.register_hicache_draft_pools = mock.Mock()
@@ -125,11 +180,8 @@ class TestDSV4Eagle3HiCache(unittest.TestCase):
         ):
             maybe_register_hicache_draft(
                 tree_cache=tree_cache,
-                draft_worker=draft_worker,
-                spec_algorithm=spec_algorithm,
+                draft_plan=draft_plan,
                 server_args=SimpleNamespace(hicache_storage_backend=None),
-                enable_hierarchical_cache=True,
-                enable_overlap=False,
                 page_size=256,
             )
 
@@ -137,6 +189,75 @@ class TestDSV4Eagle3HiCache(unittest.TestCase):
             specs, entries
         )
         tree_cache.cache_controller.set_draft_kv_pool.assert_not_called()
+
+    def test_packed_load_restores_draft_tail_before_first_layer_is_ready(self):
+        controller = object.__new__(HybridCacheController)
+        host_indices = torch.tensor([0, 1], dtype=torch.int64)
+        device_indices = torch.tensor([2, 3], dtype=torch.int64)
+        controller.load_queue = [
+            CacheOperation(host_indices, device_indices, node_id=7, priority=0)
+        ]
+        controller.move_hybrid_indices = mock.Mock(
+            return_value=(host_indices, device_indices, None)
+        )
+        producer_event = SimpleNamespace(
+            start_event=mock.Mock(),
+            finish_event=object(),
+            complete=mock.Mock(),
+        )
+        controller.layer_done_counter = SimpleNamespace(
+            update_producer=mock.Mock(return_value=0),
+            events=[producer_event],
+        )
+        controller.mem_pool_host = mock.Mock()
+        controller.mem_pool_device = object()
+        draft_buffer = object()
+        controller.has_mtp_draft = True
+        controller.mtp_draft_device_pools = (draft_buffer,)
+        controller.layer_num = 2
+        controller.io_backend = "direct"
+        controller.load_stream = object()
+        controller.ack_load_queue = []
+        controller._record_transfer_indices_on_stream = mock.Mock()
+
+        with mock.patch(
+            "sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller."
+            "device_module.stream",
+            return_value=contextlib.nullcontext(),
+        ):
+            producer_id = HybridCacheController.start_loading(controller)
+
+        self.assertEqual(producer_id, 0)
+        controller.mem_pool_host.load_to_device_per_layer.assert_has_calls(
+            [
+                mock.call(
+                    controller.mem_pool_device,
+                    host_indices,
+                    device_indices,
+                    0,
+                    "direct",
+                    pool_transfers=None,
+                ),
+                mock.call(
+                    draft_buffer,
+                    host_indices,
+                    device_indices,
+                    2,
+                    "direct",
+                    pool_transfers=None,
+                    is_draft=True,
+                ),
+                mock.call(
+                    controller.mem_pool_device,
+                    host_indices,
+                    device_indices,
+                    1,
+                    "direct",
+                    pool_transfers=None,
+                ),
+            ]
+        )
+        producer_event.complete.assert_has_calls([mock.call(0), mock.call(1)])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_dsv4_eagle3_hicache.py
+++ b/test/registered/unit/mem_cache/test_dsv4_eagle3_hicache.py
@@ -1,0 +1,143 @@
+"""Focused CPU tests for the DSV4 EAGLE3 HiCache backport."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.mem_cache.hicache_storage import PoolName
+from sglang.srt.mem_cache.hybrid_cache import hybrid_pool_assembler
+from sglang.srt.mem_cache.kv_cache_builder import maybe_register_hicache_draft
+from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDSV4Eagle3HiCache(unittest.TestCase):
+    def test_external_draft_falls_back_from_dsv4_backend(self):
+        fallback = mock.Mock(return_value="fa3")
+        holder = SimpleNamespace(
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"])
+            ),
+            server_args=SimpleNamespace(_get_default_attn_backend=fallback),
+            use_mla_backend=False,
+        )
+
+        result = ModelRunner._fallback_dsv4_backend_for_draft(holder, "dsv4")
+
+        self.assertEqual(result, "fa3")
+        fallback.assert_called_once_with(
+            use_mla_backend=False,
+            model_config=holder.model_config,
+        )
+
+    def test_dsv4_draft_keeps_dsv4_backend(self):
+        fallback = mock.Mock(return_value="fa3")
+        holder = SimpleNamespace(
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    architectures=["DeepseekV4ForCausalLMNextN"]
+                )
+            ),
+            server_args=SimpleNamespace(_get_default_attn_backend=fallback),
+            use_mla_backend=True,
+        )
+
+        result = ModelRunner._fallback_dsv4_backend_for_draft(holder, "dsv4")
+
+        self.assertEqual(result, "dsv4")
+        fallback.assert_not_called()
+
+    def test_eagle3_capture_layers_follow_upstream_offset(self):
+        holder = SimpleNamespace(
+            pp_group=SimpleNamespace(is_last_rank=True),
+            capture_aux_hidden_states=False,
+            config=SimpleNamespace(num_hidden_layers=80),
+            model=SimpleNamespace(layers_to_capture=[]),
+        )
+
+        DeepseekV4ForCausalLM.set_eagle3_layers_to_capture(holder, [1, 39, 76])
+
+        self.assertTrue(holder.capture_aux_hidden_states)
+        self.assertEqual(holder.model.layers_to_capture, [2, 40, 77])
+
+    def test_build_full_draft_sidecar_uses_target_kv_indices(self):
+        draft_pool = mock.Mock(spec=MHATokenToKVPool)
+        draft_pool.layer_num = 1
+        draft_pool.size = 1024
+        fake_host_pool = SimpleNamespace(layer_num=1)
+        tree_cache = SimpleNamespace(
+            cache_controller=SimpleNamespace(
+                page_size=256,
+                mem_pool_host=SimpleNamespace(size=2048),
+            )
+        )
+        server_args = SimpleNamespace(
+            hicache_mem_layout="layer_first",
+            hicache_storage_backend=None,
+        )
+
+        with mock.patch.object(
+            hybrid_pool_assembler,
+            "_build_draft_host_pool",
+            return_value=fake_host_pool,
+        ):
+            specs, entries = hybrid_pool_assembler.build_hicache_draft_sidecars(
+                draft_device_pools=(draft_pool,),
+                tree_cache=tree_cache,
+                server_args=server_args,
+            )
+
+        self.assertEqual(len(specs), 1)
+        self.assertEqual(specs[0].pool_name, PoolName.DRAFT)
+        self.assertEqual(specs[0].indices_from_pool, PoolName.KV)
+        self.assertEqual(entries[0].name, PoolName.DRAFT)
+        self.assertIs(entries[0].device_pool, draft_pool)
+        self.assertEqual(entries[0].layer_mapper(0), 0)
+        self.assertIsNone(entries[0].layer_mapper(1))
+
+    def test_unified_cache_registers_sidecar_instead_of_legacy_piggyback(self):
+        draft_pool = object()
+        draft_runner = SimpleNamespace(
+            token_to_kv_pool=draft_pool,
+            model_config=object(),
+        )
+        draft_worker = SimpleNamespace(model_runner=draft_runner)
+        spec_algorithm = SimpleNamespace(
+            is_ngram=mock.Mock(return_value=False),
+            is_eagle3=mock.Mock(return_value=True),
+            supports_spec_v2=mock.Mock(return_value=False),
+        )
+        tree_cache = object.__new__(UnifiedRadixCache)
+        tree_cache.register_hicache_draft_pools = mock.Mock()
+        tree_cache.cache_controller = SimpleNamespace(set_draft_kv_pool=mock.Mock())
+        specs = [object()]
+        entries = [object()]
+
+        with mock.patch(
+            "sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler."
+            "build_hicache_draft_sidecars",
+            return_value=(specs, entries),
+        ):
+            maybe_register_hicache_draft(
+                tree_cache=tree_cache,
+                draft_worker=draft_worker,
+                spec_algorithm=spec_algorithm,
+                server_args=SimpleNamespace(hicache_storage_backend=None),
+                enable_hierarchical_cache=True,
+                enable_overlap=False,
+                page_size=256,
+            )
+
+        tree_cache.register_hicache_draft_pools.assert_called_once_with(
+            specs, entries
+        )
+        tree_cache.cache_controller.set_draft_kv_pool.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dsv4_eagle3_hicache.py
+++ b/test/registered/unit/mem_cache/test_dsv4_eagle3_hicache.py
@@ -13,6 +13,7 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
 from sglang.srt.mem_cache.kv_cache_builder import (
+    get_draft_kv_pool,
     maybe_register_hicache_draft,
     prepare_hicache_draft_plan,
 )
@@ -30,6 +31,64 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestDSV4Eagle3HiCache(unittest.TestCase):
+    def test_pd_draft_pool_resolution_without_draft_worker(self):
+        pool, model_config = get_draft_kv_pool(
+            draft_worker=None,
+            spec_algorithm=SimpleNamespace(is_ngram=mock.Mock(return_value=False)),
+            server_args=SimpleNamespace(enable_multi_layer_eagle=False),
+            enable_overlap=False,
+        )
+
+        self.assertIsNone(pool)
+        self.assertIsNone(model_config)
+
+    def test_pd_draft_pool_resolution_for_spec_v2_overlap(self):
+        draft_pool = object()
+        draft_model_config = object()
+        draft_runner = SimpleNamespace(
+            token_to_kv_pool=draft_pool,
+            model_config=draft_model_config,
+        )
+        draft_worker = SimpleNamespace(
+            draft_worker=SimpleNamespace(draft_runner=draft_runner)
+        )
+        spec_algorithm = SimpleNamespace(
+            is_ngram=mock.Mock(return_value=False),
+            supports_spec_v2=mock.Mock(return_value=True),
+        )
+
+        pool, model_config = get_draft_kv_pool(
+            draft_worker=draft_worker,
+            spec_algorithm=spec_algorithm,
+            server_args=SimpleNamespace(enable_multi_layer_eagle=False),
+            enable_overlap=True,
+        )
+
+        self.assertIs(pool, draft_pool)
+        self.assertIs(model_config, draft_model_config)
+
+    def test_pd_draft_pool_resolution_for_legacy_worker(self):
+        draft_pool = object()
+        draft_model_config = object()
+        draft_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(token_to_kv_pool=draft_pool),
+            model_config=draft_model_config,
+        )
+        spec_algorithm = SimpleNamespace(
+            is_ngram=mock.Mock(return_value=False),
+            supports_spec_v2=mock.Mock(return_value=True),
+        )
+
+        pool, model_config = get_draft_kv_pool(
+            draft_worker=draft_worker,
+            spec_algorithm=spec_algorithm,
+            server_args=SimpleNamespace(enable_multi_layer_eagle=False),
+            enable_overlap=False,
+        )
+
+        self.assertIs(pool, draft_pool)
+        self.assertIs(model_config, draft_model_config)
+
     def test_builtin_dsv4_nextn_uses_packed_hicache_plan(self):
         draft_pool = object()
         draft_runner = SimpleNamespace(


### PR DESCRIPTION
## Summary

Support speculative decoding with DeepSeek-V4-Flash-0731 while preserving HiCache L2 draft state across target-prefix replay.

This draft now covers both upstream draft-cache layouts:

- **Built-in EAGLE / NextN:** use the upstream #30393 **PACKED** layout. The 0731 checkpoint's uncompressed NextN SWA buffer is appended to the target SWA host pool as a tail layer, shares the target SWA slot mapping, is backed up in the same D2H operation, and is restored before the first local target layer is marked ready.
- **External EAGLE3:** keep the existing #30393 **SIDECAR** layout. Draft Full/SWA pools follow the target transfer indices through explicit HiCache sidecar entries.

The model/backend changes remain based on #33344.

## Why

The branch already knows how to load the 0731 checkpoint's built-in `DeepseekV4ForCausalLMNextN` layer, but the old HiCache registration happens after the target cache is built. As a result, built-in NextN draft buffers are not part of the DSV4 host-pool assembler and are not restored on an L2 target-prefix hit.

The new draft plan is resolved before cache construction, so the DSV4 assembler can pack the NextN SWA buffer into the matching target SWA host pool. External EAGLE3 remains a separate sidecar because its cache layout is independent from the target pool.

## Implementation

- Add `HiCacheDraftMode` / `HiCacheDraftPlan` and support both legacy non-overlap EAGLE workers and overlap/v2 workers.
- Select PACKED only for the built-in `DeepseekV4ForCausalLMNextN` path.
- Pass packed draft pools through `CacheInitParams` before UnifiedRadixCache/HiCache construction.
- Append draft SWA buffers after target local SWA layers using the upstream transfer-layer mapping.
- Restore the packed draft tail during the same H2D operation, before layer 0 completion is published.
- Preserve external EAGLE3 sidecar registration and its existing target-index-derived transfers.
- Fail fast for packed draft + L3 storage or EIC; those remaining upstream storage/control-plane changes are intentionally outside this L2-only backport.

## Scope

Supported in this draft:

- DeepSeek-V4-Flash-0731
- built-in EAGLE/NextN or external EAGLE3
- UnifiedRadixCache
- HiCache L2
- target Full/SWA plus DSV4 compressed side pools
- PP-local DSV4 host pools

Not claimed by this draft:

- packed/sidecar draft L3 persistence
- EIC draft integration
- DSpark
- MTP/HiCache GPU end-to-end validation on the local development host

## Validation

Passed locally:

- `git diff --check`
- `python3 -m compileall` for all changed runtime and test files
- focused Ruff F/I checks for the new draft-plan and unit-test code
- source-level audit against upstream #30393 PACKED/SIDECAR semantics
- remote branch/base freshness check before push

Added focused CPU coverage for:

- built-in DSV4 NextN selecting PACKED mode
- draft tail-layer mapping
- external EAGLE3 selecting/registering SIDECAR mode
- packed H2D restoring the draft tail before the first target-layer completion

The focused pytest file could not run on this local host because PyTorch is not installed in the available Python environment. GPU/PP service validation is still required before moving the PR out of draft.

<!-- pr-states:start -->
---
### CI States

Latest PR Test: <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** — add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** — `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->