### PR TITLE
[DSV4][DSpark] Support PP/CP/DP/DeepEP

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -279,18 +279,20 @@ def _handle_dspark(server_args: ServerArgs) -> None:
     if not server_args.device.startswith("cuda"):
         raise ValueError("DSpark speculative decoding only supports CUDA device.")
 
-    if server_args.enable_dp_attention:
+    # dp_size==1 with dp_attention is a degenerate flag under DSV4 CP; skip DP-only checks.
+    if server_args.enable_dp_attention and server_args.dp_size > 1:
         if not server_args.enable_dp_lm_head:
             raise ValueError("DSpark with dp attention requires --enable-dp-lm-head.")
-        if server_args.moe_a2a_backend != "none":
+        supports_dspark_dp_moe = server_args.moe_a2a_backend == "none" or (
+            server_args.moe_a2a_backend == "deepep"
+            and server_args.moe_runner_backend == "deep_gemm"
+        )
+        if not supports_dspark_dp_moe:
             raise ValueError(
-                "DSpark with dp attention only supports the built-in TP MoE "
-                f"(moe_a2a_backend='none'), got {server_args.moe_a2a_backend!r}."
-            )
-        if server_args.attn_cp_size > 1:
-            raise ValueError(
-                "DSpark with dp attention does not support context parallel "
-                f"(attn_cp_size={server_args.attn_cp_size})."
+                "DSpark with dp attention only supports moe_a2a_backend='none' "
+                "or moe_a2a_backend='deepep' with moe_runner_backend='deep_gemm'; "
+                f"got moe_a2a_backend={server_args.moe_a2a_backend!r}, "
+                f"moe_runner_backend={server_args.moe_runner_backend!r}."
             )
         if (
             server_args.speculative_moe_a2a_backend is not None
@@ -302,9 +304,13 @@ def _handle_dspark(server_args: ServerArgs) -> None:
                 f"(got {server_args.speculative_moe_a2a_backend!r})."
             )
 
-    if server_args.pp_size != 1:
+    if server_args.pp_size != 1 and server_args.disaggregation_mode not in (
+        "prefill",
+        "decode",
+    ):
         raise ValueError(
-            "Currently DSpark speculative decoding only supports pp_size == 1."
+            "Currently DSpark speculative decoding with pp_size > 1 is only "
+            "supported under PD disaggregation."
         )
 
     if server_args.speculative_draft_model_path is None:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -52,6 +52,8 @@ from sglang.srt.disaggregation.utils import (
     _is_fake_transfer,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_transfer_draft_kv_layer_ids,
+    get_transfer_kv_layer_ids,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce,
@@ -434,6 +436,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             transfer_kv_pool.get_contiguous_buf_infos()
         )
+        kv_layer_ids = get_transfer_kv_layer_ids(
+            self.token_to_kv_pool, len(kv_data_ptrs)
+        )
         kv_data_mem_kinds = (
             ["DRAM"] * len(kv_data_ptrs)
             if self.scheduler.enable_hisparse
@@ -449,6 +454,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_data_ptrs += device_kv_data_ptrs[c4_layer_num:]
             kv_data_lens += device_kv_data_lens[c4_layer_num:]
             kv_item_lens += device_kv_item_lens[c4_layer_num:]
+            kv_layer_ids = []
             kv_data_mem_kinds += ["VRAM"] * len(device_kv_data_ptrs[c4_layer_num:])
         if self.draft_token_to_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are
@@ -456,6 +462,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
+            kv_layer_ids += get_transfer_draft_kv_layer_ids(len(draft_kv_data_ptrs))
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
@@ -465,10 +472,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
         kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
+            kv_layer_ids if len(kv_layer_ids) == len(kv_data_ptrs) else []
         )
         if self.transfer_backend == TransferBackend.NIXL:
             kv_args.kv_data_mem_kinds = kv_data_mem_kinds

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -46,7 +46,10 @@ from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
+    pack_state_types,
     resolve_dcp_dst_entry_indices,
+    resolve_state_component_dst_index,
+    unpack_state_types,
 )
 from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs
@@ -140,6 +143,7 @@ class KVArgsRegisterInfo:
     dst_state_dim_per_tensor: List[List[int]]
     dst_kv_layer_ids: List[int]
     dst_state_layer_ids: List[List[int]]
+    dst_state_types: List[StateType] = dataclasses.field(default_factory=list)
     dst_dcp_size: int = 1
     dst_dcp_rank: int = 0
     requires_dcp_relayout: bool = False
@@ -176,6 +180,7 @@ class KVArgsRegisterInfo:
                 if len(msg) > 13 and msg[13] != b""
                 else []
             ),
+            dst_state_types=unpack_state_types(msg[18]) if len(msg) > 18 else [],
             # msg[14:16] belong to the staging field below; DCP trails it.
             dst_dcp_size=(
                 int(msg[16].decode("ascii")) if len(msg) > 16 and msg[16] != b"" else 1
@@ -1207,32 +1212,52 @@ class MooncakeKVManager(CommonKVManager):
             src_state_layer_ids = (
                 src_state_layer_ids[i] if i < len(src_state_layer_ids) else []
             )
+            dst_component_index = i
             if target_rank_registration_info is not None:
+                dst_component_index = resolve_state_component_dst_index(
+                    state_types,
+                    target_rank_registration_info.dst_state_types,
+                    i,
+                )
                 dst_data_ptrs = (
-                    target_rank_registration_info.dst_state_data_ptrs[i]
-                    if i < len(target_rank_registration_info.dst_state_data_ptrs)
+                    target_rank_registration_info.dst_state_data_ptrs[
+                        dst_component_index
+                    ]
+                    if dst_component_index
+                    < len(target_rank_registration_info.dst_state_data_ptrs)
                     else []
                 )
                 dst_item_lens = (
-                    target_rank_registration_info.dst_state_item_lens[i]
-                    if i < len(target_rank_registration_info.dst_state_item_lens)
+                    target_rank_registration_info.dst_state_item_lens[
+                        dst_component_index
+                    ]
+                    if dst_component_index
+                    < len(target_rank_registration_info.dst_state_item_lens)
                     else []
                 )
                 dst_dim_per_tensor = (
-                    target_rank_registration_info.dst_state_dim_per_tensor[i]
-                    if i < len(target_rank_registration_info.dst_state_dim_per_tensor)
+                    target_rank_registration_info.dst_state_dim_per_tensor[
+                        dst_component_index
+                    ]
+                    if dst_component_index
+                    < len(target_rank_registration_info.dst_state_dim_per_tensor)
                     else []
                 )
                 dst_state_layer_ids = (
-                    target_rank_registration_info.dst_state_layer_ids[i]
-                    if i < len(target_rank_registration_info.dst_state_layer_ids)
+                    target_rank_registration_info.dst_state_layer_ids[
+                        dst_component_index
+                    ]
+                    if dst_component_index
+                    < len(target_rank_registration_info.dst_state_layer_ids)
                     else []
                 )
             else:
                 dst_data_ptrs, dst_item_lens, dst_dim_per_tensor = [], [], []
                 dst_state_layer_ids = []
             dst_indices = (
-                req.dst_state_indices[i] if i < len(req.dst_state_indices) else []
+                req.dst_state_indices[dst_component_index]
+                if dst_component_index < len(req.dst_state_indices)
+                else []
             )
 
             if st == StateType.MAMBA:
@@ -2257,6 +2282,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
             packed_state_layer_ids = pack_int_lists(
                 self.kv_mgr.kv_args.state_layer_ids, "I"
             )
+            packed_state_types = pack_state_types(self.kv_mgr.kv_args.state_types)
             packed_kv_layer_ids = b"".join(
                 struct.pack("I", layer_id)
                 for layer_id in self.kv_mgr.kv_args.kv_layer_ids
@@ -2309,6 +2335,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
                             staging_total_size_str,
                             dst_dcp_size,
                             dst_dcp_rank,
+                            packed_state_types,
                         ]
                     )
             except zmq.ZMQError:

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -41,7 +41,10 @@ from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
+    pack_state_types,
     resolve_dcp_dst_entry_indices,
+    resolve_state_component_dst_index,
+    unpack_state_types,
 )
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_schedule
@@ -231,6 +234,7 @@ class KVArgsRegisterInfo:
     dst_state_item_lens: List[List[int]] = dataclasses.field(default_factory=list)
     dst_state_dim_per_tensor: List[List[int]] = dataclasses.field(default_factory=list)
     dst_state_layer_ids: List[List[int]] = dataclasses.field(default_factory=list)
+    dst_state_types: List[StateType] = dataclasses.field(default_factory=list)
     dst_homogeneous_mem_kind: Optional[str] = None
     kv_xfer_segments: Optional[List[_KVXferPreparedSegment]] = None
     # Keep last: optional, parsed from a variable-length tail of the ZMQ
@@ -276,6 +280,7 @@ class KVArgsRegisterInfo:
             if len(msg) > 20 and msg[20] != b""
             else []
         )
+        dst_state_types = unpack_state_types(msg[23]) if len(msg) > 23 else []
 
         return cls(
             room=str(msg[0].decode("ascii")),
@@ -304,6 +309,7 @@ class KVArgsRegisterInfo:
             dst_state_item_lens=dst_state_item_lens,
             dst_state_dim_per_tensor=dst_state_dim_per_tensor,
             dst_state_layer_ids=dst_state_layer_ids,
+            dst_state_types=dst_state_types,
             staging=StagingRegisterInfo.from_zmq_fields(msg, 14),
         )
 
@@ -1283,6 +1289,7 @@ class NixlKVManager(CommonKVManager):
                                 dst_state_item_lens=dst_info.dst_state_item_lens,
                                 dst_state_dim_per_tensor=dst_info.dst_state_dim_per_tensor,
                                 dst_state_layer_ids=dst_info.dst_state_layer_ids,
+                                dst_state_types=dst_info.dst_state_types,
                             )
                             handles.extend(
                                 h for h in state_xfer_handles if h is not None
@@ -2208,6 +2215,7 @@ class NixlKVManager(CommonKVManager):
         dst_state_item_lens: List[List[int]] | None = None,
         dst_state_dim_per_tensor: List[List[int]] | None = None,
         dst_state_layer_ids: List[List[int]] | None = None,
+        dst_state_types: List[StateType] | None = None,
     ):
         """Send state per hybrid component, dispatching by state_type[i]."""
         state_types = getattr(self.kv_args, "state_types", []) or []
@@ -2226,9 +2234,15 @@ class NixlKVManager(CommonKVManager):
         dst_state_item_lens = dst_state_item_lens or []
         dst_state_dim_per_tensor = dst_state_dim_per_tensor or []
         dst_state_layer_ids = dst_state_layer_ids or []
+        dst_state_types = dst_state_types or []
 
         handles = []
         for i, st in enumerate(state_types):
+            dst_component_index = resolve_state_component_dst_index(
+                state_types,
+                dst_state_types,
+                i,
+            )
             src_indices = (
                 prefill_state_indices[i] if i < len(prefill_state_indices) else None
             )
@@ -2250,13 +2264,31 @@ class NixlKVManager(CommonKVManager):
                 else []
             )
             src_lids = src_state_layer_ids[i] if i < len(src_state_layer_ids) else []
-            dst_ptrs = dst_state_data_ptrs[i] if i < len(dst_state_data_ptrs) else []
-            dst_indices = dst_state_indices[i] if i < len(dst_state_indices) else []
-            dst_lens = dst_state_item_lens[i] if i < len(dst_state_item_lens) else []
-            dst_dims = (
-                dst_state_dim_per_tensor[i] if i < len(dst_state_dim_per_tensor) else []
+            dst_ptrs = (
+                dst_state_data_ptrs[dst_component_index]
+                if dst_component_index < len(dst_state_data_ptrs)
+                else []
             )
-            dst_lids = dst_state_layer_ids[i] if i < len(dst_state_layer_ids) else []
+            dst_indices = (
+                dst_state_indices[dst_component_index]
+                if dst_component_index < len(dst_state_indices)
+                else []
+            )
+            dst_lens = (
+                dst_state_item_lens[dst_component_index]
+                if dst_component_index < len(dst_state_item_lens)
+                else []
+            )
+            dst_dims = (
+                dst_state_dim_per_tensor[dst_component_index]
+                if dst_component_index < len(dst_state_dim_per_tensor)
+                else []
+            )
+            dst_lids = (
+                dst_state_layer_ids[dst_component_index]
+                if dst_component_index < len(dst_state_layer_ids)
+                else []
+            )
             comp_notif = f"{notif}_{i}"
 
             if st == StateType.MAMBA:
@@ -2952,6 +2984,7 @@ class NixlKVReceiver(CommonKVReceiver):
             packed_state_layer_ids = pack_int_lists(
                 self.kv_mgr.kv_args.state_layer_ids, "I"
             )
+            packed_state_types = pack_state_types(self.kv_mgr.kv_args.state_types)
 
             # Include staging allocator metadata if available
             if (
@@ -3000,6 +3033,7 @@ class NixlKVReceiver(CommonKVReceiver):
                             packed_kv_layer_ids,
                             str(self.kv_mgr.dcp_size).encode("ascii"),
                             str(self.kv_mgr.dcp_rank).encode("ascii"),
+                            packed_state_types,
                         ]
                     )
             except zmq.ZMQError:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -24,7 +24,7 @@ import logging
 from array import array
 from collections import deque
 from http import HTTPStatus
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -41,6 +41,8 @@ from sglang.srt.disaggregation.utils import (
     TransferBackend,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_transfer_draft_kv_layer_ids,
+    get_transfer_kv_layer_ids,
     is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
@@ -193,8 +195,8 @@ class PrefillBootstrapQueue:
         layer_shard_rank = getattr(self.token_to_kv_pool, "layer_shard_rank", None)
         layer_shard_size = getattr(self.token_to_kv_pool, "layer_shard_size", 1)
         transfer_draft_cache = (
-            not layer_shard_enabled or layer_shard_rank == layer_shard_size - 1
-        )
+            self.pp_size <= 1 or self.pp_rank == self.pp_size - 1
+        ) and (not layer_shard_enabled or layer_shard_rank == layer_shard_size - 1)
         kv_args.prefill_start_layer = (
             getattr(
                 self.token_to_kv_pool,
@@ -208,6 +210,9 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
+        kv_layer_ids = get_transfer_kv_layer_ids(
+            self.token_to_kv_pool, len(kv_data_ptrs)
+        )
         kv_args.prefill_end_layer = (
             kv_args.prefill_start_layer + len(kv_data_ptrs)
             if layer_shard_enabled
@@ -220,6 +225,7 @@ class PrefillBootstrapQueue:
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
+            kv_layer_ids += get_transfer_draft_kv_layer_ids(len(draft_kv_data_ptrs))
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
@@ -228,10 +234,7 @@ class PrefillBootstrapQueue:
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
         kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
+            kv_layer_ids if len(kv_layer_ids) == len(kv_data_ptrs) else []
         )
         if not self.is_mla_backend:
             kv_args.kv_head_num = self.token_to_kv_pool.head_num
@@ -459,6 +462,43 @@ class PrefillBootstrapQueue:
             return bootstrapped_reqs
         else:
             return bootstrapped_reqs, failed_reqs
+
+    def get_ready_bootstrapped_rids_for_pp(self) -> Tuple[List[str], List[str]]:
+        """Return ordered PP candidates without reserving local resources."""
+        good_rids: List[str] = []
+        failed_rids: List[str] = []
+        if len(self.queue) == 0:
+            return good_rids, failed_rids
+
+        polls = poll_and_all_reduce_attn_cp_tp_group(
+            [req.disagg_kv_sender for req in self.queue],
+            self.scheduler.attn_cp_cpu_group,
+            self.scheduler.attn_tp_cpu_group,
+        )
+        metadata_credits = self.req_to_metadata_buffer_idx_allocator.available_size()
+        admission_blocked = False
+
+        for req, poll in zip(self.queue, polls):
+            if poll == KVPoll.Failed:
+                failed_rids.append(req.rid)
+            elif poll == KVPoll.WaitingForInput:
+                if admission_blocked:
+                    continue
+                metadata_cost = 1 if req.metadata_buffer_index < 0 else 0
+                if metadata_cost > metadata_credits:
+                    admission_blocked = True
+                    continue
+                metadata_credits -= metadata_cost
+                good_rids.append(req.rid)
+            elif poll == KVPoll.Bootstrapping:
+                continue
+            else:
+                raise RuntimeError(
+                    f"Unexpected poll state {poll} for req {req.rid} "
+                    "in get_ready_bootstrapped_rids_for_pp"
+                )
+
+        return good_rids, failed_rids
 
     def release_memory_occupation(self):
         self.queue.clear()
@@ -815,16 +855,19 @@ class SchedulerDisaggregationPrefillMixin:
         )
 
     def process_disagg_prefill_inflight_queue(
-        self: Scheduler, rids_to_check: Optional[List[str]] = None
+        self: Scheduler,
+        transfer_status: Optional[Tuple[List[str], List[str]]] = None,
     ) -> List[Req]:
         """
         Poll the requests in the middle of transfer. If done, return the request.
-        rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
+        transfer_status: For PP, the consensus success and failure request ids.
         """
         if len(self.disagg_prefill_inflight_queue) == 0:
             return []
 
         done_reqs = []
+        success_rids = set(transfer_status[0]) if transfer_status is not None else set()
+        failed_rids = set(transfer_status[1]) if transfer_status is not None else set()
 
         polls = poll_and_all_reduce_attn_cp_tp_group(
             [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
@@ -835,8 +878,32 @@ class SchedulerDisaggregationPrefillMixin:
         undone_reqs: List[Req] = []
         # Check .poll() for the reqs in disagg_prefill_inflight_queue. If Success, respond to the client and remove it from the queue
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
-            if rids_to_check is not None:
-                if req.rid not in rids_to_check:
+            if transfer_status is not None:
+                consensus_failed = req.rid in failed_rids
+                failure_pending = isinstance(req.finished_reason, FINISH_ABORT)
+                if consensus_failed or failure_pending:
+                    if consensus_failed and not failure_pending:
+                        prepare_abort(
+                            req,
+                            (
+                                "Prefill transfer failed on another PP rank; "
+                                "waiting for the local transfer to stop"
+                            ),
+                            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                        )
+                    local_transfer_stopped = req.pending_bootstrap or poll in (
+                        KVPoll.Success,
+                        KVPoll.Failed,
+                    )
+                    if not local_transfer_stopped:
+                        undone_reqs.append(req)
+                        continue
+
+                    self.handle_inflight_transfer_failure(req)
+                    done_reqs.append(req)
+                    continue
+
+                if req.rid not in success_rids:
                     undone_reqs.append(req)
                     continue
 
@@ -950,9 +1017,11 @@ class SchedulerDisaggregationPrefillMixin:
             self.metrics_collector.increment_transfer_failed_reqs()
         return exc
 
-    def get_transferred_rids(self: Scheduler) -> List[str]:
+    def get_transferred_rids(
+        self: Scheduler,
+    ) -> Tuple[List[str], List[str]]:
         """
-        Used by PP, get the transferred rids but **do not pop**
+        Used by PP, inspect terminal transfer states without popping requests.
         """
         polls = poll_and_all_reduce_attn_cp_tp_group(
             [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
@@ -960,13 +1029,16 @@ class SchedulerDisaggregationPrefillMixin:
             self.attn_tp_cpu_group,
         )
 
-        transferred_rids: List[str] = []
+        success_rids: List[str] = []
+        failed_rids: List[str] = []
 
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
-            if poll == KVPoll.Success or poll == KVPoll.Failed:
-                transferred_rids.append(req.rid)
+            if poll == KVPoll.Success:
+                success_rids.append(req.rid)
+            elif poll == KVPoll.Failed:
+                failed_rids.append(req.rid)
 
-        return transferred_rids
+        return success_rids, failed_rids
 
     def handle_bootstrap_failure(self: Scheduler, req: Req) -> None:
         error_message = (

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -959,6 +959,97 @@ def resolve_dcp_dst_entry_indices(
     ]
 
 
+_DRAFT_KV_LAYER_ID_BASE = 1_000_000
+
+
+def get_transfer_kv_layer_ids(kv_pool, num_entries: int) -> List[int]:
+    """Return global layer ids aligned with ``kv_pool.get_contiguous_buf_infos``.
+
+    Pools with a custom sparse/MLA layout expose ``get_kv_layer_ids`` directly.
+    Plain MHA-like draft pools usually expose only ``start_layer``/``end_layer``;
+    infer either one entry per layer or K/V tensor-major entries.
+    """
+    if kv_pool is None or num_entries <= 0:
+        return []
+
+    if hasattr(kv_pool, "get_kv_layer_ids"):
+        layer_ids = list(kv_pool.get_kv_layer_ids())
+        if len(layer_ids) == num_entries:
+            return layer_ids
+
+    start_layer = int(getattr(kv_pool, "start_layer", 0) or 0)
+    end_layer = getattr(kv_pool, "end_layer", None)
+    if end_layer is not None:
+        layer_ids = list(range(start_layer, int(end_layer)))
+        if len(layer_ids) == num_entries:
+            return layer_ids
+        if len(layer_ids) * 2 == num_entries:
+            return layer_ids * 2
+
+    return []
+
+
+def get_transfer_draft_kv_layer_ids(num_entries: int) -> List[int]:
+    """Return layer-id metadata for draft KV entries.
+
+    Draft KV is not target-model KV and should not share the target layer-id
+    namespace, especially when PP prefill sends target KV by layer subset but a
+    single rank also sends replicated draft KV.
+    """
+    if num_entries <= 0:
+        return []
+    return [_DRAFT_KV_LAYER_ID_BASE + i for i in range(num_entries)]
+
+
+def pack_state_types(state_types) -> bytes:
+    return ",".join(
+        state_type.value if hasattr(state_type, "value") else str(state_type)
+        for state_type in (state_types or [])
+    ).encode("ascii")
+
+
+def unpack_state_types(data: bytes):
+    from sglang.srt.disaggregation.base.conn import StateType
+
+    if not data:
+        return []
+    return [StateType(value) for value in data.decode("ascii").split(",") if value]
+
+
+def resolve_state_component_dst_index(src_state_types, dst_state_types, src_index: int):
+    """Map a source state component to the matching destination component.
+
+    Older registrations did not carry state_types; keep positional behavior in
+    that case. When available, match by StateType occurrence so optional target
+    components (for example C128_STATE) do not shift draft state components.
+    """
+    if not dst_state_types:
+        return src_index
+    if not src_state_types:
+        raise RuntimeError(
+            "Destination state_types are present but source state_types are empty."
+        )
+    if src_index >= len(src_state_types):
+        raise RuntimeError(
+            f"Source state component index {src_index} exceeds "
+            f"state_types length {len(src_state_types)}."
+        )
+    state_type = src_state_types[src_index]
+    occurrence = sum(
+        1 for item in src_state_types[: src_index + 1] if item == state_type
+    )
+    seen = 0
+    for dst_index, dst_state_type in enumerate(dst_state_types):
+        if dst_state_type == state_type:
+            seen += 1
+            if seen == occurrence:
+                return dst_index
+    raise RuntimeError(
+        f"Decode peer is missing state component {state_type!s} "
+        f"occurrence {occurrence}."
+    )
+
+
 def append_state_component(
     kv_args: KVArgs,
     state_type: StateType,

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1277,7 +1277,7 @@ class GroupCoordinator:
                 return torch.ops.sgl_kernel.shm_allgather(input_, dim)
             else:
                 torch.distributed.all_gather_into_tensor(
-                    output_tensor, input_, group=self.device_group
+                    output_tensor, input_, group=self.cpu_group
                 )
         else:
             self.all_gather_into_tensor(output_tensor, input_)

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -278,7 +279,10 @@ class DeepEPBuffer:
         #            auto-enables fabric in C++ when supported, so we skip it:
         #            https://github.com/fzyzcjy/DeepEP/blob/814e508537c6ffc775d59f6f1b9ba43f3a65968c/csrc/deep_ep.cpp#L52
         is_cu12 = get_cuda_version()[0] == 12
-        if not is_cu12 and use_mnnvl_fabric:
+        supports_use_fabric = (
+            "use_fabric" in inspect.signature(Buffer.__init__).parameters
+        )
+        if not is_cu12 and use_mnnvl_fabric and supports_use_fabric:
             buffer_kwargs["use_fabric"] = True
 
         state.buffer = Buffer(group, num_nvl_bytes, num_rdma_bytes, **buffer_kwargs)

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -6,7 +6,7 @@ import time
 from array import array
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -46,6 +46,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
 
+PPTransferStatus = Tuple[List[str], List[str]]
+PPReleasePayload = Union[List[str], PPTransferStatus]
+
 
 def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
     """Check if output send/recv can be skipped for this batch."""
@@ -57,6 +60,35 @@ def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
         and not batch.contains_last_prefill_chunk
         and not batch.return_logprob
     )
+
+
+def _pp_ordered_intersection(left: List[str], right: List[str]) -> List[str]:
+    right_set = set(right)
+    return [rid for rid in left if rid in right_set]
+
+
+def _pp_ordered_union(left: List[str], right: List[str]) -> List[str]:
+    seen = set(left)
+    merged = list(left)
+    for rid in right:
+        if rid not in seen:
+            seen.add(rid)
+            merged.append(rid)
+    return merged
+
+
+def _pp_merge_transfer_status(
+    previous: PPTransferStatus,
+    current: PPTransferStatus,
+) -> PPTransferStatus:
+    previous_success, previous_failed = previous
+    current_success, current_failed = current
+    failed = _pp_ordered_union(previous_failed, current_failed)
+    success = _pp_ordered_intersection(previous_success, current_success)
+    if failed:
+        failed_set = set(failed)
+        success = [rid for rid in success if rid not in failed_set]
+    return success, failed
 
 
 @dataclass
@@ -218,8 +250,8 @@ class SchedulerPPMixin:
         bmbs = [None] * self.pp_loop_size
         tmbs = [None] * self.pp_loop_size
         consensus_bootstrapped_rids: Optional[List[str]] = None
-        transferred_rids: List[str] = []
-        release_rids: Optional[List[str]] = None
+        transferred_rids: PPTransferStatus = ([], [])
+        release_rids: Optional[PPTransferStatus] = None
         send_bootstrapped_work = []
         send_transfer_work = []
         send_consensus_bootstrapped_work = []
@@ -817,18 +849,20 @@ class SchedulerPPMixin:
                 )
             )
             self.waiting_queue.extend(good_reqs)
-            return [[req.rid for req in good_reqs], [req.rid for req in failed_reqs]]
+            return [
+                [req.rid for req in good_reqs],
+                _pp_ordered_union(
+                    bad_consensus_bootstrapped_rids,
+                    [req.rid for req in failed_reqs],
+                ),
+            ]
         return None
 
     def _pp_pd_get_bootstrapped_ids(self: Scheduler):
         # communicate pre-consensus bootstrapp reqs
         if self.pp_group.is_first_rank:
-            # First rank, pop the bootstrap reqs from the bootstrap queue
-            good_bootstrapped_rids, bad_bootstrapped_rids = self.get_rids(
-                self.disagg_prefill_bootstrap_queue.queue,
-                True,
-                [KVPoll.WaitingForInput],
-                [KVPoll.Failed],
+            good_bootstrapped_rids, bad_bootstrapped_rids = (
+                self.disagg_prefill_bootstrap_queue.get_ready_bootstrapped_rids_for_pp()
             )
         else:
             # Other ranks, receive the bootstrap reqs info from the previous rank and ensure the consensus
@@ -836,17 +870,16 @@ class SchedulerPPMixin:
             prev_good_bootstrapped_rids, prev_bad_bootstrapped_rids = (
                 prev_bootstrapped_rids
             )
-            curr_good_bootstrapped_rids, curr_bad_bootstrapped_rids = self.get_rids(
-                self.disagg_prefill_bootstrap_queue.queue,
-                True,
-                [KVPoll.WaitingForInput],
-                [KVPoll.Failed],
+            curr_good_bootstrapped_rids, curr_bad_bootstrapped_rids = (
+                self.disagg_prefill_bootstrap_queue.get_ready_bootstrapped_rids_for_pp()
             )
-            good_bootstrapped_rids = list(
-                set(prev_good_bootstrapped_rids) & set(curr_good_bootstrapped_rids)
+            good_bootstrapped_rids = _pp_ordered_intersection(
+                prev_good_bootstrapped_rids,
+                curr_good_bootstrapped_rids,
             )
-            bad_bootstrapped_rids = list(
-                set(prev_bad_bootstrapped_rids) | set(curr_bad_bootstrapped_rids)
+            bad_bootstrapped_rids = _pp_ordered_union(
+                prev_bad_bootstrapped_rids,
+                curr_bad_bootstrapped_rids,
             )
         # Route locally-aborted reqs through the bad-union consensus so every PP
         # rank flushes them in the same consensus round, regardless of when the
@@ -862,28 +895,21 @@ class SchedulerPPMixin:
         )
         return [good_bootstrapped_rids, bad_bootstrapped_rids]
 
-    def _pp_pd_get_prefill_transferred_ids(self: Scheduler):
+    def _pp_pd_get_prefill_transferred_ids(
+        self: Scheduler,
+    ) -> PPTransferStatus:
         # get the current stage transfer success
+        current_status = self.get_transferred_rids()
         if self.pp_group.is_first_rank:
-            transferred_rids = self.get_rids(
-                self.disagg_prefill_inflight_queue,
-                True,
-                [KVPoll.Success, KVPoll.Failed],
-            )
+            transferred_rids = current_status
         # if other ranks, do intersection with the previous rank's transferred rids
         else:
             # 2 (Release): Receive the transferred rids from the previous rank
             # 1. recv previous stage's transferred reqs info
-            prev_transferred_rids = self._pp_recv_pyobj_from_prev_stage()
-            # 2. get the current stage's transferred reqs info
-            curr_transferred_rids = self.get_rids(
-                self.disagg_prefill_inflight_queue,
-                True,
-                [KVPoll.Success, KVPoll.Failed],
-            )
-            # 3. new consensus rids = intersection(previous consensus rids, transfer finished rids)
-            transferred_rids = list(
-                set(prev_transferred_rids) & set(curr_transferred_rids)
+            previous_status = self._pp_recv_pyobj_from_prev_stage()
+            transferred_rids = _pp_merge_transfer_status(
+                previous=previous_status,
+                current=current_status,
             )
         return transferred_rids
 
@@ -912,10 +938,10 @@ class SchedulerPPMixin:
 
     def _pp_pd_send_consensus_release_ids(
         self: Scheduler,
-        tmbs: List[List[str]],
+        tmbs: List[Optional[PPReleasePayload]],
         next_first_rank_mb_id: int,
-        release_rids: List[str],
-        transferred_rids: List[str],
+        release_rids: Optional[PPReleasePayload],
+        transferred_rids: PPReleasePayload,
     ):
         send_release_work = []
         if self.pp_group.is_last_rank:
@@ -1148,13 +1174,30 @@ class SchedulerPPMixin:
                 extend_input_len_per_req,
                 extend_logprob_start_len_per_req,
             ) = get_logprob_from_pp_outputs(pp_outputs)
-        next_token_ids = pp_outputs["next_token_ids"].to(torch.int64)
+        # PP outputs may be on CPU after result processing, while draft state is
+        # filtered with device-resident batch indices.
+        next_token_ids = pp_outputs["next_token_ids"].to(
+            device=batch.device,
+            dtype=torch.int64,
+            non_blocking=True,
+        )
         # PP rank 0 also relays into output_tokens_buf so the next iter's
         # resolve_forward_inputs finds these tokens for the decode portion
         # of mixed-chunk batches (which gather via mix_running_indices).
         self.future_map.stash(
             batch.req_pool_indices, RelayPayload(bonus_tokens=next_token_ids)
         )
+        next_draft_input = None
+        if batch.spec_algorithm.is_dspark():
+            from sglang.srt.speculative.dspark_components.dspark_draft import (
+                make_next_draft_input,
+            )
+
+            next_draft_input = make_next_draft_input(
+                bonus_tokens=next_token_ids,
+                new_seq_lens=batch.seq_lens,
+            )
+            batch.spec_info = next_draft_input
         batch.input_ids = None
         output_result = GenerationBatchResult(
             logits_output=logits_output,
@@ -1163,6 +1206,7 @@ class SchedulerPPMixin:
             extend_input_len_per_req=extend_input_len_per_req,
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             can_run_cuda_graph=mb_metadata.can_run_cuda_graph,
+            next_draft_input=next_draft_input,
         )
         return output_result
 
@@ -1291,7 +1335,15 @@ class SchedulerPPMixin:
                     "set_run_batch_cpu_start_time",
                     trace_only=True,
                 )
-                result = self.run_batch(cur_batch, pp_proxy_tensors)
+                if cur_batch.spec_algorithm.is_dspark():
+                    self.model_worker.set_pp_proxy_tensors_for_next_forward(
+                        pp_proxy_tensors
+                    )
+                try:
+                    result = self.run_batch(cur_batch, pp_proxy_tensors)
+                finally:
+                    if cur_batch.spec_algorithm.is_dspark():
+                        self.model_worker.set_pp_proxy_tensors_for_next_forward(None)
                 set_time_batch(
                     cur_batch.reqs,
                     "set_run_batch_cpu_end_time",

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -120,7 +120,7 @@ class GenerationBatchResult:
         Only the tensors which are needed for processing results are copied,
         e.g., next_token_ids, logits outputs
         """
-        if return_logprob:
+        if self.logits_output is not None and return_logprob:
             if self.logits_output.next_token_logprobs is not None:
                 self.logits_output.next_token_logprobs = _async_d2h(
                     self.logits_output.next_token_logprobs
@@ -144,11 +144,16 @@ class GenerationBatchResult:
                     _async_d2h(v) if torch.is_tensor(v) else v
                     for v in self.logits_output.next_token_token_ids_logprobs_val
                 ]
-        if return_hidden_states and self.logits_output.hidden_states is not None:
+        if (
+            self.logits_output is not None
+            and return_hidden_states
+            and self.logits_output.hidden_states is not None
+        ):
             self.logits_output.hidden_states = _async_d2h(
                 self.logits_output.hidden_states
             )
-        self.next_token_ids = _async_d2h(self.next_token_ids)
+        if self.next_token_ids is not None:
+            self.next_token_ids = _async_d2h(self.next_token_ids)
 
         if self.accept_lens is not None:
             self.accept_lens = _async_d2h(self.accept_lens)

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -666,6 +666,22 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         assert self.full_to_swa_index_mapping is not None
         return self.full_to_swa_index_mapping[kv_indices]
 
+    def get_kv_layer_ids(self) -> List[int]:
+        """Global layer IDs aligned with the compressed KV entry layout."""
+        stage_ratios = self.compression_ratios[self._stage_start : self._stage_end]
+        c4_layer_ids = [
+            self._stage_start + local_layer_id
+            for local_layer_id, ratio in enumerate(stage_ratios)
+            if ratio == 4
+        ]
+        c128_layer_ids = [
+            self._stage_start + local_layer_id
+            for local_layer_id, ratio in enumerate(stage_ratios)
+            if ratio == 128
+        ]
+        # get_contiguous_buf_infos orders entries as C4, C4 indexer, C128.
+        return c4_layer_ids + c4_layer_ids + c128_layer_ids
+
     def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs: List[int] = []
         data_lens: List[int] = []

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -61,6 +61,8 @@ def get_draft_kv_pool(
     or None when no draft KV pool is available."""
     if draft_worker is None or spec_algorithm.is_ngram():
         return None
+    if spec_algorithm.is_dspark() and draft_worker.is_lifecycle_only_pp_prefill_rank:
+        return None
 
     # V2 workers nest the draft runner under `.draft_worker`.
     if server_args.enable_multi_layer_eagle:

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -197,9 +197,11 @@ def _assert_pp_mtp_compat(
     num_effective_layers: int,
     model_num_layers: int,
 ) -> None:
+    # DSPARK uses a separate draft worker even when the target config bundles MTP layers.
     assert (
         (not model_has_mtp_layers)
         or (spec_algorithm.is_none())
+        or spec_algorithm.is_dspark()
         or (
             (not spec_algorithm.is_none())
             and (num_effective_layers == model_num_layers)

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -112,8 +112,9 @@ def _allocate_decode_buffers(
             # mHC (e.g. DSV4) flattens residual into hidden_states (size = hc_hidden_size).
             is_mhc = hc_hidden_size is not None
             hs = hc_hidden_size if is_mhc else hidden_size
+            # Target verify expands each request into num_tokens_per_req rows.
             pp_proxy_tensors = {
-                "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
             }
             if not is_mhc:
                 # Only Kimi K3 supplies num_blocks: its PP bank is token-major

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -371,15 +371,31 @@ class EagerRunner(BaseRunner):
                 else hidden_states
             )
 
-        hidden_states = cp_gather_after_forward(
-            hidden_states, forward_batch, torch.cuda.current_stream()
-        )
+        stream = torch.cuda.current_stream()
+        hidden_states = cp_gather_after_forward(hidden_states, forward_batch, stream)
+        # DSpark aux tensors ride the same CP token split; gather them the same way.
+        if aux_hidden_states is not None:
+            if isinstance(aux_hidden_states, torch.Tensor):
+                aux_hidden_states = cp_gather_after_forward(
+                    aux_hidden_states, forward_batch, stream
+                )
+            else:
+                aux_hidden_states = [
+                    cp_gather_after_forward(aux, forward_batch, stream)
+                    for aux in aux_hidden_states
+                ]
+        logits_kwargs = {}
+        # DSV4 returns (hidden_states, hidden_states_before_norm) from its model body.
+        if isinstance(hidden_states, tuple):
+            hidden_states, hidden_states_before_norm = hidden_states
+            logits_kwargs["hidden_states_before_norm"] = hidden_states_before_norm
         return model.logits_processor(
             forward_batch.input_ids,
             hidden_states,
             model.lm_head,
             forward_batch,
             aux_hidden_states,
+            **logits_kwargs,
         )
 
     def _execute_idle(

--- a/python/sglang/srt/model_executor/runner_utils/buffers.py
+++ b/python/sglang/srt/model_executor/runner_utils/buffers.py
@@ -132,8 +132,9 @@ class DecodeInputBuffers(ForwardInputBuffers):
             if pp_size > 1:
                 is_mhc = hc_hidden_size is not None
                 hs = hc_hidden_size if is_mhc else hidden_size
+                # Target verify expands each request into num_tokens_per_req rows.
                 pp_proxy_tensors = {
-                    "hidden_states": torch.zeros((max_bs, hs), dtype=dtype),
+                    "hidden_states": torch.zeros((max_num_token, hs), dtype=dtype),
                 }
                 if not is_mhc:
                     # Only Kimi K3 supplies num_blocks: its PP bank is token-major

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2389,12 +2389,6 @@ class DeepseekV4Model(nn.Module):
             if hasattr(forward_batch, _attr):
                 delattr(forward_batch, _attr)
         capture_dspark = self.dspark_layers_to_capture is not None
-        if capture_dspark and dsa_use_prefill_cp(forward_batch):
-            raise NotImplementedError(
-                "DSpark aux hidden-state capture is not supported together with "
-                "DeepSeek-V4 prefill context parallelism (attn_cp_size > 1). Disable one "
-                "of them: DSpark static-verify is CP-off for v1."
-            )
         dspark_aux_hidden_states: List[torch.Tensor] = []
         # DSpark aux capture needs the per-layer eager loop (TBO's overlapped
         # execution cannot expose per-layer completed hidden states), so skip
@@ -2445,16 +2439,35 @@ class DeepseekV4Model(nn.Module):
 
         # CP all-gather only on the last PP rank; PP IPC carries CP-split tensors.
         if self.pp_group.is_last_rank and dsa_use_prefill_cp(forward_batch):
+            stream = torch.cuda.current_stream()
             hidden_states = cp_all_gather_rerange_output(
                 hidden_states,
                 self.cp_size,
                 forward_batch,
-                torch.cuda.current_stream(),
+                stream,
             )
+            # Gather DSpark aux tensors on the same CP token split.
+            if capture_dspark:
+                dspark_aux_hidden_states = [
+                    cp_all_gather_rerange_output(
+                        aux, self.cp_size, forward_batch, stream
+                    )
+                    for aux in dspark_aux_hidden_states
+                ]
 
         if not self.pp_group.is_last_rank:
             # Flatten 3D mHC tensor for PP IPC.
-            return PPProxyTensors({"hidden_states": hidden_states.flatten(1)})
+            proxy_tensors = {"hidden_states": hidden_states.flatten(1)}
+            if capture_dspark:
+                if dspark_aux_hidden_states:
+                    proxy_tensors["dspark_aux_hidden_states"] = torch.cat(
+                        dspark_aux_hidden_states, dim=-1
+                    )
+                else:
+                    proxy_tensors["dspark_aux_hidden_states"] = hidden_states.new_empty(
+                        hidden_states.shape[0], 0
+                    )
+            return PPProxyTensors(proxy_tensors)
 
         pre_hc_head = hidden_states.flatten(1)
 
@@ -2543,14 +2556,17 @@ class DeepseekV4ForCausalLM(nn.Module):
         return self.model.get_input_embeddings()
 
     def set_dspark_layers_to_capture(self, layer_ids: List[int]) -> None:
-        if not self.pp_group.is_last_rank:
-            return
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
-        self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        local_layer_ids = [
+            int(layer_id)
+            for layer_id in layer_ids
+            if self.model.start_layer <= int(layer_id) < self.model.end_layer
+        ]
+        self.capture_aux_hidden_states = bool(local_layer_ids)
+        self.model.dspark_layers_to_capture = local_layer_ids or None
 
     def determine_num_fused_shared_experts(self):
         self.num_fused_shared_experts = 0

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -18,6 +18,11 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+from sglang.srt.layers.quantization.fp8_utils import (
+    inverse_transform_scale_ue8m0,
+    transform_scale_ue8m0,
+)
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
@@ -40,9 +45,10 @@ from sglang.srt.models.dspark import (
     gather_and_crop_vocab,
     run_markov_block,
 )
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_disagg, get_parallel
 from sglang.srt.speculative.dspark_components.dspark_config import (
     parse_dspark_draft_config,
+    use_lifecycle_only_draft_model,
 )
 from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyMode,
@@ -59,6 +65,83 @@ _PAD_NUM_HEADS = 64
 _CONFIDENCE = Invariant(
     "dspark.model.confidence", Bucket.GUARD, InClosedRange(0.0, 1.0)
 )
+
+
+class _BlockFp8LinearSlice(nn.Module):
+    """Persistent K-block slice of a loaded block-FP8 ReplicatedLinear."""
+
+    def __init__(
+        self,
+        *,
+        source: ReplicatedLinear,
+        feature_indices: List[int],
+        feature_width: int,
+    ) -> None:
+        super().__init__()
+        quant_method = source.quant_method
+        if not (
+            isinstance(quant_method, Fp8LinearMethod)
+            and quant_method.block_quant
+            and not quant_method.use_mxfp8
+            and not quant_method.use_marlin
+        ):
+            raise ValueError(
+                "DSpark block-FP8 projection slice requires a non-MXFP8 "
+                "block-quantized Fp8LinearMethod."
+            )
+
+        block_k = int(quant_method.weight_block_size[1])
+        if feature_width % block_k != 0:
+            raise ValueError(
+                f"DSpark feature width {feature_width} must align to FP8 "
+                f"block_k={block_k}."
+            )
+        blocks_per_feature = feature_width // block_k
+        device = source.weight.device
+        weight_columns = torch.cat(
+            [
+                torch.arange(
+                    feature_index * feature_width,
+                    (feature_index + 1) * feature_width,
+                    device=device,
+                )
+                for feature_index in feature_indices
+            ]
+        )
+        scale_columns = torch.cat(
+            [
+                torch.arange(
+                    feature_index * blocks_per_feature,
+                    (feature_index + 1) * blocks_per_feature,
+                    device=device,
+                )
+                for feature_index in feature_indices
+            ]
+        )
+
+        self.quant_method = quant_method
+        self.weight = nn.Parameter(
+            source.weight.detach().index_select(1, weight_columns).contiguous(),
+            requires_grad=False,
+        )
+        source_scale = source.weight_scale_inv.detach()
+        scale_is_ue8m0 = source.weight_scale_inv.format_ue8m0
+        if scale_is_ue8m0:
+            source_scale = inverse_transform_scale_ue8m0(
+                source_scale, mn=source.weight.shape[0]
+            )
+        local_scale = source_scale.index_select(1, scale_columns).contiguous()
+        if scale_is_ue8m0:
+            local_scale = transform_scale_ue8m0(local_scale, mn=source.weight.shape[0])
+        self.weight_scale_inv = nn.Parameter(
+            local_scale,
+            requires_grad=False,
+        )
+        self.weight_scale_inv.format_ue8m0 = scale_is_ue8m0
+        self.register_parameter("bias", None)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.quant_method.apply(self, hidden_states, bias=None)
 
 
 def apply_rotary_emb(
@@ -300,6 +383,7 @@ class DSparkV4MarkovHead(nn.Module):
             self.markov_rank, self.vocab_size, bias=False, dtype=markov_w2_dtype
         )
         self._tp_shard: Optional[MarkovW2ShardGeometry] = None
+        self._shard_group = None
 
     def configure_tp_shard(self, *, lm_head: nn.Module) -> None:
         if not self._opt_markov_w2_tp_shard:
@@ -319,16 +403,23 @@ class DSparkV4MarkovHead(nn.Module):
                 f"num_embeddings_per_partition({per_partition}) * tp_size({tp_size}) != "
                 f"num_embeddings_padded({num_padded})."
             )
-        attn_tp_size = get_parallel().attn_tp_group.world_size
-        if attn_tp_size != tp_size:
+        # Follow lm_head's group choice; attn_tp_group degenerates to size 1
+        # under prefill CP while lm_head still shards over the full TP group.
+        parallel = get_parallel()
+        shard_group = (
+            parallel.attn_tp_group
+            if getattr(lm_head, "use_attn_tp_group", False)
+            else parallel.tp_group
+        )
+        shard_group_size = shard_group.world_size
+        if shard_group_size != tp_size:
             raise ValueError(
-                "DSpark markov_w2 TP-shard needs the attn-TP group (used for the per-step "
-                f"all-gather) to equal the lm_head shard group, got attn_tp_size="
-                f"{attn_tp_size} vs lm_head tp_size={tp_size}. This config (e.g. DP "
-                "attention without --enable-dp-lm-head, where lm_head shards over the "
-                "global TP group) is unsupported; disable "
-                "SGLANG_DSPARK_OPT_MARKOV_W2_TP_SHARD."
+                "DSpark markov_w2 TP-shard needs the per-step all-gather group to "
+                f"equal the lm_head shard group, got shard_group_size="
+                f"{shard_group_size} vs lm_head tp_size={tp_size}. "
+                "Disable SGLANG_DSPARK_OPT_MARKOV_W2_TP_SHARD."
             )
+        self._shard_group = shard_group
         self._tp_shard = MarkovW2ShardGeometry(
             tp_size=tp_size,
             org_vocab_start=int(lm_head.shard_indices.org_vocab_start_index),
@@ -381,7 +472,8 @@ class DSparkV4MarkovHead(nn.Module):
             bias = F.linear(latent.float(), weight_local)
         step_local = BuildStepLocal.execute(bias=bias, base_local=base_local)
         if shard.tp_size > 1:
-            full = get_parallel().attn_tp_group.all_gather(step_local, dim=-1)
+            assert self._shard_group is not None
+            full = self._shard_group.all_gather(step_local, dim=-1)
         else:
             full = step_local
         return full[..., : self.vocab_size]
@@ -591,6 +683,39 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
 
         self.start_layer = 0
         self.end_layer = self.num_stages
+        parallel = get_parallel()
+        self.is_lifecycle_only = use_lifecycle_only_draft_model(
+            disaggregation_mode=get_disagg().disaggregation_mode,
+            pp_rank=parallel.pp_rank,
+            pp_size=parallel.pp_size,
+            target_layer_ids=[
+                int(layer_id) for layer_id in (dspark_config.target_layer_ids or [])
+            ],
+            num_hidden_layers=target_num_layers,
+        )
+        self.hc_mult = int(config.hc_mult)
+        self.norm_eps = float(config.rms_norm_eps)
+        self.hc_eps = float(config.hc_eps)
+        self.embed_tokens: Optional[nn.Module] = None
+        self.lm_head: Optional[nn.Module] = None
+        self._partial_feature_indices: tuple[int, ...] = ()
+        self._partial_main_proj: Optional[_BlockFp8LinearSlice] = None
+        self._use_fp32_lm_head = envs.SGLANG_DSPARK_FP32_LM_HEAD.get()
+        self._opt_markov_w2_tp_shard = envs.SGLANG_DSPARK_OPT_MARKOV_W2_TP_SHARD.get()
+        if self.is_lifecycle_only:
+            # Keep ModelRunner's distributed lifecycle aligned without building
+            # draft compute modules on PP ranks that cannot contribute context.
+            self.stages = nn.ModuleList()
+            self.markov_head = None
+            self.confidence_head = None
+            logger.info(
+                "DSpark PP rank %s uses a lifecycle-only draft model; all target "
+                "features are owned by final PP rank %s.",
+                parallel.pp_rank,
+                parallel.pp_size - 1,
+            )
+            return
+
         use_multi_stream = (
             envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.get()
             and envs.SGLANG_DSPARK_ENABLE_MULTI_STREAM.get()
@@ -621,14 +746,6 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         self.confidence_head = build_dspark_v4_confidence_head(
             config=config, markov_rank=int(dspark_config.markov_rank)
         )
-        self.hc_mult = int(config.hc_mult)
-        self.norm_eps = float(config.rms_norm_eps)
-        self.hc_eps = float(config.hc_eps)
-
-        self.embed_tokens: Optional[nn.Module] = None
-        self.lm_head: Optional[nn.Module] = None
-        self._use_fp32_lm_head = envs.SGLANG_DSPARK_FP32_LM_HEAD.get()
-        self._opt_markov_w2_tp_shard = envs.SGLANG_DSPARK_OPT_MARKOV_W2_TP_SHARD.get()
 
     @property
     def enable_confidence_head(self) -> bool:
@@ -641,10 +758,101 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         self.lm_head = lm_head
         self.markov_head.configure_tp_shard(lm_head=lm_head)
 
-    def project_target_hidden(self, main_hidden: torch.Tensor) -> torch.Tensor:
+    def prune_to_ctx_projection(self) -> None:
+        if self.is_lifecycle_only:
+            return
         stage0 = self.stages[0]
-        projected, _ = stage0.main_proj(main_hidden)
-        return stage0.main_norm(projected)
+        projection_stage = nn.Module()
+        projection_stage.main_proj = stage0.main_proj
+        projection_stage.main_norm = stage0.main_norm
+        # Preserve stages.0.main_proj parameter names for online weight updates.
+        self.stages = nn.ModuleList([projection_stage])
+        self.markov_head = None
+        self.confidence_head = None
+        self.embed_tokens = None
+        self.lm_head = None
+        del stage0
+        torch.cuda.empty_cache()
+
+    def project_target_hidden(self, main_hidden: torch.Tensor) -> torch.Tensor:
+        projected, _ = self.stages[0].main_proj(main_hidden)
+        return self.stages[0].main_norm(projected)
+
+    def prepare_target_hidden_partial(self, feature_indices: List[int]) -> None:
+        feature_indices = [int(index) for index in feature_indices]
+        main_proj = self.stages[0].main_proj
+        quant_method = main_proj.quant_method
+        self._partial_feature_indices = tuple(feature_indices)
+        if not (
+            isinstance(quant_method, Fp8LinearMethod)
+            and quant_method.block_quant
+            and not quant_method.use_mxfp8
+            and not quant_method.use_marlin
+        ):
+            self._partial_main_proj = None
+            logger.warning(
+                "DSpark partial projection cannot slice quant method %s; "
+                "falling back to the full-K projection.",
+                type(quant_method).__name__,
+            )
+            return
+        self._partial_main_proj = _BlockFp8LinearSlice(
+            source=main_proj,
+            feature_indices=feature_indices,
+            feature_width=int(self.config.hidden_size),
+        )
+        logger.info(
+            "DSpark block-FP8 partial projection uses feature columns %s "
+            "(local K=%s, full K=%s).",
+            feature_indices,
+            len(feature_indices) * int(self.config.hidden_size),
+            int(main_proj.weight.shape[1]),
+        )
+
+    def project_target_hidden_partial(
+        self, main_hidden: torch.Tensor, feature_indices: list[int]
+    ) -> torch.Tensor:
+        """Project PP-local target features into an additive pre-norm context."""
+        if not feature_indices:
+            raise ValueError("feature_indices must be non-empty.")
+        feature_indices = [int(index) for index in feature_indices]
+        if min(feature_indices) < 0 or max(feature_indices) >= self.num_target_features:
+            raise ValueError(
+                "DeepSeek-V4 DSpark feature_indices out of range: "
+                f"{feature_indices=} {self.num_target_features=}."
+            )
+
+        hidden_size = int(self.config.hidden_size)
+        expected = len(feature_indices) * hidden_size
+        if main_hidden.ndim != 2 or int(main_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "DeepSeek-V4 DSpark partial main_hidden feature dim mismatch. "
+                f"Expected shape [N, {expected}] for {feature_indices=}, "
+                f"but got shape={tuple(main_hidden.shape)}."
+            )
+
+        if (
+            self._partial_main_proj is not None
+            and tuple(feature_indices) == self._partial_feature_indices
+        ):
+            return self._partial_main_proj(main_hidden)
+
+        local_features = main_hidden.view(
+            main_hidden.shape[0], len(feature_indices), hidden_size
+        )
+        full_features = main_hidden.new_zeros(
+            main_hidden.shape[0], self.num_target_features, hidden_size
+        )
+        # Reuse ReplicatedLinear.forward so FP8 weights and scales follow the
+        # same quantization path as the full, non-PP projection.
+        feature_index = torch.tensor(
+            feature_indices, dtype=torch.long, device=main_hidden.device
+        )
+        full_features.index_copy_(1, feature_index, local_features)
+        projected, _ = self.stages[0].main_proj(
+            full_features.view(main_hidden.shape[0], -1)
+        )
+        return projected
 
     def write_target_hidden_kv(
         self,
@@ -655,6 +863,37 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         pool: DeepSeekV4TokenToKVPool,
     ) -> None:
         main_x = self.project_target_hidden(main_hidden)
+        self._write_context_hidden_kv(
+            main_x=main_x,
+            swa_loc=swa_loc,
+            positions=positions,
+            pool=pool,
+        )
+
+    def write_projected_context_kv(
+        self,
+        *,
+        projected_context: torch.Tensor,
+        swa_loc: torch.Tensor,
+        positions: torch.Tensor,
+        pool: DeepSeekV4TokenToKVPool,
+    ) -> None:
+        main_x = self.stages[0].main_norm(projected_context)
+        self._write_context_hidden_kv(
+            main_x=main_x,
+            swa_loc=swa_loc,
+            positions=positions,
+            pool=pool,
+        )
+
+    def _write_context_hidden_kv(
+        self,
+        *,
+        main_x: torch.Tensor,
+        swa_loc: torch.Tensor,
+        positions: torch.Tensor,
+        pool: DeepSeekV4TokenToKVPool,
+    ) -> None:
         swa_loc = swa_loc.to(torch.int32)
         kvs = CommitKvProj.execute(
             main_x=main_x,
@@ -758,6 +997,8 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         return confidence
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
+        if self.is_lifecycle_only:
+            return
         params_dict = dict(self.named_parameters())
         loaded_params = set()
 

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -399,6 +399,40 @@ class DFlashDraftModel(nn.Module):
             )
         return self.hidden_norm(self.fc(target_hidden))
 
+    def project_target_hidden_partial(
+        self, target_hidden: torch.Tensor, feature_indices: list[int]
+    ) -> torch.Tensor:
+        """Project PP-local target features into an additive pre-norm context."""
+        if not feature_indices:
+            raise ValueError("feature_indices must be non-empty.")
+        feature_indices = [int(i) for i in feature_indices]
+        if (
+            min(feature_indices) < 0
+            or max(feature_indices) >= self.num_context_features
+        ):
+            raise ValueError(
+                "feature_indices out of range for DFLASH context projection: "
+                f"{feature_indices=} {self.num_context_features=}."
+            )
+        hidden_size = int(self.config.hidden_size)
+        expected = len(feature_indices) * hidden_size
+        if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "DFLASH partial target_hidden feature dim mismatch. "
+                f"Expected shape [N, {expected}] for {feature_indices=}, "
+                f"but got shape={tuple(target_hidden.shape)}."
+            )
+
+        cols = []
+        for idx in feature_indices:
+            start = idx * hidden_size
+            cols.extend(range(start, start + hidden_size))
+        index = torch.tensor(cols, dtype=torch.long, device=self.fc.weight.device)
+        weight = self.fc.weight.index_select(1, index)
+        if target_hidden.dtype != weight.dtype:
+            target_hidden = target_hidden.to(weight.dtype)
+        return F.linear(target_hidden, weight)
+
     @torch.no_grad()
     def forward(
         self,
@@ -584,6 +618,35 @@ class DFlashLagunaForCausalLM(DFlashDraftModel):
             normed[:, i, :] = norm(slices[:, i, :])
         fused = normed.reshape(target_hidden.shape[0], -1)
         return self.hidden_norm(self.fc(fused))
+
+    def project_target_hidden_partial(
+        self, target_hidden: torch.Tensor, feature_indices: list[int]
+    ) -> torch.Tensor:
+        if not feature_indices:
+            raise ValueError("feature_indices must be non-empty.")
+        feature_indices = [int(i) for i in feature_indices]
+        hidden_size = int(self.config.hidden_size)
+        expected = len(feature_indices) * hidden_size
+        if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "Laguna DFLASH partial target_hidden feature dim mismatch. "
+                f"Expected shape [N, {expected}] for {feature_indices=}, "
+                f"but got shape={tuple(target_hidden.shape)}."
+            )
+        slices = target_hidden.view(
+            target_hidden.shape[0], len(feature_indices), hidden_size
+        )
+        compute_dtype = self.fc.weight.dtype
+        if slices.dtype != compute_dtype:
+            slices = slices.to(compute_dtype)
+        normed = torch.empty_like(slices)
+        for out_idx, feature_idx in enumerate(feature_indices):
+            normed[:, out_idx, :] = self.aux_hidden_norms[feature_idx](
+                slices[:, out_idx, :]
+            )
+        return super().project_target_hidden_partial(
+            normed.reshape(target_hidden.shape[0], -1), feature_indices
+        )
 
 
 EntryClass = [DFlashDraftModel, DFlashLagunaForCausalLM]

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -513,6 +513,44 @@ class DSparkDraftMixin:
         commit_lens: Optional[torch.Tensor] = None,
     ) -> None:
         ctx_hidden = self.project_target_hidden(target_hidden)
+        self.write_context_hidden_kv(
+            ctx_hidden=ctx_hidden,
+            pool=pool,
+            positions=positions,
+            cache_loc=cache_loc,
+            cache_loc_2d=cache_loc_2d,
+            commit_lens=commit_lens,
+        )
+
+    def write_projected_context_kv(
+        self,
+        *,
+        projected_context: torch.Tensor,
+        pool,
+        positions: torch.Tensor,
+        cache_loc: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+    ) -> None:
+        self.write_context_hidden_kv(
+            ctx_hidden=self.hidden_norm(projected_context),
+            pool=pool,
+            positions=positions,
+            cache_loc=cache_loc,
+            cache_loc_2d=cache_loc_2d,
+            commit_lens=commit_lens,
+        )
+
+    def write_context_hidden_kv(
+        self,
+        *,
+        ctx_hidden: torch.Tensor,
+        pool,
+        positions: torch.Tensor,
+        cache_loc: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+    ) -> None:
         stacked = self._stacked_ctx_kv_params()
         if stacked is not None:
             k_all, v_all = self._project_ctx_kv_stacked(

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -2500,16 +2500,29 @@ class KimiK3LinearModel(nn.Module):
                 )
 
         if not self.pp_group.is_last_rank:
+            proxy_tensors = {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+            if self.dspark_layers_to_capture is not None:
+                if aux_hidden_states:
+                    proxy_tensors["dspark_aux_hidden_states"] = torch.cat(
+                        aux_hidden_states, dim=-1
+                    )
+                else:
+                    proxy_tensors["dspark_aux_hidden_states"] = hidden_states.new_empty(
+                        hidden_states.shape[0], 0
+                    )
             assert not sp_sharded
             if attn_res is not None:
                 if residual is not None:
                     # Materialize the delayed MLP add: the wire carries the
                     # full stream head (bit-identical to the fused fold).
                     hidden_states = residual + hidden_states
+                    proxy_tensors["hidden_states"] = hidden_states
                 residual = attn_res.block_residual  # raw bank across ranks
-            return PPProxyTensors(
-                {"hidden_states": hidden_states, "residual": residual}
-            )
+                proxy_tensors["residual"] = residual
+            return PPProxyTensors(proxy_tensors)
 
         if hidden_states.shape[0] != 0:
             if attn_res is not None:
@@ -2618,18 +2631,17 @@ class KimiK3LinearForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
-        if self.pp_group.world_size > 1:
-            # Capture layers living on non-last PP ranks would be silently
-            # skipped (the flag is only set on the last rank).
-            raise NotImplementedError("DSPARK aux hidden capture requires PP=1.")
-        if not self.pp_group.is_last_rank:
-            return
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
-        self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        local_layer_ids = [
+            int(layer_id)
+            for layer_id in layer_ids
+            if self.model.start_layer <= int(layer_id) < self.model.end_layer
+        ]
+        self.capture_aux_hidden_states = bool(local_layer_ids)
+        self.model.dspark_layers_to_capture = local_layer_ids or None
 
     @torch.no_grad()
     def forward(
@@ -2740,6 +2752,35 @@ class KimiK3LinearForCausalLM(nn.Module):
         loaded_params: set[str] = set()
 
         num_hidden_layers = self.config.num_hidden_layers
+
+        def maybe_load_truncated_moe_gate(
+            param_name: str, param: torch.Tensor, loaded_weight: torch.Tensor
+        ) -> bool:
+            if self.config.num_experts is None:
+                return False
+            if not (
+                param_name.endswith(".mlp.gate.weight")
+                or param_name.endswith(".mlp.gate.e_score_correction_bias")
+            ):
+                return False
+            if loaded_weight.shape == param.data.shape:
+                return False
+            keep_num_experts = int(self.config.num_experts)
+            if loaded_weight.shape[0] < keep_num_experts:
+                raise ValueError(
+                    f"Cannot truncate Kimi-K3 MoE gate weight {param_name}: "
+                    f"checkpoint has {loaded_weight.shape[0]} experts, "
+                    f"requested {keep_num_experts}."
+                )
+            truncated_weight = loaded_weight.narrow(0, 0, keep_num_experts)
+            if truncated_weight.shape != param.data.shape:
+                raise ValueError(
+                    f"Unexpected truncated Kimi-K3 MoE gate shape for {param_name}: "
+                    f"{truncated_weight.shape=} {param.data.shape=}."
+                )
+            param.data.copy_(truncated_weight)
+            return True
+
         for args in weights:
             name, loaded_weight = args[:2]
             kwargs = args[2] if len(args) > 2 else {}
@@ -2846,6 +2887,9 @@ class KimiK3LinearForCausalLM(nn.Module):
                     if name not in params_dict:
                         continue
                     param = params_dict[name]
+                    if maybe_load_truncated_moe_gate(name, param, loaded_weight):
+                        loaded_params.add(name)
+                        continue
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )

--- a/python/sglang/srt/models/kimi_linear.py
+++ b/python/sglang/srt/models/kimi_linear.py
@@ -623,12 +623,20 @@ class KimiLinearModel(nn.Module):
                 )
 
         if not self.pp_group.is_last_rank:
-            return PPProxyTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                }
-            )
+            proxy_tensors = {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+            if self.dspark_layers_to_capture is not None:
+                if aux_hidden_states:
+                    proxy_tensors["dspark_aux_hidden_states"] = torch.cat(
+                        aux_hidden_states, dim=-1
+                    )
+                else:
+                    proxy_tensors["dspark_aux_hidden_states"] = hidden_states.new_empty(
+                        hidden_states.shape[0], 0
+                    )
+            return PPProxyTensors(proxy_tensors)
         else:
             if hidden_states.shape[0] != 0:
                 if residual is None:
@@ -674,16 +682,17 @@ class KimiLinearForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
-        if self.pp_group.world_size > 1:
-            raise NotImplementedError("DSPARK aux hidden capture requires PP=1.")
-        if not self.pp_group.is_last_rank:
-            return
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
-        self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        local_layer_ids = [
+            int(layer_id)
+            for layer_id in layer_ids
+            if self.model.start_layer <= int(layer_id) < self.model.end_layer
+        ]
+        self.capture_aux_hidden_states = bool(local_layer_ids)
+        self.model.dspark_layers_to_capture = local_layer_ids or None
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8720,8 +8720,20 @@ class ServerArgs:
 
         if self.pp_size > 1:
             assert (
-                self.disable_overlap_schedule and self.speculative_algorithm is None
-            ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+                self.disable_overlap_schedule
+            ), "Pipeline parallelism is not compatible with overlap schedule"
+            pp_dspark_prefill = (
+                self.speculative_algorithm or ""
+            ).upper() == "DSPARK" and self.disaggregation_mode == "prefill"
+            assert self.speculative_algorithm is None or pp_dspark_prefill, (
+                "Pipeline parallelism with speculative decoding is only supported "
+                "for DSPARK on a PD prefill server"
+            )
+            assert self.min_free_slots_delay is None, (
+                "--min-free-slots-delay is not supported with pipeline "
+                "parallelism: allocatable slots per microbatch are bounded by "
+                "pp-max-micro-batch-size, so the threshold may never be reached"
+            )
 
         assert not (
             self.dp_size > 1 and self.nnodes != 1 and not self.enable_dp_attention

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -38,6 +38,45 @@ def draft_is_deepseek_v4(*, server_args: ServerArgs) -> bool:
     return draft_hf_config is not None and is_deepseek_v4(draft_hf_config)
 
 
+def resolve_single_owner_pp_rank(
+    *, target_layer_ids: List[int], num_hidden_layers: int, pp_size: int
+) -> Optional[int]:
+    from sglang.srt.distributed.utils import get_pp_indices
+
+    if not target_layer_ids:
+        return None
+    for pp_rank in range(pp_size):
+        start_layer, end_layer = get_pp_indices(
+            num_hidden_layers=num_hidden_layers,
+            pp_rank=pp_rank,
+            pp_size=pp_size,
+        )
+        if all(start_layer <= layer_id < end_layer for layer_id in target_layer_ids):
+            return pp_rank
+    return None
+
+
+def use_lifecycle_only_draft_model(
+    *,
+    disaggregation_mode: str,
+    pp_rank: int,
+    pp_size: int,
+    target_layer_ids: List[int],
+    num_hidden_layers: int,
+) -> bool:
+    owner_pp_rank = resolve_single_owner_pp_rank(
+        target_layer_ids=target_layer_ids,
+        num_hidden_layers=num_hidden_layers,
+        pp_size=pp_size,
+    )
+    return (
+        disaggregation_mode == "prefill"
+        and pp_size > 1
+        and owner_pp_rank == pp_size - 1
+        and pp_rank != owner_pp_rank
+    )
+
+
 def dspark_gamma_from_num_draft_tokens(num_draft_tokens: int) -> int:
     gamma = int(num_draft_tokens) - 1
     if gamma < 1:

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -2,11 +2,15 @@ from typing import Optional
 
 import torch
 
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+    is_unified_kv_triton,
+)
 from sglang.kernels.ops.speculative.cache_locs import assign_extend_cache_locs_func
 from sglang.kernels.ops.speculative.dspark.dspark_verify_window import (
     BuildCommitInjectLayout,
 )
 from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 
@@ -36,6 +40,8 @@ class TargetHiddenKvInjector:
         positions: torch.Tensor,
         cache_loc_2d: Optional[torch.Tensor] = None,
         commit_lens: Optional[torch.Tensor] = None,
+        state_slot: Optional[torch.Tensor] = None,
+        final_pos: Optional[torch.Tensor] = None,
     ) -> None:
         if target_hidden is None or target_hidden.numel() == 0:
             return
@@ -54,6 +60,14 @@ class TargetHiddenKvInjector:
             commit_lens = commit_lens.to(
                 device=device, dtype=torch.int32, non_blocking=True
             )
+        if state_slot is not None:
+            state_slot = state_slot.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+        if final_pos is not None:
+            final_pos = final_pos.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
 
         pool = self.draft_model_runner.token_to_kv_pool
         if hasattr(pool, "set_swa_key_buffer_radix_fused_norm_rope"):
@@ -64,12 +78,92 @@ class TargetHiddenKvInjector:
                 positions=positions,
                 cache_loc_2d=cache_loc_2d,
                 commit_lens=commit_lens,
+                state_slot=state_slot,
+                final_pos=final_pos,
             )
             return
 
         with torch.inference_mode():
             self.draft_model.write_target_hidden_kv(
                 target_hidden=target_hidden,
+                pool=pool,
+                positions=positions,
+                cache_loc=cache_loc,
+                cache_loc_2d=cache_loc_2d,
+                commit_lens=commit_lens,
+            )
+
+    def inject_projected_context(
+        self,
+        *,
+        projected_context: torch.Tensor,
+        cache_loc: torch.Tensor,
+        positions: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+        state_slot: Optional[torch.Tensor] = None,
+        final_pos: Optional[torch.Tensor] = None,
+    ) -> None:
+        if projected_context is None or projected_context.numel() == 0:
+            return
+        device = self.model_runner.device
+        cache_loc = cache_loc.to(device=device, dtype=torch.int64, non_blocking=True)
+        positions = positions.to(device=device, dtype=torch.int64, non_blocking=True)
+        projected_context = projected_context.to(device=device, non_blocking=True)
+        n_real = positions.shape[0]
+        if projected_context.shape[0] > n_real:
+            projected_context = projected_context[:n_real]
+        if cache_loc_2d is not None:
+            cache_loc_2d = cache_loc_2d.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+        if commit_lens is not None:
+            commit_lens = commit_lens.to(
+                device=device, dtype=torch.int32, non_blocking=True
+            )
+        if state_slot is not None:
+            state_slot = state_slot.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+        if final_pos is not None:
+            final_pos = final_pos.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+
+        pool = self.draft_model_runner.token_to_kv_pool
+        if isinstance(pool, DeepSeekV4TokenToKVPool):
+            if is_unified_kv_triton():
+                swa_loc = self._unified_inject_loc(
+                    pool=pool,
+                    positions=positions,
+                    cache_loc_2d=cache_loc_2d,
+                    commit_lens=commit_lens,
+                    state_slot=state_slot,
+                    final_pos=final_pos,
+                )
+            else:
+                swa_loc = pool.translate_loc_from_full_to_swa(cache_loc).to(torch.int32)
+                if commit_lens is not None and cache_loc_2d is not None:
+                    bs, verify_len = cache_loc_2d.shape
+                    col = torch.arange(verify_len, device=cache_loc.device).view(1, -1)
+                    committed_mask = (
+                        col < commit_lens.to(torch.long).view(-1, 1)
+                    ).reshape(-1)
+                    swa_loc = torch.where(
+                        committed_mask, swa_loc, torch.full_like(swa_loc, -1)
+                    )
+            with torch.inference_mode():
+                self.draft_model.write_projected_context_kv(
+                    projected_context=projected_context,
+                    swa_loc=swa_loc,
+                    positions=positions,
+                    pool=pool,
+                )
+            return
+
+        with torch.inference_mode():
+            self.draft_model.write_projected_context_kv(
+                projected_context=projected_context,
                 pool=pool,
                 positions=positions,
                 cache_loc=cache_loc,
@@ -86,13 +180,29 @@ class TargetHiddenKvInjector:
         positions: torch.Tensor,
         cache_loc_2d: Optional[torch.Tensor],
         commit_lens: Optional[torch.Tensor],
+        state_slot: Optional[torch.Tensor] = None,
+        final_pos: Optional[torch.Tensor] = None,
     ) -> None:
-        swa_loc = pool.translate_loc_from_full_to_swa(cache_loc).to(torch.int32)
-        if commit_lens is not None and cache_loc_2d is not None:
-            bs, verify_len = cache_loc_2d.shape
-            col = torch.arange(verify_len, device=cache_loc.device).view(1, -1)
-            committed_mask = (col < commit_lens.to(torch.long).view(-1, 1)).reshape(-1)
-            swa_loc = torch.where(committed_mask, swa_loc, torch.full_like(swa_loc, -1))
+        if is_unified_kv_triton():
+            swa_loc = self._unified_inject_loc(
+                pool=pool,
+                positions=positions,
+                cache_loc_2d=cache_loc_2d,
+                commit_lens=commit_lens,
+                state_slot=state_slot,
+                final_pos=final_pos,
+            )
+        else:
+            swa_loc = pool.translate_loc_from_full_to_swa(cache_loc).to(torch.int32)
+            if commit_lens is not None and cache_loc_2d is not None:
+                bs, verify_len = cache_loc_2d.shape
+                col = torch.arange(verify_len, device=cache_loc.device).view(1, -1)
+                committed_mask = (
+                    col < commit_lens.to(torch.long).view(-1, 1)
+                ).reshape(-1)
+                swa_loc = torch.where(
+                    committed_mask, swa_loc, torch.full_like(swa_loc, -1)
+                )
 
         with torch.inference_mode():
             self.draft_model.write_target_hidden_kv(
@@ -101,6 +211,38 @@ class TargetHiddenKvInjector:
                 positions=positions,
                 pool=pool,
             )
+
+    def _unified_inject_loc(
+        self,
+        *,
+        pool,
+        positions: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor],
+        commit_lens: Optional[torch.Tensor],
+        state_slot: Optional[torch.Tensor],
+        final_pos: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Build unified-KV SWA ring locations for target-hidden injection."""
+        if state_slot is None:
+            raise RuntimeError(
+                "unified_kv target-hidden injection requires state_slot "
+                "(per-token draft req_pool_indices)."
+            )
+        ring = pool.unified_swa_ring_size
+        win = pool.unified_swa_window
+        pos = positions.to(torch.int64)
+        loc = state_slot.to(torch.int64) * ring + pos % ring
+        if final_pos is not None:
+            keep = pos > (final_pos.to(torch.int64) - win)
+            loc = torch.where(keep, loc, torch.full_like(loc, -1))
+        if commit_lens is not None and cache_loc_2d is not None:
+            _, verify_len = cache_loc_2d.shape
+            col = torch.arange(verify_len, device=positions.device).view(1, -1)
+            committed = (
+                col < commit_lens.to(torch.long).view(-1, 1)
+            ).reshape(-1)
+            loc = torch.where(committed, loc, torch.full_like(loc, -1))
+        return loc.to(torch.int32)
 
     def inject_ragged(
         self,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -1,13 +1,20 @@
 import logging
-from contextlib import nullcontext
+from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from typing import Optional
 
 import torch
 
+from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
+    is_unified_kv_triton,
+)
 from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
+from sglang.srt.layers.moe.utils import (
+    speculative_moe_a2a_backend_context,
+    speculative_moe_backend_context,
+)
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -29,6 +36,7 @@ from sglang.srt.speculative.dspark_components.dspark_config import (
     DSV4_DRAFT_ATTENTION_BACKEND,
     draft_is_deepseek_v4,
     resolve_runtime_config,
+    resolve_single_owner_pp_rank,
 )
 from sglang.srt.speculative.dspark_components.dspark_draft import (
     DraftBlockProposer,
@@ -67,6 +75,12 @@ from sglang.srt.utils import get_available_gpu_memory, is_cuda
 logger = logging.getLogger(__name__)
 
 
+def _is_context_only_pp_prefill_rank(
+    *, disaggregation_mode: str, pp_rank: int, pp_size: int
+) -> bool:
+    return disaggregation_mode == "prefill" and pp_size > 1 and pp_rank < pp_size - 1
+
+
 class DSparkWorkerV2(BaseSpecWorker):
 
     def __init__(
@@ -93,6 +107,27 @@ class DSparkWorkerV2(BaseSpecWorker):
             server_args.enable_dp_attention and not self._draft_is_moe
         )
         self._is_pd_prefill = server_args.disaggregation_mode == "prefill"
+        self._is_context_only_pp_prefill_rank = _is_context_only_pp_prefill_rank(
+            disaggregation_mode=server_args.disaggregation_mode,
+            pp_rank=ps.pp_rank,
+            pp_size=ps.pp_size,
+        )
+        self._use_full_projection_prefill = False
+        if self._is_pd_prefill and self._draft_is_moe and ps.pp_size > 1:
+            target_layer_ids = [
+                int(layer_id)
+                for layer_id in (
+                    self.model_runner.spec_aux_config.dflash_target_layer_ids or []
+                )
+            ]
+            owner_pp_rank = resolve_single_owner_pp_rank(
+                target_layer_ids=target_layer_ids,
+                num_hidden_layers=self.model_runner.model_config.num_hidden_layers,
+                pp_size=ps.pp_size,
+            )
+            self._use_full_projection_prefill = (
+                owner_pp_rank == ps.pp_size - 1 and ps.pp_rank == owner_pp_rank
+            )
         self._decode_graph_allowed = (
             not server_args.disable_cuda_graph and not self._is_pd_prefill
         )
@@ -111,7 +146,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             bundle = build_draft_tp_worker(
                 server_args=server_args,
                 gpu_id=gpu_id,
-                ps=replace(ps, pp_rank=0),
+                ps=ps,
                 nccl_port=nccl_port,
                 target_model_config=target_worker.model_runner.model_config,
                 algo_label="DSPARK",
@@ -123,6 +158,9 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.draft_model_runner = bundle.draft_model_runner
         self.draft_model = bundle.draft_model
         self._draft_sampler = None
+        self._is_lifecycle_only_pp_prefill_rank = (
+            self._draft_is_moe and self.draft_model.is_lifecycle_only
+        )
 
         runtime_config = resolve_runtime_config(
             draft_hf_config=self.draft_model_runner.model_config.hf_config,
@@ -135,6 +173,12 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.verify_num_draft_tokens = runtime_config.verify_num_draft_tokens
         self.speculative_num_draft_tokens = self.verify_num_draft_tokens
         self._mask_token_id = runtime_config.mask_token_id
+        self._pp_context_feature_indices: Optional[list[int]] = None
+        self._next_pp_proxy_tensors = None
+
+        if self._is_lifecycle_only_pp_prefill_rank:
+            self._init_lifecycle_only_prefill()
+            return
 
         if self.ps.tp_rank == 0:
             logger.info(
@@ -158,14 +202,16 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         target_model = self.target_worker.model_runner.model
         lm_head = getattr(target_model, "lm_head", None)
-        if lm_head is None or not hasattr(lm_head, "weight"):
+        needs_lm_head = not self._is_context_only_pp_prefill_rank
+        if needs_lm_head and (lm_head is None or not hasattr(lm_head, "weight")):
             raise RuntimeError(
                 "DSpark requires the target model to expose `lm_head` with `weight`."
             )
-        self.draft_model.attach_shared_modules(
-            embed_tokens=self._resolve_target_embed_tokens(target_model),
-            lm_head=lm_head,
-        )
+        if needs_lm_head:
+            self.draft_model.attach_shared_modules(
+                embed_tokens=self._resolve_target_embed_tokens(target_model),
+                lm_head=lm_head,
+            )
 
         self._verify_planner = DSparkVerifyPlanner(
             draft_model=self.draft_model,
@@ -269,20 +315,88 @@ class DSparkWorkerV2(BaseSpecWorker):
             simulate_acc_len=self._simulate_acc_len,
         )
 
-        if self._is_pd_prefill and not self._draft_is_moe:
-            self.draft_model.prune_to_ctx_kv_injection()
+        if self._is_pd_prefill:
+            if self._draft_is_moe and self._is_context_only_pp_prefill_rank:
+                self.draft_model.prune_to_ctx_projection()
+            elif not self._draft_is_moe:
+                self.draft_model.prune_to_ctx_kv_injection()
+            self._init_pp_context_feature_indices()
+
+    def _init_lifecycle_only_prefill(self) -> None:
+        self._verify_planner = None
+        self._kv_injector = None
+        self._proposer = None
+        self._verify_epilogue = None
+        self._verify_executor = None
+        self._simulate_acc_len = float(envs.SGLANG_SIMULATE_ACC_LEN.get())
+        self._forced_budget_frac = None
+        self._need_mamba_verify_commit = False
+        self._observers = None
 
     def _resolve_target_embed_tokens(self, target_model):
         if hasattr(target_model, "get_input_embeddings"):
             return target_model.get_input_embeddings()
         return target_model.model.get_input_embeddings()
 
+    def _init_pp_context_feature_indices(self) -> None:
+        if self.ps.pp_size <= 1:
+            return
+        if not hasattr(self.draft_model, "project_target_hidden_partial"):
+            return
+
+        target_layer_ids = getattr(
+            self.model_runner.spec_aux_config, "dflash_target_layer_ids", None
+        )
+        if not target_layer_ids:
+            return
+
+        target_model = self.target_worker.model_runner.model
+        start_layer = int(getattr(target_model, "start_layer", 0))
+        end_layer = int(getattr(target_model, "end_layer", 0))
+        target_layer_to_feature = {
+            int(layer_id): idx for idx, layer_id in enumerate(target_layer_ids)
+        }
+        local_feature_indices = [
+            target_layer_to_feature[layer_id]
+            for layer_id in range(start_layer, end_layer)
+            if layer_id in target_layer_to_feature
+        ]
+        if not local_feature_indices:
+            return
+
+        self._pp_context_feature_indices = local_feature_indices
+        if self._draft_is_moe and not self._use_full_projection_prefill:
+            self.draft_model.prepare_target_hidden_partial(local_feature_indices)
+        if self.ps.tp_rank == 0:
+            logger.info(
+                "DSpark PP-local context projection will accumulate feature indices %s "
+                "from target layers %s for PP rank %s local layers [%s, %s).",
+                local_feature_indices,
+                list(target_layer_ids),
+                self.ps.pp_rank,
+                start_layer,
+                end_layer,
+            )
+
     @property
     def carries_confidence(self) -> bool:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return False
         return self._verify_planner.carries_confidence
 
     @property
+    def is_lifecycle_only_pp_prefill_rank(self) -> bool:
+        return self._is_lifecycle_only_pp_prefill_rank
+
+    def _draft_model_runners(self) -> tuple:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return ()
+        return super()._draft_model_runners()
+
+    @property
     def spec_v2_attn_backends(self) -> tuple:
+        if self._is_context_only_pp_prefill_rank:
+            return (self._target_worker.model_runner.attn_backend,)
         return (
             self._target_worker.model_runner.attn_backend,
             self.draft_model_runner.attn_backend,
@@ -293,10 +407,14 @@ class DSparkWorkerV2(BaseSpecWorker):
             raise AttributeError(name)
         return getattr(self.target_worker, name)
 
+    @contextmanager
     def _draft_context(self):
-        if self._draft_dp_context_enabled:
-            return draft_tp_context(get_parallel().attn_tp_group)
-        return nullcontext()
+        with ExitStack() as stack:
+            if self._draft_dp_context_enabled:
+                stack.enter_context(draft_tp_context(get_parallel().attn_tp_group))
+            stack.enter_context(speculative_moe_backend_context())
+            stack.enter_context(speculative_moe_a2a_backend_context())
+            yield
 
     def alloc_memory_pool(
         self,
@@ -304,6 +422,26 @@ class DSparkWorkerV2(BaseSpecWorker):
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
     ):
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return
+        if memory_pool_config is not None and self._is_context_only_pp_prefill_rank:
+            page_size = int(self.page_size)
+
+            def _minimal_capacity(capacity):
+                if capacity is None or capacity == 0:
+                    return capacity
+                return page_size
+
+            memory_pool_config = replace(
+                memory_pool_config,
+                max_total_num_tokens=page_size,
+                full_max_total_num_tokens=_minimal_capacity(
+                    memory_pool_config.full_max_total_num_tokens
+                ),
+                swa_max_total_num_tokens=_minimal_capacity(
+                    memory_pool_config.swa_max_total_num_tokens
+                ),
+            )
         self._draft_worker.alloc_memory_pool(
             memory_pool_config=memory_pool_config,
             req_to_token_pool=req_to_token_pool,
@@ -311,6 +449,9 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
 
     def init_attention_backends(self):
+        if self._is_context_only_pp_prefill_rank:
+            self._need_mamba_verify_commit = False
+            return
         with self._draft_context():
             self._draft_worker.init_attention_backends()
         self._need_mamba_verify_commit = mambaish_config(
@@ -321,6 +462,8 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
 
     def init_cuda_graphs(self):
+        if self._is_context_only_pp_prefill_rank:
+            return
         capture_decode_cuda_graph = self._decode_graph_allowed
         if is_cuda() and capture_decode_cuda_graph:
             available_mem = get_available_gpu_memory(self.device, self.gpu_id)
@@ -365,21 +508,57 @@ class DSparkWorkerV2(BaseSpecWorker):
     def clear_cache_pool(self):
         pass
 
+    def _refresh_partial_projection(self) -> None:
+        if (
+            self._draft_is_moe
+            and not self._is_lifecycle_only_pp_prefill_rank
+            and not self._use_full_projection_prefill
+            and self._pp_context_feature_indices is not None
+        ):
+            self.draft_model.prepare_target_hidden_partial(
+                self._pp_context_feature_indices
+            )
+
+    def update_weights_from_disk(self, recv_req):
+        success, message = super().update_weights_from_disk(recv_req)
+        if success:
+            self._refresh_partial_projection()
+        return success, message
+
+    def update_weights_from_ipc(self, recv_req):
+        success, message = super().update_weights_from_ipc(recv_req)
+        if success:
+            self._refresh_partial_projection()
+        return success, message
+
     def set_dspark_forced_budget_frac(self, frac: Optional[float]) -> None:
         self._forced_budget_frac = frac
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return
         self._verify_planner.set_forced_budget_frac(frac)
 
     def dump_info_records(self) -> Optional[dict]:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return None
         return self._observers.dump_info_records()
 
     def clear_info_records(self) -> None:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return
         self._observers.clear_info_records()
 
     def block_accept_estimate_log_suffix(self) -> Optional[str]:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return None
         return self._observers.block_accept_estimate_log_suffix()
 
     def note_request_finished(self, *, rid: str, natural_stop: bool) -> None:
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return
         self._observers.note_request_finished(rid=rid, natural_stop=natural_stop)
+
+    def set_pp_proxy_tensors_for_next_forward(self, pp_proxy_tensors) -> None:
+        self._next_pp_proxy_tensors = pp_proxy_tensors
 
     def forward_batch_generation(
         self,
@@ -387,42 +566,95 @@ class DSparkWorkerV2(BaseSpecWorker):
         on_publish=None,
         grammar_barrier=None,
     ) -> GenerationBatchResult:
+        pp_proxy_tensors = self._next_pp_proxy_tensors
+        self._next_pp_proxy_tensors = None
+
         if getattr(batch, "return_logprob", False):
             raise ValueError(
                 "DSpark speculative decoding does not support return_logprob yet."
             )
 
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return self._forward_lifecycle_only_prefill(
+                batch=batch,
+                on_publish=on_publish,
+                pp_proxy_tensors=pp_proxy_tensors,
+            )
+
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
-            return self._forward_prefill(batch, on_publish)
+            return self._forward_prefill(batch, on_publish, pp_proxy_tensors)
 
         return self._forward_decode(batch, on_publish, grammar_barrier)
 
-    def _forward_prefill(
-        self, batch: ScheduleBatch, on_publish
+    def _forward_lifecycle_only_prefill(
+        self, *, batch: ScheduleBatch, on_publish, pp_proxy_tensors
     ) -> GenerationBatchResult:
         if batch.forward_mode.is_idle():
-            if get_parallel().enable_dp_attention:
-                self.target_worker.forward_batch_generation(
-                    batch, capture_hidden_mode=CaptureHiddenMode.FULL
-                )
-            return self._decode_idle_result(on_publish=on_publish)
+            return self._forward_idle_prefill(
+                batch=batch,
+                on_publish=on_publish,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=CaptureHiddenMode.NULL,
+            )
+        if not (batch.forward_mode.is_extend() or batch.is_extend_in_batch):
+            raise RuntimeError(
+                "Lifecycle-only DSpark worker only supports prefill batches."
+            )
 
         batch_output = self.target_worker.forward_batch_generation(
-            batch, capture_hidden_mode=CaptureHiddenMode.FULL
+            batch,
+            pp_proxy_tensors=pp_proxy_tensors,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+        )
+        batch_output.new_seq_lens = batch.seq_lens
+        if on_publish is not None:
+            on_publish(batch_output.new_seq_lens)
+        if batch_output.logits_output is not None:
+            batch_output.logits_output.hidden_states = None
+        return batch_output
+
+    def _forward_prefill(
+        self, batch: ScheduleBatch, on_publish, pp_proxy_tensors=None
+    ) -> GenerationBatchResult:
+        if batch.forward_mode.is_idle():
+            return self._forward_idle_prefill(
+                batch=batch,
+                on_publish=on_publish,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+            )
+
+        batch_output = self.target_worker.forward_batch_generation(
+            batch,
+            pp_proxy_tensors=pp_proxy_tensors,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
         )
         logits_output = batch_output.logits_output
+        output_pp_proxy_tensors = batch_output.pp_hidden_states_proxy_tensors
+        target_hidden = (
+            logits_output.hidden_states
+            if logits_output is not None
+            else (
+                output_pp_proxy_tensors.tensors.get("dspark_aux_hidden_states")
+                if output_pp_proxy_tensors is not None
+                else None
+            )
+        )
         next_token_ids = batch_output.next_token_ids
         batch_output.new_seq_lens = batch.seq_lens
         if on_publish is not None:
             on_publish(batch_output.new_seq_lens)
 
-        if logits_output.hidden_states is None:
+        if target_hidden is None and self.ps.pp_size <= 1:
             raise RuntimeError(
                 "DSpark requires target aux hidden capture for prefill, but got None. "
                 "Make sure the target model has DFlash layers-to-capture configured."
             )
+        has_local_target_hidden = (
+            target_hidden is not None and target_hidden.numel() > 0
+        )
         if batch.extend_lens is None or batch.prefix_lens is None:
             raise RuntimeError(
                 "DSpark expected extend_lens / prefix_lens in extend mode, got None."
@@ -432,7 +664,10 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         # Must inject before prefill returns: the scheduler may update radix
         # afterward, invalidating out_cache_loc.
-        device = next_token_ids.device
+        # Non-last PP ranks return PPProxyTensors and do not sample tokens, so
+        # next_token_ids is None there. Positions are still needed for local
+        # draft-KV injection, and should live on this worker's device.
+        device = self.device
         ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
         draft_seq_lens = torch.tensor(
             batch.prefix_lens, dtype=torch.int32, device=device
@@ -443,19 +678,105 @@ class DSparkWorkerV2(BaseSpecWorker):
             ctx_lens,
             int(sum(batch.extend_lens)),
         )
-        self._kv_injector.inject_target_hidden(
-            target_hidden=logits_output.hidden_states,
-            cache_loc=batch.out_cache_loc,
-            positions=positions,
-        )
-        # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
-        logits_output.hidden_states = None
+        state_slot = final_pos = None
+        if is_unified_kv_triton():
+            repeats = ctx_lens.to(torch.int64)
+            state_slot = torch.repeat_interleave(
+                batch.req_pool_indices.to(device=device, dtype=torch.int64), repeats
+            )
+            final_pos = torch.repeat_interleave(
+                (draft_seq_lens + ctx_lens - 1).to(torch.int64), repeats
+            )
+        if self._use_full_projection_prefill:
+            if not has_local_target_hidden or output_pp_proxy_tensors is not None:
+                raise RuntimeError(
+                    "Single-owner DSpark prefill requires target hidden states "
+                    "on the final PP rank."
+                )
+            self._kv_injector.inject_target_hidden(
+                target_hidden=target_hidden,
+                cache_loc=batch.out_cache_loc,
+                positions=positions,
+                state_slot=state_slot,
+                final_pos=final_pos,
+            )
+        else:
+            incoming_ctx = (
+                pp_proxy_tensors.tensors.get("dspark_ctx_acc")
+                if pp_proxy_tensors is not None
+                else None
+            )
+            local_ctx = None
+            if (
+                self.ps.pp_size > 1
+                and has_local_target_hidden
+                and self._pp_context_feature_indices is not None
+            ):
+                local_ctx = self.draft_model.project_target_hidden_partial(
+                    target_hidden, self._pp_context_feature_indices
+                )
+            if output_pp_proxy_tensors is not None:
+                output_pp_proxy_tensors.tensors.pop("dspark_aux_hidden_states", None)
+            ctx_acc = None
+            if incoming_ctx is not None and local_ctx is not None:
+                ctx_acc = (
+                    incoming_ctx.to(device=local_ctx.device, dtype=local_ctx.dtype)
+                    + local_ctx
+                )
+            elif incoming_ctx is not None:
+                ctx_acc = incoming_ctx.to(device=self.device, non_blocking=True)
+            elif local_ctx is not None:
+                ctx_acc = local_ctx
 
-        batch_output.next_draft_input = make_next_draft_input(
-            bonus_tokens=next_token_ids,
-            new_seq_lens=batch.seq_lens,
-        )
+            if output_pp_proxy_tensors is not None:
+                if ctx_acc is not None:
+                    output_pp_proxy_tensors.tensors["dspark_ctx_acc"] = ctx_acc
+            elif ctx_acc is not None:
+                self._kv_injector.inject_projected_context(
+                    projected_context=ctx_acc,
+                    cache_loc=batch.out_cache_loc,
+                    positions=positions,
+                    state_slot=state_slot,
+                    final_pos=final_pos,
+                )
+            elif has_local_target_hidden and not (
+                self.ps.pp_size > 1 and not self._draft_is_moe
+            ):
+                self._kv_injector.inject_target_hidden(
+                    target_hidden=target_hidden,
+                    cache_loc=batch.out_cache_loc,
+                    positions=positions,
+                    state_slot=state_slot,
+                    final_pos=final_pos,
+                )
+        # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
+        if logits_output is not None:
+            logits_output.hidden_states = None
+
+        if next_token_ids is not None:
+            batch_output.next_draft_input = make_next_draft_input(
+                bonus_tokens=next_token_ids,
+                new_seq_lens=batch.seq_lens,
+            )
         return batch_output
+
+    def _forward_idle_prefill(
+        self,
+        *,
+        batch: ScheduleBatch,
+        on_publish,
+        pp_proxy_tensors,
+        capture_hidden_mode: CaptureHiddenMode,
+    ) -> GenerationBatchResult:
+        if get_parallel().enable_dp_attention:
+            batch_output = self.target_worker.forward_batch_generation(
+                batch,
+                pp_proxy_tensors=pp_proxy_tensors,
+                capture_hidden_mode=capture_hidden_mode,
+            )
+            if self._is_context_only_pp_prefill_rank:
+                return batch_output
+        return self._decode_idle_result(on_publish=on_publish)
 
     def _idle_verify_ragged_layout(self, batch: ScheduleBatch):
         if batch.global_num_tokens is None or not self._verify_planner.is_compact_mode:
@@ -520,7 +841,8 @@ class DSparkWorkerV2(BaseSpecWorker):
             self._observers.note_idle_decode_step()
             if get_parallel().enable_dp_attention:
                 if self._draft_is_moe:
-                    self._proposer.run_idle_participation(batch)
+                    with self._draft_context():
+                        self._proposer.run_idle_participation(batch)
                 self._verify_executor.run_idle_participation(
                     batch=batch, idle_layout=self._idle_verify_ragged_layout(batch)
                 )
@@ -785,4 +1107,6 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
 
     def get_confidence_budget_prepare(self):
+        if self._is_lifecycle_only_pp_prefill_rank:
+            return None
         return self._verify_planner.confidence_budget_prepare()

--- a/test/registered/cp/test_deepseek_v4_flash_fp4_b200_cp.py
+++ b/test/registered/cp/test_deepseek_v4_flash_fp4_b200_cp.py
@@ -195,5 +195,49 @@ class TestDSV4FlashFP4B200Balanced_CP_NonDeepEP(
             kill_process_tree(cls.process.pid)
 
 
+# DSPARK draft is bundled with the -DSpark checkpoint.
+DSPARK_MODEL = "deepseek-ai/DeepSeek-V4-Flash-DSpark"
+
+
+class TestDSV4FlashFP4B200_CP_DSpark(
+    BasicDecodeCorrectnessMixin,
+    GSM8KMixin,
+    CustomTestCase,
+):
+    """DSPARK speculation + prefill CP (interleave, CP_V2, attn_cp=tp)."""
+
+    gsm8k_accuracy_thres = 0.90
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = try_cached_model(DSPARK_MODEL)
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=[
+                "--trust-remote-code",
+                "--tp",
+                "4",
+                "--attn-cp-size",
+                "4",
+                "--speculative-algorithm",
+                "DSPARK",
+                "--enable-prefill-cp",
+                "--cp-strategy",
+                "interleave",
+                "--moe-runner-backend",  # for fp4 checkpoint
+                "flashinfer_mxfp4",
+            ],
+            env={"SGLANG_ENABLE_CP_V2": "1"},
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -15,7 +15,10 @@ from sglang.srt.disaggregation.common.utils import (
 from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     get_dsv4_c128_state_indices,
+    pack_state_types,
+    resolve_state_component_dst_index,
     setup_state_kv_args,
+    unpack_state_types,
 )
 from sglang.srt.managers.overlap_utils import FutureMap, RelayPayload
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
@@ -57,6 +60,24 @@ class TestDisaggregationWire(unittest.TestCase):
     def test_list_of_buffers_roundtrip(self):
         bufs = [b"abc", b"", b"de", b"x" * 17]
         self.assertEqual(unpack_list_of_buffers(pack_list_of_buffers(bufs)), bufs)
+
+    def test_state_component_matching_uses_type_occurrence(self):
+        src_state_types = [StateType.SWA, StateType.SWA]
+        dst_state_types = [StateType.SWA, StateType.C128_STATE, StateType.SWA]
+
+        self.assertEqual(
+            resolve_state_component_dst_index(src_state_types, dst_state_types, 0),
+            0,
+        )
+        self.assertEqual(
+            resolve_state_component_dst_index(src_state_types, dst_state_types, 1),
+            2,
+        )
+
+    def test_state_types_roundtrip(self):
+        state_types = [StateType.SWA, StateType.C128_STATE, StateType.SWA_RING]
+
+        self.assertEqual(unpack_state_types(pack_state_types(state_types)), state_types)
 
 
 class TestGroupConcurrentContiguous(unittest.TestCase):

--- a/test/registered/unit/disaggregation/test_pp_pd_consensus.py
+++ b/test/registered/unit/disaggregation/test_pp_pd_consensus.py
@@ -1,0 +1,296 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.base import KVPoll  # noqa: E402
+from sglang.srt.disaggregation.prefill import (  # noqa: E402
+    PrefillBootstrapQueue,
+    SchedulerDisaggregationPrefillMixin,
+)
+from sglang.srt.disaggregation.utils import (  # noqa: E402
+    _DRAFT_KV_LAYER_ID_BASE,
+    build_transfer_entry_pairs,
+)
+from sglang.srt.managers.schedule_batch import FINISH_ABORT  # noqa: E402
+from sglang.srt.managers.scheduler_pp_mixin import (  # noqa: E402
+    _pp_merge_transfer_status,
+)
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestPPPDConsensus(CustomTestCase):
+    @staticmethod
+    def _make_prefill_queue(pp_rank):
+        class FakeKVArgs:
+            pass
+
+        class FakeManager:
+            def __init__(self, kv_args, *_args):
+                self.kv_args = kv_args
+
+        class FakePool:
+            start_layer = 4
+            end_layer = 6
+            head_num = 1
+            page_size = 64
+
+            @staticmethod
+            def get_contiguous_buf_infos():
+                return [10, 11], [100, 100], [10, 10]
+
+        class FakeDraftPool:
+            start_layer = 0
+            end_layer = 1
+
+            @staticmethod
+            def get_contiguous_buf_infos():
+                return [20], [100], [10]
+
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.transfer_backend = "mooncake"
+        queue.tp_rank = 0
+        queue.pp_rank = pp_rank
+        queue.pp_size = 2
+        queue.scheduler = SimpleNamespace(
+            ps=SimpleNamespace(dp_rank=0, gpu_id=0),
+            server_args=SimpleNamespace(disaggregation_ib_device=None),
+            tp_worker=SimpleNamespace(
+                model_runner=SimpleNamespace(kv_cache_dtype_str="auto")
+            ),
+            model_config=SimpleNamespace(
+                num_hidden_layers=8,
+                get_total_num_kv_heads=lambda: 1,
+            ),
+            req_to_token_pool=None,
+        )
+        queue.token_to_kv_pool = FakePool()
+        queue.draft_token_to_kv_pool = FakeDraftPool()
+        queue.metadata_buffers = SimpleNamespace(get_buf_infos=lambda: ([], [], []))
+        queue.is_mla_backend = False
+        return queue, FakeKVArgs, FakeManager
+
+    def test_transfer_failure_overrides_ordered_success_intersection(self):
+        """A failure on one PP rank must terminate an otherwise successful rid."""
+        status = _pp_merge_transfer_status(
+            previous=(["req-a", "req-b", "req-c"], ["req-x"]),
+            current=(["req-c", "req-a", "req-b"], ["req-b", "req-y"]),
+        )
+
+        self.assertEqual(
+            status,
+            (["req-a", "req-c"], ["req-x", "req-b", "req-y"]),
+        )
+
+    def test_bootstrap_probe_respects_local_metadata_credit_prefix(self):
+        """A slower PP rank must not advertise requests it cannot admit."""
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.queue = [
+            SimpleNamespace(
+                rid="req-failed",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-ready",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-blocked",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+        ]
+        queue.scheduler = SimpleNamespace(
+            attn_cp_cpu_group=object(),
+            attn_tp_cpu_group=object(),
+        )
+        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(
+            available_size=lambda: 1
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.prefill." "poll_and_all_reduce_attn_cp_tp_group",
+            return_value=[
+                KVPoll.Failed,
+                KVPoll.WaitingForInput,
+                KVPoll.WaitingForInput,
+            ],
+        ):
+            good_rids, failed_rids = queue.get_ready_bootstrapped_rids_for_pp()
+
+        self.assertEqual(good_rids, ["req-ready"])
+        self.assertEqual(failed_rids, ["req-failed"])
+        self.assertEqual(
+            [req.metadata_buffer_index for req in queue.queue],
+            [-1, -1, -1],
+        )
+
+    def test_bootstrap_probe_reports_failures_after_metadata_backpressure(self):
+        """Admission backpressure must not hide terminal failures later in FIFO."""
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.queue = [
+            SimpleNamespace(
+                rid="req-blocked",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-failed",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-ready-after-block",
+                metadata_buffer_index=0,
+                disagg_kv_sender=object(),
+            ),
+        ]
+        queue.scheduler = SimpleNamespace(
+            attn_cp_cpu_group=object(),
+            attn_tp_cpu_group=object(),
+        )
+        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(
+            available_size=lambda: 0
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.prefill." "poll_and_all_reduce_attn_cp_tp_group",
+            return_value=[
+                KVPoll.WaitingForInput,
+                KVPoll.Failed,
+                KVPoll.WaitingForInput,
+            ],
+        ):
+            good_rids, failed_rids = queue.get_ready_bootstrapped_rids_for_pp()
+
+        self.assertEqual(good_rids, [])
+        self.assertEqual(failed_rids, ["req-failed"])
+
+    def test_remote_failure_waits_for_local_transfer_terminal_state(self):
+        """Do not release source KV while the local Mooncake worker is reading it."""
+        sender = SimpleNamespace()
+        req = SimpleNamespace(
+            rid="req-race",
+            disagg_kv_sender=sender,
+            finished_reason=None,
+            pending_bootstrap=False,
+            return_logprob=False,
+            time_stats=SimpleNamespace(set_completion_time=Mock()),
+        )
+        handle_failure = Mock()
+        scheduler = SimpleNamespace(
+            disagg_prefill_inflight_queue=[req],
+            attn_cp_cpu_group=object(),
+            attn_tp_cpu_group=object(),
+            ps=SimpleNamespace(pp_rank=1),
+            handle_inflight_transfer_failure=handle_failure,
+            output_streamer=SimpleNamespace(stream_output=Mock()),
+            req_to_metadata_buffer_idx_allocator=object(),
+        )
+
+        def mark_abort(target_req, message, status_code):
+            del message, status_code
+            target_req.finished_reason = FINISH_ABORT("remote PP failure")
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill."
+                "poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.Transferring],
+            ),
+            patch(
+                "sglang.srt.disaggregation.prefill.prepare_abort",
+                side_effect=mark_abort,
+            ),
+        ):
+            done_reqs = SchedulerDisaggregationPrefillMixin.process_disagg_prefill_inflight_queue(
+                scheduler,
+                transfer_status=([], ["req-race"]),
+            )
+
+        self.assertEqual(done_reqs, [])
+        self.assertEqual(scheduler.disagg_prefill_inflight_queue, [req])
+        handle_failure.assert_not_called()
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.prefill."
+                "poll_and_all_reduce_attn_cp_tp_group",
+                return_value=[KVPoll.Success],
+            ),
+            patch("sglang.srt.disaggregation.prefill.maybe_release_metadata_buffer"),
+        ):
+            done_reqs = SchedulerDisaggregationPrefillMixin.process_disagg_prefill_inflight_queue(
+                scheduler,
+                transfer_status=([], []),
+            )
+
+        self.assertEqual(done_reqs, [req])
+        self.assertEqual(scheduler.disagg_prefill_inflight_queue, [])
+        handle_failure.assert_called_once_with(req)
+
+    def test_only_last_pp_registers_draft_kv_for_transfer(self):
+        """Draft KV has one prefill owner even though every PP rank has a worker."""
+        layer_ids_by_rank = []
+        for pp_rank in (0, 1):
+            queue, fake_args, fake_manager = self._make_prefill_queue(pp_rank)
+
+            def get_kv_class(_backend, class_type):
+                return fake_args if class_type.value == "kvargs" else fake_manager
+
+            with (
+                patch(
+                    "sglang.srt.disaggregation.prefill.get_kv_class",
+                    side_effect=get_kv_class,
+                ),
+                patch(
+                    "sglang.srt.disaggregation.prefill.setup_state_kv_args",
+                ),
+            ):
+                manager = queue._init_kv_manager()
+            layer_ids_by_rank.append(manager.kv_args.kv_layer_ids)
+
+        self.assertEqual(layer_ids_by_rank[0], [4, 5])
+        self.assertEqual(
+            layer_ids_by_rank[1],
+            [4, 5, _DRAFT_KV_LAYER_ID_BASE],
+        )
+
+    def test_pp_prefill_entries_pair_with_pp1_decode_entries(self):
+        """Each PP source maps target layers plus the unique draft entry by id."""
+        decode_layer_ids = [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            _DRAFT_KV_LAYER_ID_BASE,
+        ]
+
+        rank_0_pairs = build_transfer_entry_pairs(
+            src_layer_ids=[0, 1, 2, 3],
+            dst_layer_ids=decode_layer_ids,
+            n_src=4,
+            n_dst=7,
+        )
+        rank_1_pairs = build_transfer_entry_pairs(
+            src_layer_ids=[4, 5, _DRAFT_KV_LAYER_ID_BASE],
+            dst_layer_ids=decode_layer_ids,
+            n_src=3,
+            n_dst=7,
+        )
+
+        self.assertEqual(rank_0_pairs, [(0, 0), (1, 1), (2, 2), (3, 3)])
+        self.assertEqual(rank_1_pairs, [(0, 4), (1, 5), (2, 6)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dspark_pp_context.py
+++ b/test/registered/unit/spec/test_dspark_pp_context.py
@@ -1,0 +1,387 @@
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod  # noqa: E402
+from sglang.srt.mem_cache.kv_cache_builder import get_draft_kv_pool  # noqa: E402
+from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig  # noqa: E402
+from sglang.srt.model_executor.runner.base_runner import (  # noqa: E402
+    _allocate_decode_buffers,
+)
+from sglang.srt.model_executor.runner_utils.buffers import (  # noqa: E402
+    DecodeInputBuffers,
+)
+from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM  # noqa: E402
+from sglang.srt.models.deepseek_v4_dspark import (  # noqa: E402
+    DeepseekV4ForCausalLMDSpark,
+    _BlockFp8LinearSlice,
+)
+from sglang.srt.models.dflash import DFlashDraftModel  # noqa: E402
+from sglang.srt.speculative.dspark_components.dspark_config import (  # noqa: E402
+    resolve_single_owner_pp_rank,
+    use_lifecycle_only_draft_model,
+)
+from sglang.srt.speculative.dspark_components.dspark_worker_v2 import (  # noqa: E402
+    DSparkWorkerV2,
+    _is_context_only_pp_prefill_rank,
+)
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _TupleLinear(torch.nn.Module):
+    def __init__(self, input_size: int, output_size: int):
+        super().__init__()
+        self.linear = torch.nn.Linear(input_size, output_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor):
+        return self.linear(hidden_states), None
+
+
+def _make_deepseek_v4_dspark_projection_model(
+    *, hidden_size: int, num_target_features: int
+) -> DeepseekV4ForCausalLMDSpark:
+    model = DeepseekV4ForCausalLMDSpark.__new__(DeepseekV4ForCausalLMDSpark)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(hidden_size=hidden_size)
+    model.num_target_features = num_target_features
+    stage = torch.nn.Module()
+    stage.main_proj = _TupleLinear(hidden_size * num_target_features, hidden_size)
+    stage.main_norm = torch.nn.RMSNorm(hidden_size, eps=1e-6)
+    model.stages = torch.nn.ModuleList([stage])
+    model.markov_head = torch.nn.Identity()
+    model.confidence_head = torch.nn.Identity()
+    model.embed_tokens = None
+    model.lm_head = None
+    model.is_lifecycle_only = False
+    model._partial_feature_indices = ()
+    model._partial_main_proj = None
+    return model
+
+
+class TestDSparkPPContext(CustomTestCase):
+    def test_full_projection_fast_path_requires_final_pp_owner(self):
+        """Only final-rank ownership can bypass the ctx_acc handoff."""
+        with patch.dict(
+            os.environ,
+            {"SGLANG_PP_LAYER_PARTITION": "6,5,6,5,6,5,5,5"},
+        ):
+            self.assertEqual(
+                resolve_single_owner_pp_rank(
+                    target_layer_ids=[40, 41, 42],
+                    num_hidden_layers=43,
+                    pp_size=8,
+                ),
+                7,
+            )
+            self.assertIsNone(
+                resolve_single_owner_pp_rank(
+                    target_layer_ids=[35, 40],
+                    num_hidden_layers=43,
+                    pp_size=8,
+                )
+            )
+
+    def test_lifecycle_only_draft_model_is_limited_to_non_owner_ranks(self):
+        common = dict(
+            disaggregation_mode="prefill",
+            pp_size=8,
+            target_layer_ids=[40, 41, 42],
+            num_hidden_layers=43,
+        )
+        for pp_rank in range(7):
+            self.assertTrue(use_lifecycle_only_draft_model(pp_rank=pp_rank, **common))
+        self.assertFalse(use_lifecycle_only_draft_model(pp_rank=7, **common))
+        self.assertFalse(
+            use_lifecycle_only_draft_model(
+                pp_rank=0,
+                **{**common, "target_layer_ids": [35, 40]},
+            )
+        )
+
+    def test_lifecycle_only_model_does_not_consume_checkpoint_weights(self):
+        model = DeepseekV4ForCausalLMDSpark.__new__(DeepseekV4ForCausalLMDSpark)
+        torch.nn.Module.__init__(model)
+        model.is_lifecycle_only = True
+
+        def weights():
+            raise AssertionError("lifecycle-only model consumed checkpoint weights")
+            yield
+
+        model.load_weights(weights())
+
+    def test_block_fp8_projection_slice_selects_matching_weight_and_scale_blocks(self):
+        feature_width = 128
+        output_size = 2
+        quant_method = Fp8LinearMethod(
+            Fp8Config(
+                is_checkpoint_fp8_serialized=True,
+                activation_scheme="dynamic",
+                weight_block_size=[128, 128],
+            )
+        )
+        weight = torch.arange(
+            output_size * feature_width * 3, dtype=torch.float32
+        ).reshape(output_size, feature_width * 3)
+        weight_scale = torch.tensor([[11.0, 22.0, 33.0]])
+        source = SimpleNamespace(
+            quant_method=quant_method,
+            weight=torch.nn.Parameter(weight, requires_grad=False),
+            weight_scale_inv=torch.nn.Parameter(weight_scale, requires_grad=False),
+        )
+        source.weight_scale_inv.format_ue8m0 = False
+
+        projection_slice = _BlockFp8LinearSlice(
+            source=source,
+            feature_indices=[0, 2],
+            feature_width=feature_width,
+        )
+
+        expected_weight = torch.cat(
+            [weight[:, :feature_width], weight[:, 2 * feature_width :]], dim=1
+        )
+        self.assertTrue(torch.equal(projection_slice.weight, expected_weight))
+        self.assertTrue(
+            torch.equal(
+                projection_slice.weight_scale_inv,
+                torch.tensor([[11.0, 33.0]]),
+            )
+        )
+
+    def test_partial_projection_uses_prepared_quantized_slice(self):
+        model = _make_deepseek_v4_dspark_projection_model(
+            hidden_size=4, num_target_features=3
+        )
+        expected = torch.randn(2, 4)
+        projection_slice = Mock(return_value=expected)
+        model._partial_feature_indices = (1,)
+        model._partial_main_proj = projection_slice
+        local_hidden = torch.randn(2, 4)
+
+        actual = model.project_target_hidden_partial(local_hidden, [1])
+
+        projection_slice.assert_called_once_with(local_hidden)
+        self.assertIs(actual, expected)
+
+    def test_pp_spec_verify_buffers_use_token_axis(self):
+        """PP verify buffers must cover bs times speculative token width."""
+        max_bs = 64
+        num_tokens_per_req = 6
+        max_num_token = max_bs * num_tokens_per_req
+        common_kwargs = dict(
+            device=torch.device("cpu"),
+            max_bs=max_bs,
+            max_num_token=max_num_token,
+            hidden_size=4,
+            dtype=torch.float32,
+            dp_size=1,
+            pp_size=8,
+            is_encoder_decoder=False,
+            require_mlp_tp_gather=False,
+            seq_len_fill_value=1,
+            encoder_len_fill_value=0,
+            num_tokens_per_req=num_tokens_per_req,
+            cache_loc_dtype=torch.int64,
+            enable_mamba_track=False,
+            hc_hidden_size=16,
+        )
+        eager_buffers = _allocate_decode_buffers(vocab_size=8, **common_kwargs)
+        graph_buffers = DecodeInputBuffers.create(
+            next_token_logits_buffer=torch.zeros((max_num_token, 8)),
+            **common_kwargs,
+        )
+
+        self.assertEqual(
+            eager_buffers.pp_proxy_tensors["hidden_states"].shape,
+            (max_num_token, 16),
+        )
+        self.assertEqual(
+            graph_buffers.pp_proxy_tensors["hidden_states"].shape,
+            (max_num_token, 16),
+        )
+
+    def test_partial_projection_sum_matches_full_projection(self):
+        """PP partial projections must preserve the full pre-norm FC result."""
+        torch.manual_seed(0)
+        hidden_size = 4
+        model = DFlashDraftModel.__new__(DFlashDraftModel)
+        torch.nn.Module.__init__(model)
+        model.config = SimpleNamespace(hidden_size=hidden_size)
+        model.num_context_features = 3
+        model.fc = torch.nn.Linear(3 * hidden_size, hidden_size, bias=False)
+        model.hidden_norm = torch.nn.RMSNorm(hidden_size, eps=1e-6)
+
+        feature_hidden = [
+            torch.randn(5, hidden_size, dtype=torch.float32) for _ in range(3)
+        ]
+        full_hidden = torch.cat(feature_hidden, dim=-1)
+        full_projected = model.project_target_hidden(full_hidden)
+
+        stage_0 = model.project_target_hidden_partial(
+            torch.cat([feature_hidden[0], feature_hidden[2]], dim=-1),
+            [0, 2],
+        )
+        stage_1 = model.project_target_hidden_partial(feature_hidden[1], [1])
+        pp_projected = model.hidden_norm(stage_0 + stage_1)
+
+        torch.testing.assert_close(pp_projected, full_projected)
+
+    def test_deepseek_v4_partial_projection_survives_context_only_pruning(self):
+        """Cross-rank contributions must retain full projection math after pruning."""
+        torch.manual_seed(1)
+        hidden_size = 4
+        model = _make_deepseek_v4_dspark_projection_model(
+            hidden_size=hidden_size, num_target_features=3
+        )
+        features = [torch.randn(5, hidden_size, dtype=torch.float32) for _ in range(3)]
+        full_projected = model.project_target_hidden(torch.cat(features, dim=-1))
+
+        stage_0 = model.project_target_hidden_partial(
+            torch.cat([features[0], features[2]], dim=-1),
+            [0, 2],
+        )
+        model.prune_to_ctx_projection()
+        stage_1 = model.project_target_hidden_partial(features[1], [1])
+        pp_projected = model.stages[0].main_norm(stage_0 + stage_1)
+        write_context_hidden_kv = Mock()
+        model._write_context_hidden_kv = write_context_hidden_kv
+        model.write_projected_context_kv(
+            projected_context=stage_0 + stage_1,
+            swa_loc=torch.arange(5),
+            positions=torch.arange(5),
+            pool=object(),
+        )
+
+        self.assertEqual(list(model.stages[0]._modules), ["main_proj", "main_norm"])
+        torch.testing.assert_close(pp_projected, full_projected)
+        torch.testing.assert_close(
+            write_context_hidden_kv.call_args.kwargs["main_x"],
+            full_projected,
+        )
+
+    def test_deepseek_v4_capture_is_local_to_each_pp_rank(self):
+        """A target feature on a non-last rank must not disappear from ctx_acc."""
+        model = DeepseekV4ForCausalLM.__new__(DeepseekV4ForCausalLM)
+        torch.nn.Module.__init__(model)
+        model.pp_group = SimpleNamespace(is_last_rank=False)
+        model.model = SimpleNamespace(
+            start_layer=10,
+            end_layer=20,
+            dspark_layers_to_capture=None,
+        )
+        model.capture_aux_hidden_states = False
+
+        model.set_dspark_layers_to_capture([5, 12, 18, 25])
+
+        self.assertTrue(model.capture_aux_hidden_states)
+        self.assertEqual(model.model.dspark_layers_to_capture, [12, 18])
+
+    def test_non_last_pp_prefill_does_not_require_target_lm_head(self):
+        """PP0-PP(N-2) must initialize without the last rank's lm_head."""
+        self.assertTrue(
+            _is_context_only_pp_prefill_rank(
+                disaggregation_mode="prefill",
+                pp_rank=0,
+                pp_size=8,
+            )
+        )
+        self.assertFalse(
+            _is_context_only_pp_prefill_rank(
+                disaggregation_mode="prefill",
+                pp_rank=7,
+                pp_size=8,
+            )
+        )
+
+    def test_context_only_rank_does_not_require_draft_attention_backend(self):
+        """Projection-only ranks must initialize overlap state without draft attention."""
+        target_backend = object()
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._is_context_only_pp_prefill_rank = True
+        worker._target_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(attn_backend=target_backend)
+        )
+        worker.draft_model_runner = SimpleNamespace()
+
+        self.assertEqual(worker.spec_v2_attn_backends, (target_backend,))
+
+    def test_lifecycle_only_rank_does_not_allocate_draft_pool(self):
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._draft_worker = Mock()
+        worker._is_lifecycle_only_pp_prefill_rank = True
+
+        worker.alloc_memory_pool(memory_pool_config=Mock())
+
+        worker._draft_worker.alloc_memory_pool.assert_not_called()
+
+    def test_lifecycle_only_rank_does_not_publish_draft_pool(self):
+        worker = SimpleNamespace(is_lifecycle_only_pp_prefill_rank=True)
+        spec_algorithm = SimpleNamespace(
+            is_ngram=lambda: False,
+            is_dspark=lambda: True,
+        )
+
+        self.assertIsNone(
+            get_draft_kv_pool(
+                draft_worker=worker,
+                spec_algorithm=spec_algorithm,
+                server_args=SimpleNamespace(enable_multi_layer_eagle=False),
+            )
+        )
+
+    def test_non_last_pp_prefill_uses_minimal_draft_kv_pool(self):
+        """A context-only PP rank must not reserve the full draft KV capacity."""
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._draft_worker = Mock()
+        worker._is_pd_prefill = True
+        worker._draft_is_moe = True
+        worker._is_context_only_pp_prefill_rank = True
+        worker._is_lifecycle_only_pp_prefill_rank = False
+        worker.ps = SimpleNamespace(pp_rank=0, pp_size=2)
+        worker.page_size = 64
+        full_config = MemoryPoolConfig(
+            max_total_num_tokens=4096,
+            max_running_requests=32,
+        )
+
+        worker.alloc_memory_pool(memory_pool_config=full_config)
+
+        passed_config = worker._draft_worker.alloc_memory_pool.call_args.kwargs[
+            "memory_pool_config"
+        ]
+        self.assertEqual(passed_config.max_total_num_tokens, 64)
+        self.assertEqual(passed_config.max_running_requests, 32)
+        self.assertEqual(full_config.max_total_num_tokens, 4096)
+
+    def test_last_pp_prefill_keeps_full_draft_kv_pool(self):
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._draft_worker = Mock()
+        worker._is_pd_prefill = True
+        worker._draft_is_moe = True
+        worker._is_context_only_pp_prefill_rank = False
+        worker._is_lifecycle_only_pp_prefill_rank = False
+        worker.ps = SimpleNamespace(pp_rank=1, pp_size=2)
+        worker.page_size = 64
+        full_config = MemoryPoolConfig(
+            max_total_num_tokens=4096,
+            max_running_requests=32,
+        )
+
+        worker.alloc_memory_pool(memory_pool_config=full_config)
+
+        passed_config = worker._draft_worker.alloc_memory_pool.call_args.kwargs[
+            "memory_pool_config"
+        ]
+        self.assertIs(passed_config, full_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make DSV4 DSpark prefill/decode disaggregation pipeline-parallel aware
- synchronize PP transfer admission and terminal status across stages
- keep the full draft model and draft KV pool on the owning PP stage while retaining lifecycle-only state elsewhere
- carry partial target-context projections across PP stages
- wire DSpark through CP, DP attention, and DeepEP-compatible execution paths
- add focused CPU regression coverage for PP/PD consensus, DSpark PP context, and disaggregation wire compatibility

## Validation

- test_pp_pd_consensus.py: 6 passed
- test_dspark_pp_context.py: 15 passed
- test_disaggregation_wire.py: 20 passed
- git diff --check

## Base

Built directly on the latest ep_main (c435f334b0).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32457575458](https://github.com/bytedance-iaas/sglang/actions/runs/32457575458)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32457718501](https://github.com/bytedance-iaas/sglang/actions/runs/32457718501)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->