### PR TITLE
[DSpark][MoE] Support MegaMoE under DP attention

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -283,17 +283,33 @@ def _handle_dspark(server_args: ServerArgs) -> None:
     if server_args.enable_dp_attention and server_args.dp_size > 1:
         if not server_args.enable_dp_lm_head:
             raise ValueError("DSpark with dp attention requires --enable-dp-lm-head.")
-        supports_dspark_dp_moe = server_args.moe_a2a_backend == "none" or (
+        supports_dspark_dp_moe = server_args.moe_a2a_backend in (
+            "none",
+            "megamoe",
+        ) or (
             server_args.moe_a2a_backend == "deepep"
             and server_args.moe_runner_backend == "deep_gemm"
         )
         if not supports_dspark_dp_moe:
             raise ValueError(
-                "DSpark with dp attention only supports moe_a2a_backend='none' "
-                "or moe_a2a_backend='deepep' with moe_runner_backend='deep_gemm'; "
+                "DSpark with dp attention supports moe_a2a_backend='none', "
+                "moe_a2a_backend='megamoe', or moe_a2a_backend='deepep' with "
+                "moe_runner_backend='deep_gemm'; "
                 f"got moe_a2a_backend={server_args.moe_a2a_backend!r}, "
                 f"moe_runner_backend={server_args.moe_runner_backend!r}."
             )
+        if server_args.moe_a2a_backend != "none":
+            from sglang.srt.speculative.ragged_verify import (
+                RaggedVerifyMode,
+                read_ragged_verify_mode,
+            )
+
+            if read_ragged_verify_mode() is not RaggedVerifyMode.STATIC:
+                raise ValueError(
+                    "DSpark with dp attention + "
+                    f"moe_a2a_backend={server_args.moe_a2a_backend!r} requires "
+                    "SGLANG_RAGGED_VERIFY_MODE=static."
+                )
         if (
             server_args.speculative_moe_a2a_backend is not None
             and server_args.speculative_moe_a2a_backend != server_args.moe_a2a_backend

--- a/test/registered/spec/dspark/test_dspark_draft_path_default.py
+++ b/test/registered/spec/dspark/test_dspark_draft_path_default.py
@@ -5,6 +5,7 @@ from sglang.srt.arg_groups.speculative_hook import (
     _handle_dspark,
     _target_checkpoint_bundles_dspark_draft,
 )
+from sglang.srt.environ import envs
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -82,6 +83,59 @@ class TestDsparkDraftPathDefaulting(CustomTestCase):
             server_args.speculative_draft_model_path,
             "deepseek-ai/some-other-dspark-draft",
         )
+
+
+class TestDsparkDpAttentionMoeA2aGate(CustomTestCase):
+    """Gate contract for DSpark + DP attention + MoE A2A backends."""
+
+    def _dp_server_args(
+        self, *, moe_a2a_backend: str, moe_runner_backend: str = "auto"
+    ) -> ServerArgs:
+        server_args = _make_dspark_server_args(
+            model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()
+        )
+        server_args.enable_dp_attention = True
+        server_args.enable_dp_lm_head = True
+        server_args.dp_size = 2
+        server_args.tp_size = 2
+        server_args.moe_a2a_backend = moe_a2a_backend
+        server_args.moe_runner_backend = moe_runner_backend
+        return server_args
+
+    def test_supported_a2a_backends(self):
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("static"):
+            for backend, runner in (
+                ("none", "auto"),
+                ("megamoe", "deep_gemm"),
+                ("deepep", "deep_gemm"),
+            ):
+                _handle_dspark(
+                    self._dp_server_args(
+                        moe_a2a_backend=backend, moe_runner_backend=runner
+                    )
+                )
+
+            for backend, runner in (
+                ("deepep", "marlin"),
+                ("pplx", "deep_gemm"),
+            ):
+                with self.assertRaisesRegex(ValueError, backend):
+                    _handle_dspark(
+                        self._dp_server_args(
+                            moe_a2a_backend=backend, moe_runner_backend=runner
+                        )
+                    )
+
+    def test_a2a_backends_require_static_verify_mode(self):
+        with envs.SGLANG_RAGGED_VERIFY_MODE.override("compact"):
+            for backend in ("megamoe", "deepep"):
+                with self.assertRaisesRegex(ValueError, "static"):
+                    _handle_dspark(
+                        self._dp_server_args(
+                            moe_a2a_backend=backend,
+                            moe_runner_backend="deep_gemm",
+                        )
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- allow MegaMoE as a DSpark MoE A2A backend under DP attention
- preserve the existing DeepEP + DeepGEMM combination
- require static ragged verify mode for A2A backends
- keep bundled DSpark checkpoint draft-path defaulting intact

Backports the relevant behavior from sgl-project/sglang#34844.

## Validation

- test_dspark_draft_path_default.py: 7 passed
- git diff --check

## Dependency

Depends on #727. This PR is intentionally based on the #727 head branch so its review diff contains only the MegaMoE gate changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32463030193](https://github.com/bytedance-iaas/sglang/actions/runs/32463030193)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32463030005](https://github.com/bytedance-iaas/sglang/actions/runs/32463030005)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->