### PR TITLE
[DSV4][DSpark] Budget draft KV only on its PP owner

### DIFF
--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -667,7 +667,7 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.num_layers_ca128 = sum(1 for r in self.compression_ratios if r == 128)
 
         self.bytes_per_full_token = self._get_bytes_per_full_token()
-        if self.is_speculative:
+        if self.is_speculative and self._should_budget_draft_pool(kvc):
             # Reserve memory for the speculative draft worker by inflating
             # per-token bytes by (target+draft)/target. Equivalent to dflash's
             # scale_kv_cell_size_per_token_for_dflash but applied to
@@ -705,6 +705,26 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 logger.info(
                     "DSV4 compressed attention: online c128 enabled (ring_size=1)"
                 )
+
+    @staticmethod
+    def _should_budget_draft_pool(kvc: KVCacheConfigurator) -> bool:
+        """Return whether this PP stage owns the speculative draft KV pool.
+
+        DSV4 DSpark PD prefill keeps the full draft SWA pool on the final PP
+        stage, matching ``prepare_dspark_hicache_draft_plan``. Earlier stages
+        either have no draft pool or retain only a one-page lifecycle pool, so
+        charging the full draft geometry there understates the shared PP token
+        capacity. Other speculative layouts keep the existing budgeting
+        behavior.
+        """
+
+        if not kvc.spec_algorithm.is_dspark():
+            return True
+        return not (
+            kvc.server_args.disaggregation_mode == "prefill"
+            and kvc.ps.pp_size > 1
+            and kvc.ps.pp_rank != kvc.ps.pp_size - 1
+        )
 
     def _get_bytes_per_full_token(self) -> float:
         kv_bytes = self.qk_nope_head_dim + self.qk_rope_head_dim * 2 + 8

--- a/test/registered/unit/model_executor/test_dsv4_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_dsv4_pool_configurator.py
@@ -1,0 +1,47 @@
+"""CPU-only tests for the DSV4 memory-pool configurator."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.model_executor.pool_configurator import DSV4PoolConfigurator
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSV4DSparkDraftPoolBudget(CustomTestCase):
+    @staticmethod
+    def _make_kvc(*, pp_rank, pp_size=4, is_dspark=True, mode="prefill"):
+        return SimpleNamespace(
+            spec_algorithm=SimpleNamespace(is_dspark=lambda: is_dspark),
+            server_args=SimpleNamespace(disaggregation_mode=mode),
+            ps=SimpleNamespace(pp_rank=pp_rank, pp_size=pp_size),
+        )
+
+    def test_pd_prefill_budgets_draft_pool_only_on_final_pp_stage(self):
+        should_budget = [
+            DSV4PoolConfigurator._should_budget_draft_pool(
+                self._make_kvc(pp_rank=rank)
+            )
+            for rank in range(4)
+        ]
+
+        self.assertEqual(should_budget, [False, False, False, True])
+
+    def test_other_speculative_layouts_keep_existing_budgeting(self):
+        cases = (
+            self._make_kvc(pp_rank=0, is_dspark=False),
+            self._make_kvc(pp_rank=0, mode="decode"),
+            self._make_kvc(pp_rank=0, pp_size=1),
+        )
+
+        for kvc in cases:
+            with self.subTest(kvc=kvc):
+                self.assertTrue(
+                    DSV4PoolConfigurator._should_budget_draft_pool(kvc)
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- charge the full DSpark draft KV pool only to its owning final PP stage during PD prefill
- keep the existing budgeting behavior for non-DSpark speculative layouts
- avoid understating shared PP token capacity on lifecycle-only stages
- add CPU regression coverage for owner and non-owner layouts

This adapts bytedance-iaas/sglang#724 commit 6e01f279 to the refactored KVCacheConfigurator API on ep_main.

## Validation

- test_dsv4_pool_configurator.py: 2 passed
- production module py_compile passed
- git diff --check

## Base

Independent PR built directly on ep_main.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32458023932](https://github.com/bytedance-iaas/sglang/actions/runs/32458023932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32458023508](https://github.com/bytedance-iaas/sglang/actions/runs/32458023508)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->