### PR TITLE
[DSV4][DSpark] Make KV pool budgeting PP-aware

### DIFF
--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -352,7 +352,14 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.qk_nope_head_dim = cfg.qk_nope_head_dim
         self.qk_rope_head_dim = cfg.qk_rope_head_dim
         self.indexer_head_dim = cfg.index_head_dim
-        self.compression_ratios = cfg.compress_ratios
+        # PP-local slice; matches DeepSeekV4TokenToKVPool's stage_ratios.
+        self.compression_ratios = cfg.compress_ratios[mr.start_layer : mr.end_layer]
+        if mr.pp_size > 1:
+            logger.info(
+                f"DSV4 pool PP slice: rank={mr.pp_group.rank_in_group} "
+                f"layers=[{mr.start_layer},{mr.end_layer}) "
+                f"local={len(self.compression_ratios)}/{len(cfg.compress_ratios)}"
+            )
         self.swa_page_size = cfg.window_size
         self.swa_ratio = mr.server_args.swa_full_tokens_ratio
         self.is_speculative = (

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -395,7 +395,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             )
 
         self.bytes_per_full_token = self._get_bytes_per_full_token()
-        if self.is_speculative:
+        if self.is_speculative and self._should_budget_draft_pool(mr):
             self.bytes_per_full_token += self._get_draft_bytes_per_full_token(mr)
 
         # Online c128 keeps a single in-progress (max, sum, kv) state per index
@@ -427,6 +427,26 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 logger.info(
                     "DSV4 compressed attention: online c128 enabled (ring_size=1)"
                 )
+
+    @staticmethod
+    def _should_budget_draft_pool(mr: ModelRunner) -> bool:
+        """Return whether this PP stage owns the speculative draft KV pool.
+
+        DSV4 DSpark PD prefill keeps the full draft SWA pool on the final PP
+        stage, matching ``prepare_dspark_hicache_draft_plan``. Earlier stages
+        either have no draft pool or retain only a one-page lifecycle pool, so
+        charging the full packed draft geometry there understates the shared PP
+        token capacity. Other speculative layouts keep the existing budgeting
+        behavior.
+        """
+
+        if not mr.spec_algorithm.is_dspark():
+            return True
+        return not (
+            mr.server_args.disaggregation_mode == "prefill"
+            and mr.pp_size > 1
+            and mr.pp_rank != mr.pp_size - 1
+        )
 
     def _get_draft_bytes_per_full_token(self, mr: ModelRunner) -> float:
         """Return the draft pool's flat contribution to one target full token."""

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -343,7 +343,44 @@ class TestDSV4DSparkDraftKvBudget(unittest.TestCase):
         def is_eagle():
             return False
 
-    def test_uses_packed_draft_geometry_and_all_stages(self):
+    def _make_runner(
+        self,
+        *,
+        pp_rank=0,
+        pp_size=1,
+        start_layer=0,
+        end_layer=3,
+        compress_ratios=None,
+    ):
+        if compress_ratios is None:
+            compress_ratios = [0, 0, 0]
+        return SimpleNamespace(
+            model_config=SimpleNamespace(
+                qk_nope_head_dim=448,
+                qk_rope_head_dim=64,
+                index_head_dim=128,
+                compress_ratios=compress_ratios,
+                window_size=128,
+            ),
+            server_args=SimpleNamespace(
+                swa_full_tokens_ratio=0.1,
+                speculative_algorithm="DSPARK",
+                effective_speculative_algorithm="DSPARK",
+                max_speculative_num_draft_tokens=6,
+                disaggregation_mode="prefill",
+            ),
+            enable_hisparse=False,
+            spec_algorithm=self._DSparkAlgorithm(),
+            dspark_draft_num_layers=3,
+            dspark_draft_cell_size_per_token=584,
+            start_layer=start_layer,
+            end_layer=end_layer,
+            pp_rank=pp_rank,
+            pp_size=pp_size,
+            pp_group=SimpleNamespace(rank_in_group=pp_rank),
+        )
+
+    def test_uses_packed_draft_geometry(self):
         from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
             get_dsv4_kv_bytes_per_token,
         )
@@ -372,28 +409,48 @@ class TestDSV4DSparkDraftKvBudget(unittest.TestCase):
     def test_configurator_adds_exact_flat_draft_term(self):
         from sglang.srt.model_executor.pool_configurator import DSV4PoolConfigurator
 
-        runner = SimpleNamespace(
-            model_config=SimpleNamespace(
-                qk_nope_head_dim=448,
-                qk_rope_head_dim=64,
-                index_head_dim=128,
-                compress_ratios=[0, 0, 0],
-                window_size=128,
-            ),
-            server_args=SimpleNamespace(
-                swa_full_tokens_ratio=0.1,
-                speculative_algorithm="DSPARK",
-                effective_speculative_algorithm="DSPARK",
-                max_speculative_num_draft_tokens=6,
-            ),
-            enable_hisparse=False,
-            spec_algorithm=self._DSparkAlgorithm(),
-            dspark_draft_num_layers=3,
-            dspark_draft_cell_size_per_token=584,
-        )
+        runner = self._make_runner()
 
         configurator = DSV4PoolConfigurator(runner)
         target_bytes = 0.1 * 584 * 3
+        draft_bytes = 0.1 * 584 * 3
+        self.assertAlmostEqual(
+            configurator.bytes_per_full_token,
+            target_bytes + draft_bytes,
+        )
+
+    def test_pp_uses_only_local_target_layers(self):
+        from sglang.srt.model_executor.pool_configurator import DSV4PoolConfigurator
+
+        runner = self._make_runner(
+            pp_rank=1,
+            pp_size=4,
+            start_layer=2,
+            end_layer=4,
+            compress_ratios=[0] * 8,
+        )
+
+        configurator = DSV4PoolConfigurator(runner)
+
+        self.assertEqual(configurator.compression_ratios, [0, 0])
+        self.assertAlmostEqual(
+            configurator.bytes_per_full_token,
+            0.1 * 584 * 2,
+        )
+
+    def test_final_pp_stage_budgets_packed_draft_pool(self):
+        from sglang.srt.model_executor.pool_configurator import DSV4PoolConfigurator
+
+        runner = self._make_runner(
+            pp_rank=3,
+            pp_size=4,
+            start_layer=6,
+            end_layer=8,
+            compress_ratios=[0] * 8,
+        )
+
+        configurator = DSV4PoolConfigurator(runner)
+        target_bytes = 0.1 * 584 * 2
         draft_bytes = 0.1 * 584 * 3
         self.assertAlmostEqual(
             configurator.bytes_per_full_token,


### PR DESCRIPTION
<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->