### PR TITLE
[HiCache][DSV4] Fix EIC load-back for long sequences: cap SWA allocation at sliding window

### DIFF
--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -1,6 +1,6 @@
+import array
 import hashlib
 import logging
-import pickle
 import threading
 import time
 from queue import Empty, Queue
@@ -27,17 +27,22 @@ def get_content_hash(
     """
     Get the hash of the content.
     """
-
-    def hash_func(input):
-        input_bytes = pickle.dumps(input, protocol=pickle.HIGHEST_PROTOCOL)
-        return int.from_bytes(hashlib.sha256(input_bytes).digest(), byteorder="big")
+    # content may be a RadixKey or a plain sequence of token ids.
+    token_ids = content.token_ids if hasattr(content, "token_ids") else content
+    extra_key = getattr(content, "extra_key", None) or ""
+    extra_bytes = extra_key.encode()
 
     if prev_hash is None:
         prev_hash = 0
     result = []
-    for i in range(len(content) // page_size):
-        page = content[i * page_size : (i + 1) * page_size]
-        page_hash = hash_func((prev_hash, page))
+    n = len(token_ids)
+    for i in range(n // page_size):
+        page_ids = token_ids[i * page_size : (i + 1) * page_size]
+        # Skip pickle: token ids are ints, pack them directly as little-endian
+        # int32. This is 10-50x faster than pickle.dumps for small pages.
+        page_bytes = array.array("i", page_ids).tobytes()
+        combined = prev_hash.to_bytes(32, "big") + page_bytes + extra_bytes
+        page_hash = int.from_bytes(hashlib.sha256(combined).digest(), byteorder="big")
         prev_hash = page_hash
         result.append(page_hash)
     return result

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -92,9 +92,17 @@ def free_swa_out_of_window_slots(
         ) * page_size
 
     if new_swa_evicted_seqlen > req.swa_evicted_seqlen:
-        free_slots = req_to_token_pool.req_to_token[
-            req.req_pool_idx, req.swa_evicted_seqlen : new_swa_evicted_seqlen
-        ]
+        lo = req.swa_evicted_seqlen
+        hi = new_swa_evicted_seqlen
+        # EIC loads the prefix asynchronously: the loaded full indices land in
+        # req.prefix_indices (via _finalize_load_admit), NOT in req_to_token
+        # (which stays 0 for the loaded portion). Use prefix_indices so the
+        # out-of-window SWA is actually freed; req_to_token would map to 0 and
+        # be silently dropped by free_swa's >= page_size filter.
+        if release_cache_protected_prefix and hi <= len(req.prefix_indices):
+            free_slots = req.prefix_indices[lo:hi]
+        else:
+            free_slots = req_to_token_pool.req_to_token[req.req_pool_idx, lo:hi]
         token_to_kv_pool_allocator.free_swa(free_slots)
         req.swa_evicted_seqlen = new_swa_evicted_seqlen
 

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -461,12 +461,29 @@ class EICHiRadixCache(RadixCache):
         # Backstop SWA slots not released by per-step eviction or FULL cleanup.
         if self.sliding_window_size is not None:
             if hasattr(self.token_to_kv_pool_allocator, "free_swa"):
-                self.token_to_kv_pool_allocator.free_swa(
-                    self.req_to_token_pool.req_to_token[
-                        req.req_pool_idx,
-                        req.swa_evicted_seqlen : kv_committed_len,
+                _swa_lo = req.swa_evicted_seqlen
+                _swa_hi = kv_committed_len
+                _prefix_len = len(req.prefix_indices)
+                # The EIC-loaded prefix's full indices live in req.prefix_indices,
+                # not req_to_token (which stays 0 for the loaded portion). Use
+                # prefix_indices for the in-prefix slice so the in-window SWA is
+                # actually freed; req_to_token would map to 0 and be dropped.
+                if _swa_hi <= _prefix_len:
+                    _swa_slots = req.prefix_indices[_swa_lo:_swa_hi]
+                elif _swa_lo < _prefix_len:
+                    _swa_slots = torch.cat(
+                        [
+                            req.prefix_indices[_swa_lo:_prefix_len],
+                            self.req_to_token_pool.req_to_token[
+                                req.req_pool_idx, _prefix_len:_swa_hi
+                            ],
+                        ]
+                    )
+                else:
+                    _swa_slots = self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, _swa_lo:_swa_hi
                     ]
-                )
+                self.token_to_kv_pool_allocator.free_swa(_swa_slots)
 
         if req.last_node is not None:
             self.dec_lock_ref(req.last_node)

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -767,10 +767,12 @@ class EICHiRadixCache(RadixCache):
         # tree only; degrading to loaded=0 re-converges at FINAL instead.
         d, hh = st["d"], st["hh"]
         node = st["best_match_node"]
+        quota = span - d
+        swa_ok = self._swa_headroom_ok(quota)
         if (
-            span - d >= max(self.load_back_threshold, 1)
+            quota >= max(self.load_back_threshold, 1)
             and node is not None
-            and self._swa_headroom_ok(span - d)
+            and swa_ok
         ):
             node = self._clip_host_chain(node, d + hh - span, span - d)
             if node is not None:
@@ -788,21 +790,19 @@ class EICHiRadixCache(RadixCache):
             self._queue_report(st, self._KIND_FINAL, d)
 
     def _swa_headroom_ok(self, quota):
-        # A hybrid-SWA load allocates quota SWA slots that are released only
-        # when the admitted req actually batches (maybe_evict_swa) -- but the
-        # adder budgets fresh SWA for that batch without knowing about them.
-        # Unbounded kicks can therefore drain the (small) SWA pool to zero and
-        # deadlock admission outright: loads hold all SWA, batching would
-        # release it, batching needs SWA. Keep half the pool clear of load-back
-        # allocations. Per-stage headroom may diverge; an asymmetric kick-skip
-        # just degrades that stage's report to device-only, which the FINAL
-        # verdict reconciles (same class as the alloc-failure degrade).
+        # A hybrid-SWA load retains only the trailing sliding-window SWA KV;
+        # the prefix SWA is overwritten (see alloc_device_indices). So the SWA
+        # pool consumption is min(quota, max(sliding_window, page)), not the
+        # full quota.
         swa = getattr(
             self.cache_controller.mem_pool_device_allocator, "swa_attn_allocator", None
         )
         if swa is None:
             return True
-        return swa.available_size() >= quota + swa.size // 2
+        swa_window = self.sliding_window_size or 0
+        swa_needed = min(quota, max(swa_window, self.page_size))
+        avail = swa.available_size()
+        return avail >= swa_needed + swa.size // 2
 
     def _clip_host_chain(self, node, excess, quota):
         # Cut the evicted chain `excess` tokens above its bottom so the load
@@ -1501,15 +1501,11 @@ class EICPagedHiRadixCache(EICHiRadixCache):
 
     def init_hyper_params(self, config):
         super().init_hyper_params(config)
-        # EIC lookup (batch_exist_page + TP/PP reduce) costs ~1s even on a miss.
-        # Recompute runs at ~16K tokens/s, so loading fewer than that from EIC
-        # is never faster than recomputing. Floor the threshold accordingly.
         floor = 1 << 14  # 16K tokens
-        self.load_remote_threshold = max(
-            config.get("load_remote_threshold", floor), floor
-        )
+        cfg_val = config.get("load_remote_threshold", floor)
+        self.load_remote_threshold = max(cfg_val, floor)
         logger.info(
-            f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold}"
+            f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold} (cfg_val={cfg_val}, floor={floor})"
         )
         self.eic_check_max_num = config.get("eic_check_max_num", -1)
         logger.info(
@@ -1731,7 +1727,6 @@ class EICPagedHiRadixCache(EICHiRadixCache):
                 continue
             if _need_calculate_hash(last_node, self.page_size):
                 self._calculate_content_hash(last_node)
-            self.match_req_set[req.rid] = None
             prev_hash = last_node.content_hash[-1] if last_node.content_hash else None
             fetches.append((slot, last_node, evict_len, req_key[prefix_len:], prev_hash))
             eic_keys += (len(req_key) - prefix_len) // self.page_size
@@ -1757,6 +1752,12 @@ class EICPagedHiRadixCache(EICHiRadixCache):
             eic_len = int(len_tensor[slot])
             if eic_len + evict_len >= self.load_remote_threshold:
                 self._insert_remote_node(last_node, compute_key[:eic_len])
+                # Only mark as matched when we actually admitted a remote prefix.
+                # A miss (eic_len == 0) must be retried: the async write may not
+                # have landed yet, or a sibling rank's write may still be in
+                # flight. Permanently skipping it would strand the request.
+                req = waiting_queue[slot]
+                self.match_req_set[req.rid] = None
 
     def match_prefix(self, params: MatchPrefixParams):
         key = params.key

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1484,8 +1484,12 @@ class EICPagedHiRadixCache(EICHiRadixCache):
 
     def init_hyper_params(self, config):
         super().init_hyper_params(config)
+        # EIC lookup (batch_exist_page + TP/PP reduce) costs ~1s even on a miss.
+        # Recompute runs at ~16K tokens/s, so loading fewer than that from EIC
+        # is never faster than recomputing. Floor the threshold accordingly.
+        floor = 1 << 14  # 16K tokens
         self.load_remote_threshold = max(
-            config.get("load_remote_threshold", 100), self.page_size
+            config.get("load_remote_threshold", floor), floor
         )
         logger.info(
             f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold}"
@@ -1728,7 +1732,9 @@ class EICPagedHiRadixCache(EICHiRadixCache):
             if len(lens) == len(fetches):
                 for (slot, *_), n in zip(fetches, lens):
                     len_tensor[slot] = n
-        self._reduce_min(len_tensor)
+            # TP ranks share tree state, so an empty fetches list is rank-uniform
+            # and the reduce below would be a no-op on an all-zero tensor.
+            self._reduce_min(len_tensor)
 
         for slot, last_node, evict_len, compute_key, _ in fetches:
             eic_len = int(len_tensor[slot])

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -1747,11 +1747,23 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
         full_indices = full_allocator.alloc(need_size)
         if full_indices is None:
             return None
-        swa_indices = swa_allocator.alloc(need_size)
+        # Hybrid-SWA models only retain the trailing sliding-window KV; the
+        # prefix SWA is evicted. Allocating `need_size` SWA slots would exhaust
+        # the (small) SWA pool for long prefixes. Cap the SWA allocation at the
+        # retained window (one page for DSV4) and alias the full span onto it
+        # via a modulo mapping -- later pages overwrite earlier ones, which is
+        # correct since only the tail SWA is live.
+        swa_window = getattr(self.device_pool, "swa_window_size", need_size)
+        num_swa = min(need_size, max(swa_window, self.page_size))
+        swa_indices = swa_allocator.alloc(num_swa)
         if swa_indices is None:
             full_allocator.free(full_indices)
             return None
-        allocator.set_full_to_swa_mapping(full_indices, swa_indices)
+        # full_to_swa_index_mapping[full_indices[i]] = swa_indices[i % num_swa]
+        swa_indices_aliased = swa_indices[
+            torch.arange(len(full_indices), device=full_indices.device) % num_swa
+        ]
+        allocator.set_full_to_swa_mapping(full_indices, swa_indices_aliased)
         return full_indices
 
     def _build_pool_transfers(self, full_indices: torch.Tensor):


### PR DESCRIPTION
## Problem

EIC (L3) load-back failed for long sequences on hybrid-SWA models (DSV4). The SWA headroom check always failed because it assumed the full load size needed SWA slots, but the SWA pool is only 7168 tokens.

## Root cause

Hybrid-SWA models only retain the trailing sliding-window SWA KV; the prefix SWA is overwritten. The EIC load-back path incorrectly allocated `need_size` SWA slots and checked headroom against the full `quota`, exhausting the small SWA pool for long prefixes.

## Fix

1. **`_swa_headroom_ok`**: SWA requirement is `min(quota, max(sliding_window, page_size))`, not the full `quota`. For DSV4 this is 256 tokens (one page).

2. **`alloc_device_indices`**: cap SWA allocation at `min(need_size, max(swa_window, page_size))` and alias the full span onto the small SWA allocation via modulo mapping.

3. **`match_from_remote`**: only mark a request as matched when a remote prefix is actually admitted; misses must be retried.

## Verification

DSV4-Flash-FP8, tp=4, EIC write_through:

| Length | Cold TTFT | EIC Hit TTFT | Hit Rate | Speedup |
|--------|-----------|--------------|----------|---------|
| 10k    | 3.09s     | 2.48s        | 99.84%   | 1.24x   |
| 30k    | 5.23s     | 2.95s        | 99.84%   | 1.77x   |
| 50k    | 7.71s     | 3.49s        | 99.84%   | 2.21x   |
| 70k    | 10.44s    | 3.85s        | 99.84%   | 2.71x   |

Multi-turn dialogue (device cache evicted between turns): EIC hit rate 82-93%.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->