### PR TITLE
[HiCache][DSV4] Fix EIC SWA budget/double-free, PD PP=1 batch size, async write copy

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2452,7 +2452,10 @@ class Scheduler(
         return ret
 
     def get_num_allocatable_reqs(self, running_bs):
-        res = get_global_server_args().pp_max_micro_batch_size - running_bs
+        if self.ps.pp_size > 1:
+            res = get_global_server_args().pp_max_micro_batch_size - running_bs
+        else:
+            res = self.max_running_requests - running_bs
         res = min(res, self.req_to_token_pool.available_size())
         return res
 

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -790,10 +790,6 @@ class EICHiRadixCache(RadixCache):
             self._queue_report(st, self._KIND_FINAL, d)
 
     def _swa_headroom_ok(self, quota):
-        # A hybrid-SWA load retains only the trailing sliding-window SWA KV;
-        # the prefix SWA is overwritten (see alloc_device_indices). So the SWA
-        # pool consumption is min(quota, max(sliding_window, page)), not the
-        # full quota.
         swa = getattr(
             self.cache_controller.mem_pool_device_allocator, "swa_attn_allocator", None
         )
@@ -1795,12 +1791,20 @@ class EICPagedHiRadixCache(EICHiRadixCache):
             host_hit_length += len(last_node.host_value)
             last_node = last_node.parent
 
+        # Load-back keeps only the trailing window of SWA KV; report that.
+        swa_host_hit_length = 0
+        if host_hit_length > 0 and self.sliding_window_size is not None:
+            swa_host_hit_length = min(
+                host_hit_length, max(self.sliding_window_size, self.page_size)
+            )
+
         return MatchResult(
             device_indices=value,
             last_device_node=last_node,
             last_host_node=last_host_node,
             best_match_node=last_host_node,
             host_hit_length=host_hit_length,
+            swa_host_hit_length=swa_host_hit_length,
         )
 
     def write_backup(self, node: TreeNode, write_back=False):

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -386,7 +386,9 @@ class EICKVClient:
     def _write_thread(self):
         logger.info(f"start write thread thread_id {threading.get_ident()}")
         while True:
-            keys, values = self.write_queue.get()
+            keys, values, copy_event = self.write_queue.get()
+            if copy_event is not None:
+                copy_event.synchronize()
             self._async_set_impl(keys, values)
             for value in values:
                 if self.kv_cache_write_mem_pool.check_data_ptr_allocated(
@@ -412,13 +414,15 @@ class EICKVClient:
             if objs is None:
                 return False
 
+            copy_event = None
             if obj_inputs is not None:
                 write_stream = torch.cuda.current_stream()
                 with torch.cuda.stream(write_stream):
                     for i in range(len(keys)):
                         objs[i] = objs[i].reshape(obj_inputs[i].shape)
                         objs[i].copy_(obj_inputs[i], non_blocking=True)
-                write_stream.synchronize()
+                copy_event = torch.cuda.Event()
+                copy_event.record(write_stream)
             elif device_indices is not None and copy_func is not None:
                 copy_func(device_indices, objs)
             else:
@@ -426,7 +430,7 @@ class EICKVClient:
                     "async set impl input obj_inputs and device_indices are both None"
                 )
                 return False
-            self.write_queue.put((keys, objs))
+            self.write_queue.put((keys, objs, copy_event))
 
             cost_time = time.perf_counter() - start_time
             if cost_time >= 0.5:
@@ -450,7 +454,7 @@ class EICKVClient:
                     "async set impl input obj_inputs and device_indices are both None"
                 )
                 return False
-            self.write_queue.put((keys, objs))
+            self.write_queue.put((keys, objs, None))
             logger.warning(
                 f"async batch set fallback to malloc, cost {(time.perf_counter() - start_time) * 1e3}.2f ms, {len(keys)} keys"
             )
@@ -1747,22 +1751,17 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
         full_indices = full_allocator.alloc(need_size)
         if full_indices is None:
             return None
-        # Hybrid-SWA models only retain the trailing sliding-window KV; the
-        # prefix SWA is evicted. Allocating `need_size` SWA slots would exhaust
-        # the (small) SWA pool for long prefixes. Cap the SWA allocation at the
-        # retained window (one page for DSV4) and alias the full span onto it
-        # via a modulo mapping -- later pages overwrite earlier ones, which is
-        # correct since only the tail SWA is live.
+        # Only the trailing window gets real SWA slots; earlier tokens map to 0.
         swa_window = getattr(self.device_pool, "swa_window_size", need_size)
         num_swa = min(need_size, max(swa_window, self.page_size))
         swa_indices = swa_allocator.alloc(num_swa)
         if swa_indices is None:
             full_allocator.free(full_indices)
             return None
-        # full_to_swa_index_mapping[full_indices[i]] = swa_indices[i % num_swa]
-        swa_indices_aliased = swa_indices[
-            torch.arange(len(full_indices), device=full_indices.device) % num_swa
-        ]
+        swa_indices_aliased = torch.zeros(
+            len(full_indices), dtype=swa_indices.dtype, device=swa_indices.device
+        )
+        swa_indices_aliased[-num_swa:] = swa_indices
         allocator.set_full_to_swa_mapping(full_indices, swa_indices_aliased)
         return full_indices
 


### PR DESCRIPTION
## Fixes

1. **SWA budget** — `match_prefix` reports `swa_host_hit_length = min(host_hit_length, max(sliding_window, page_size))` so the scheduler accounts for SWA slots occupied by an EIC load-back.
2. **SWA double-free** — `alloc_device_indices` maps only the trailing window to real SWA slots (earlier tokens → 0) instead of modulo aliasing.
3. **PD prefill batch=1 on PP=1** — `get_num_allocatable_reqs` uses `max_running_requests` when `pp_size == 1`; `pp_max_micro_batch_size` only bounds PP>1.
4. **Async write copy** — `async_batch_set` records a CUDA event instead of synchronizing the write stream; the client write thread waits on it before `mset`.

## Verification

PD cluster, DSV4 prefill tp8, `write_back`, cc32 × 4096-token prefix, same pod, JIT warm:

| | EIC | no-EIC |
|---|---|---|
| TTFT p50 / p99 | **1.95s / 2.42s** | 4.8s / 4.9s |
| throughput | **16.1 req/s** | 6.9 req/s |

Single-node: EIC hit rate 99.84% (10k–70k prompts), TTFT speedup 1.24×–2.71×.

## Deployment note (config, not code)

The original 13s TTFT on the PD cluster was caused by EIC flag `--eic_use_polling_mode=true`: 128 `eic_io` threads busy-polled (~2060% CPU idle), exhausting the pod's 20-core CFS quota (90% periods throttled) and starving the scheduler. Set it to `false`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->