### PR TITLE
[HiCache][DSV4] Fix EIC write_through batch starvation: lock leaf only, async GPU→CPU copy

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2452,7 +2452,10 @@ class Scheduler(
         return ret
 
     def get_num_allocatable_reqs(self, running_bs):
-        res = get_global_server_args().pp_max_micro_batch_size - running_bs
+        if self.ps.pp_size > 1:
+            res = get_global_server_args().pp_max_micro_batch_size - running_bs
+        else:
+            res = self.max_running_requests - running_bs
         res = min(res, self.req_to_token_pool.available_size())
         return res
 

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -383,7 +383,11 @@ class EICHiRadixCache(RadixCache):
             node.host_value = host_indices
             self.ongoing_write_through[node.id] = node
             if not write_back:
-                self.inc_lock_ref(node)
+                # ponytail: lock only the leaf; ancestors are protected by
+                # their other resident children, so locking them just removes
+                # shared-prefix tokens from evictable_size and starves batch
+                # formation during the ~600ms EIC write.
+                self.inc_lock_ref(node, lock_ancestors=False)
         else:
             return 0
 
@@ -550,7 +554,9 @@ class EICHiRadixCache(RadixCache):
                         self.cache_controller.mem_pool_host.free(node.host_value)
                     node.host_value = None
             if not write_back:
-                self.dec_lock_ref(self.ongoing_write_through[ack_id])
+                self.dec_lock_ref(
+                    self.ongoing_write_through[ack_id], lock_ancestors=False
+                )
             # clear the reference
             del self.ongoing_write_through[ack_id]
         cost_time = time.perf_counter() - write_check_start_time
@@ -1822,7 +1828,11 @@ class EICPagedHiRadixCache(EICHiRadixCache):
             node.host_value = host_indices
             self.ongoing_write_through[node.id] = node
             if not write_back:
-                self.inc_lock_ref(node)
+                # ponytail: lock only the leaf; ancestors are protected by
+                # their other resident children, so locking them just removes
+                # shared-prefix tokens from evictable_size and starves batch
+                # formation during the ~600ms EIC write.
+                self.inc_lock_ref(node, lock_ancestors=False)
         else:
             return 0
 

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -386,7 +386,12 @@ class EICKVClient:
     def _write_thread(self):
         logger.info(f"start write thread thread_id {threading.get_ident()}")
         while True:
-            keys, values = self.write_queue.get()
+            keys, values, copy_event = self.write_queue.get()
+            if copy_event is not None:
+                # ponytail: wait for the GPU→CPU copy here, not in the
+                # caller's thread, so the cache-controller write thread can
+                # continue queuing writes while the copy is in flight.
+                copy_event.synchronize()
             self._async_set_impl(keys, values)
             for value in values:
                 if self.kv_cache_write_mem_pool.check_data_ptr_allocated(
@@ -412,13 +417,19 @@ class EICKVClient:
             if objs is None:
                 return False
 
+            copy_event = None
             if obj_inputs is not None:
                 write_stream = torch.cuda.current_stream()
                 with torch.cuda.stream(write_stream):
                     for i in range(len(keys)):
                         objs[i] = objs[i].reshape(obj_inputs[i].shape)
                         objs[i].copy_(obj_inputs[i], non_blocking=True)
-                write_stream.synchronize()
+                # ponytail: record an event instead of synchronizing; the
+                # write thread waits on it before mset. Frees the caller
+                # (cache-controller write thread) from blocking ~600ms on
+                # the GPU→CPU copy.
+                copy_event = torch.cuda.Event()
+                copy_event.record(write_stream)
             elif device_indices is not None and copy_func is not None:
                 copy_func(device_indices, objs)
             else:
@@ -426,7 +437,7 @@ class EICKVClient:
                     "async set impl input obj_inputs and device_indices are both None"
                 )
                 return False
-            self.write_queue.put((keys, objs))
+            self.write_queue.put((keys, objs, copy_event))
 
             cost_time = time.perf_counter() - start_time
             if cost_time >= 0.5:
@@ -450,7 +461,7 @@ class EICKVClient:
                     "async set impl input obj_inputs and device_indices are both None"
                 )
                 return False
-            self.write_queue.put((keys, objs))
+            self.write_queue.put((keys, objs, None))
             logger.warning(
                 f"async batch set fallback to malloc, cost {(time.perf_counter() - start_time) * 1e3}.2f ms, {len(keys)} keys"
             )

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -825,7 +825,9 @@ class HiRadixCache(RadixCache):
         """Convert raw token_ids to a RadixKey; must be list (not tuple) for paged match."""
         return RadixKey(token_ids=list(token_ids))
 
-    def inc_lock_ref(self, node: TreeNode) -> IncLockRefResult:
+    def inc_lock_ref(
+        self, node: TreeNode, lock_ancestors: bool = True
+    ) -> IncLockRefResult:
         if self.disable:
             return IncLockRefResult(delta=0)
 
@@ -838,11 +840,16 @@ class HiRadixCache(RadixCache):
             node.lock_ref += 1
             self._update_leaf_status(node)
             self._update_host_leaf_status(node)
+            if not lock_ancestors:
+                break
             node = node.parent
         return IncLockRefResult(delta=delta)
 
     def dec_lock_ref(
-        self, node: TreeNode, params: Optional[DecLockRefParams] = None
+        self,
+        node: TreeNode,
+        params: Optional[DecLockRefParams] = None,
+        lock_ancestors: bool = True,
     ) -> DecLockRefResult:
         if self.disable:
             return DecLockRefResult(delta=0)
@@ -856,6 +863,8 @@ class HiRadixCache(RadixCache):
             node.lock_ref -= 1
             self._update_leaf_status(node)
             self._update_host_leaf_status(node)
+            if not lock_ancestors:
+                break
             if node.parent is None:
                 assert (
                     node is self.root_node

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -589,7 +589,9 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         self.update_eviction_metrics(num_evicted, start_time)
         return EvictResult(num_tokens_evicted=num_evicted)
 
-    def inc_lock_ref(self, node: TreeNode) -> IncLockRefResult:
+    def inc_lock_ref(
+        self, node: TreeNode, lock_ancestors: bool = True
+    ) -> IncLockRefResult:
         if self.disable:
             return IncLockRefResult(delta=0)
 
@@ -601,11 +603,16 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
                 delta -= len(node.key)
             node.lock_ref += 1
             self._update_leaf_status(node)
+            if not lock_ancestors:
+                break
             node = node.parent
         return IncLockRefResult(delta=delta)
 
     def dec_lock_ref(
-        self, node: TreeNode, params: Optional[DecLockRefParams] = None
+        self,
+        node: TreeNode,
+        params: Optional[DecLockRefParams] = None,
+        lock_ancestors: bool = True,
     ) -> DecLockRefResult:
         if self.disable:
             return DecLockRefResult(delta=0)
@@ -618,6 +625,8 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
                 delta += len(node.key)
             node.lock_ref -= 1
             self._update_leaf_status(node)
+            if not lock_ancestors:
+                break
             if node.parent is None:
                 assert (
                     node is self.root_node


### PR DESCRIPTION
## Problem

Under concurrent load, prefill batch=1 causing 300x throughput loss. Two root causes:

1. **EIC write lock starvation**: `write_backup(write_back=False)` called `inc_lock_ref(node)` which locked the node **and all ancestors**, removing shared-prefix tokens from `evictable_size_`. During the ~600ms EIC write, `rem_total_tokens` budget shrank to fit only 1 request → `add_one_req` returned `NO_TOKEN` → batch=1 serialization.

2. **pp_max_micro_batch_size cap**: `get_num_allocatable_reqs()` unconditionally used `pp_max_micro_batch_size` as the upper bound for allocatable requests. When deployment sets `--pp-max-micro-batch-size 1` (a PP>1 micro-batch limit) but `pp_size==1`, every prefill batch was capped to 1 request.

## Fix 1: Lock leaf only

Add `lock_ancestors` param to `RadixCache`/`HiRadixCache` `inc_lock_ref` and `dec_lock_ref`. `write_backup`/`writing_check` pass `lock_ancestors=False` — ancestors are protected by their other resident children, so locking them just starves batch formation during the EIC write window.

## Fix 2: Async GPU→CPU copy

`async_batch_set` did `write_stream.synchronize()` (~600ms blocking) before queuing to the EIC write thread. Replace with a CUDA event recorded on the write stream; the event is passed through the write queue and the EIC write thread waits on it before `mset`. Frees the caller from blocking on the copy.

## Fix 3: Don't cap by pp_max_micro_batch_size when pp_size==1

`get_num_allocatable_reqs()` now uses `max_running_requests` instead of `pp_max_micro_batch_size` when `pp_size==1`, matching the auto-compute logic at scheduler init (`max_running_requests // pp_size`).

## Test plan

- [x] `py_compile` passes on all files
- [x] 8-concurrent test: batch 1→8, throughput 34→10400 tok/s (300x)
- [ ] Long-duration EIC vs no-EIC comparison (in progress)