### PR TITLE
[MoE][MXFP4] Shard weights before Marlin padding

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
@@ -69,7 +69,10 @@ class Mxfp4MarlinMoEMethod:
 
         layer._dsv4_mxfp4_backend = None  # set in process_weights_after_loading
         fp4_block_k = 32
-        intermediate_size_per_partition = round_up(intermediate_size_per_partition, 128)
+        # Keep the loader tensors at the logical TP shard size. Marlin tile
+        # padding is applied by prepare_moe_mxfp4_layer_for_marlin() after the
+        # checkpoint has been sharded. Padding here makes the generic loader
+        # use a padded TP stride and can index past the full checkpoint tensor.
         hidden_size = round_up(hidden_size, 256)
         self.hidden_pad = hidden_size - layer.hidden_size
 


### PR DESCRIPTION
## Summary

- keep loader tensors at the logical TP shard size
- defer Marlin tile padding to prepare_moe_mxfp4_layer_for_marlin after checkpoint sharding
- prevent padded TP strides from indexing past the full checkpoint tensor

Ports bytedance-iaas/sglang commit 66bcceb68c2a2f4bb1ce709bdd15ed923e627c8e onto ep_main.

## Validation

- production module py_compile passed
- git diff --check

## Base

Independent PR built directly on ep_main.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32457617767](https://github.com/bytedance-iaas/sglang/actions/runs/32457617767)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32457719161](https://github.com/bytedance-iaas/sglang/actions/runs/32457719161)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->