### PR TITLE
feat: port MiniMax M3 DSpark support to ep_main

### DIFF
--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -11,14 +12,41 @@ from sglang.srt.configs.model_config import (
     get_minimax_sparse_layer_ids,
     get_minimax_sparse_score_type,
 )
-from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.base_attn_backend import (
+    AttentionBackend,
+)
 from sglang.srt.layers.attention.minimax_sparse_ops.minimax_sparse import (
     minimax_sparse_decode,
-    minimax_sparse_prefill,
 )
 from sglang.srt.mem_cache.memory_pool import MiniMaxSparseKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.server_args import m3_fp8_attn_gemm_enabled
+from sglang.srt.speculative.ragged_verify import (
+    build_ragged_target_verify_geometry,
+    resolve_ragged_verify_layout,
+)
+from sglang.srt.utils import is_npu
+
+if is_npu():
+    pass
+
+# Adaptive block_size_q thresholds (cut K-cache traffic; affects only the serial loop).
+_BSQ_THRESHOLD_64 = 4096  # max_seqlen_k >= 4K  -> BSQ=64
+_BSQ_THRESHOLD_32 = 1024  # max_seqlen_k >= 1K  -> BSQ=32
+_BSQ_THRESHOLD_16 = 512  # max_seqlen_k >= 512 -> BSQ=16
+# BSQ<=64 is UB-safe for the prefill indexer (Q tile up to 8KB at BSQ=64).
+
+
+def _native_indexer_enabled() -> bool:
+    # Native AscendC packed indexer switch (default off).
+    return envs.SGLANG_MINIMAX_NPU_NATIVE_INDEXER.get()
+
+
+def _native_attn_enabled() -> bool:
+    # Native AscendC sparse MAIN-attention switch (default off).
+    return envs.SGLANG_MINIMAX_NPU_NATIVE_ATTN.get()
+
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
@@ -192,21 +220,106 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 "take minutes; compiles serialize across TP ranks)."
             )
 
+    @staticmethod
+    def _target_verify_q_cap(forward_batch: ForwardBatch) -> int:
+        spec_info = getattr(forward_batch, "spec_info", None)
+        if spec_info is None:
+            raise RuntimeError(
+                "MiniMax sparse TARGET_VERIFY CUDA Graph requires spec_info."
+            )
+
+        q_cap = getattr(spec_info, "draft_token_num", None)
+        if q_cap is None or int(q_cap) <= 0:
+            q_cap = getattr(spec_info, "num_tokens_for_logprob_per_req", None)
+        if q_cap is None or int(q_cap) <= 0:
+            q_cap = getattr(spec_info, "num_tokens_per_req", None)
+        if q_cap is None or int(q_cap) <= 0:
+            raise RuntimeError(
+                "MiniMax sparse TARGET_VERIFY CUDA Graph requires a positive, "
+                "fixed per-request verify-token cap."
+            )
+        return int(q_cap)
+
+    @staticmethod
+    def _choose_decode_score_max_chunks(batch_size: int) -> int:
+        """Score chunk count per graph bucket.
+
+        bs=1 uses 16 chunks; larger buckets keep 32. Verify has its own tuning.
+        """
+        return 16 if int(batch_size) == 1 else 32
+
+    @staticmethod
+    def _choose_block_size_q(max_seqlen_k: int) -> int:
+        """Pick block_size_q from max KV length (MINIMAX_NPU_PREFILL_BSQ overrides)."""
+        _forced = os.environ.get("MINIMAX_NPU_PREFILL_BSQ")
+        if _forced:
+            try:
+                _v = int(_forced)
+                if _v > 0:
+                    return _v
+            except ValueError:
+                pass
+        if max_seqlen_k >= _BSQ_THRESHOLD_64:
+            return 64
+        if max_seqlen_k >= _BSQ_THRESHOLD_32:
+            return 32
+        if max_seqlen_k >= _BSQ_THRESHOLD_16:
+            return 16
+        return 1
+
+    # ------------------------------------------------------------------
+    # Delegation helpers
+    # ------------------------------------------------------------------
+
     def init_forward_metadata_out_graph(
         self, forward_batch: ForwardBatch, in_capture: bool = False
     ):
         # cuda-graph replay views are a SimpleNamespace without extend_seq_lens_cpu,
         # and TARGET_VERIFY sets it to None despite is_extend() — getattr covers both.
         self._msa_dec_meta = None
-        extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
-        if extend_lens is not None:
-            self._max_seqlen_q = int(max(extend_lens))
+        if self.is_npu:
+            # Invalidate cached prefill/extend metadata; rebuilt on first sparse layer.
+            self._prefill_meta = None
+            self._extend_meta = None
+            self._extend_meta_key = None
+
+        if in_capture and forward_batch.forward_mode.is_target_verify():
+            # q/k bounds are Python integers and become CUDA Graph launch
+            # constants. They must cover every layout admitted by this graph,
+            # not merely the synthetic layout used while capturing it.
+            self._max_seqlen_q = self._target_verify_q_cap(forward_batch)
         else:
-            self._max_seqlen_q = 1
-        if in_capture and forward_batch.forward_mode.is_decode_or_idle():
+            ragged_layout = (
+                resolve_ragged_verify_layout(forward_batch)
+                if forward_batch.forward_mode.is_target_verify()
+                else None
+            )
+            if ragged_layout is not None:
+                if ragged_layout.verify_lens_cpu is not None:
+                    self._max_seqlen_q = int(max(ragged_layout.verify_lens_cpu))
+                else:
+                    # Replay-side views intentionally have no fresh CPU mirror.
+                    # The fixed cap is safe and avoids a device-to-host sync.
+                    self._max_seqlen_q = self._target_verify_q_cap(forward_batch)
+            else:
+                extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
+                self._max_seqlen_q = int(max(extend_lens)) if extend_lens else 1
+
+        if in_capture and (
+            forward_batch.forward_mode.is_decode_or_idle()
+            or (self.is_npu and forward_batch.forward_mode.is_target_verify())
+        ):
+            # Capture uses tiny dummy seq_lens; bound by full context so replay
+            # (longer sequences) does not miss KV blocks.
             self._max_seqlen_k = self.max_context_len
         else:
-            self._max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item())
+            seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+            if seq_lens_cpu is None or len(seq_lens_cpu) == 0:
+                raise RuntimeError(
+                    "MiniMax sparse attention metadata requires seq_lens_cpu "
+                    "outside TARGET_VERIFY CUDA Graph capture."
+                )
+            self._max_seqlen_k = int(seq_lens_cpu.max().item())
 
         # Build plan + page table eager (outside capture) so captured forward_decode
         # runs only device-side ops; host-side code can't be captured.
@@ -332,24 +445,61 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         else:
             idx_k_cache, idx_v_cache = self.kv_pool.get_index_kv_buffer(layer.layer_id)
 
-        cu_seqlens = torch.cat(
-            [
-                torch.zeros(
-                    1, dtype=torch.int32, device=forward_batch.extend_seq_lens.device
-                ),
-                forward_batch.extend_seq_lens.to(torch.int32).cumsum(0).to(torch.int32),
-            ]
+        extend_seq_lens = forward_batch.extend_seq_lens
+        extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
+        ragged_layout = (
+            resolve_ragged_verify_layout(forward_batch)
+            if forward_batch.forward_mode.is_target_verify()
+            else None
         )
-        seq_lens = forward_batch.seq_lens.to(torch.int32)
-        if forward_batch.extend_prefix_lens is not None:
-            prefix_lens = forward_batch.extend_prefix_lens.to(torch.int32)
+
+        if ragged_layout is not None:
+            ragged_geometry = build_ragged_target_verify_geometry(
+                seq_lens=forward_batch.seq_lens,
+                layout=ragged_layout,
+            )
+            cu_seqlens = ragged_geometry.cu_seqlens_q
+            seq_lens = ragged_geometry.cache_seqlens_int32
+            prefix_lens = forward_batch.seq_lens.to(torch.int32)
+            extend_seq_lens_cpu = ragged_layout.verify_lens_cpu
+        elif extend_seq_lens is not None:
+            cu_seqlens, seq_lens, prefix_lens = self._resolve_extend_meta(
+                forward_batch, q
+            )
+        elif forward_batch.forward_mode.is_target_verify():
+            bs = int(forward_batch.seq_lens.shape[0])
+            verify_len = self._target_verify_q_cap(forward_batch)
+            expected_num_tokens = bs * verify_len
+            if bs <= 0 or q.shape[0] != expected_num_tokens:
+                raise RuntimeError(
+                    "MiniMax sparse non-ragged TARGET_VERIFY requires the fixed "
+                    "verify width from spec_info; refusing to infer a layout from "
+                    f"q.shape. Got q.shape[0]={q.shape[0]}, bs={bs}, "
+                    f"verify_cap={verify_len}, expected={expected_num_tokens}."
+                )
+            uniform_verify_lens = torch.full(
+                (bs,),
+                verify_len,
+                dtype=torch.int32,
+                device=q.device,
+            )
+            cu_seqlens = torch.arange(
+                0,
+                expected_num_tokens + 1,
+                verify_len,
+                dtype=torch.int32,
+                device=q.device,
+            )
+            seq_lens = (forward_batch.seq_lens + uniform_verify_lens).to(torch.int32)
+            prefix_lens = forward_batch.seq_lens.to(torch.int32)
+            extend_seq_lens_cpu = [verify_len] * bs
         else:
-            prefix_lens = torch.zeros_like(seq_lens)
+            raise ValueError("MiniMax sparse forward_extend requires extend_seq_lens.")
 
         # DP attention pads q beyond the real token count for collective alignment;
         # trim to actual tokens so the sparse kernel sees consistent shapes.
-        if forward_batch.extend_seq_lens_cpu is not None:
-            actual_num_tokens = int(sum(forward_batch.extend_seq_lens_cpu))
+        if extend_seq_lens_cpu is not None:
+            actual_num_tokens = int(sum(extend_seq_lens_cpu))
         else:
             actual_num_tokens = int(cu_seqlens[-1].item())
         original_num_tokens = q.shape[0]
@@ -357,45 +507,77 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             q = q[:actual_num_tokens]
             idx_q = idx_q[:actual_num_tokens]
 
-        # fp8 attention GEMMs: quantize q/idx_q AFTER the KV store (which reads
-        # the bf16 k/v) and the DP trim.
-        if self.fp8_attn_gemm:
-            q = _quant_q_fp8(q, layer.q_scale_float)
-            idx_q = _quant_q_fp8(idx_q, layer.idx_q_scale_float)
+        if self.is_npu:
+            if forward_batch.forward_mode.is_target_verify():
+                # TARGET_VERIFY runs under cuda-graph capture; use the
+                # capture-safe verify path (decode kernels, no .item()).
+                idx_o, o = self._forward_npu_triton_verify(
+                    q,
+                    k_cache,
+                    v_cache,
+                    idx_q,
+                    idx_k_cache,
+                    idx_v_cache,
+                    forward_batch,
+                    prefix_lens,
+                )
+            else:
+                idx_o, o = self._forward_npu_triton_prefill(
+                    q,
+                    k_cache,
+                    v_cache,
+                    idx_q,
+                    idx_k_cache,
+                    idx_v_cache,
+                    forward_batch,
+                    cu_seqlens,
+                    seq_lens,
+                    prefix_lens,
+                )
+        else:
+            # fp8 attention GEMMs: quantize q/idx_q AFTER the KV store (which reads
+            # the bf16 k/v) and the DP trim.
+            if self.fp8_attn_gemm:
+                q = _quant_q_fp8(q, layer.q_scale_float)
+                idx_q = _quant_q_fp8(idx_q, layer.idx_q_scale_float)
 
-        idx_o, o = minimax_sparse_prefill(
-            q,
-            k_cache,
-            v_cache,
-            None,
-            idx_q,
-            idx_k_cache,
-            idx_v_cache,
-            None,
-            self.req_to_token,
-            forward_batch.req_pool_indices,
-            cu_seqlens,
-            seq_lens,
-            prefix_lens,
-            self._max_seqlen_q,
-            self._max_seqlen_k,
-            self.block_size_q,
-            self.block_size_k,
-            self.topk_blocks,
-            self.init_blocks,
-            self.local_blocks,
-            score_type=self.score_type,
-            disable_index_value=disable_value,
-            use_msa=self.use_msa,
-            seqlens_cpu=forward_batch.extend_seq_lens_cpu,
-            q_scale=layer.q_scale_float,
-            k_scale=layer.k_scale_float,
-            v_scale=layer.v_scale_float,
-            idx_q_scale=layer.idx_q_scale_float,
-            idx_k_scale=layer.idx_k_scale_float,
-            idx_v_scale=layer.idx_v_scale_float,
-        )
+            # GPU (CUDA/ROCm) sparse path; imported here so NPU never touches it.
+            from sglang.srt.layers.attention.minimax_sparse_ops.minimax_sparse import (
+                minimax_sparse_prefill,
+            )
 
+            idx_o, o = minimax_sparse_prefill(
+                q,
+                k_cache,
+                v_cache,
+                None,
+                idx_q,
+                idx_k_cache,
+                idx_v_cache,
+                None,
+                self.req_to_token,
+                forward_batch.req_pool_indices,
+                cu_seqlens,
+                seq_lens,
+                prefix_lens,
+                self._max_seqlen_q,
+                self._max_seqlen_k,
+                self.block_size_q,
+                self.block_size_k,
+                self.topk_blocks,
+                self.init_blocks,
+                self.local_blocks,
+                score_type=self.score_type,
+                disable_index_value=disable_value,
+                use_msa=self.use_msa,
+                seqlens_cpu=extend_seq_lens_cpu,
+                q_scale=layer.q_scale_float,
+                k_scale=layer.k_scale_float,
+                v_scale=layer.v_scale_float,
+                idx_q_scale=layer.idx_q_scale_float,
+                idx_k_scale=layer.idx_k_scale_float,
+                idx_v_scale=layer.idx_v_scale_float,
+            )
         if actual_num_tokens < original_num_tokens:
             pad_len = original_num_tokens - actual_num_tokens
             o = torch.cat([o, o.new_zeros(pad_len, *o.shape[1:])], dim=0)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -542,6 +542,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     _original_batch_size: Optional[int] = None
     _original_forward_mode: Optional[ForwardMode] = None
     _original_num_tokens: Optional[int] = None
+    _target_verify_metadata_backup: Optional[Tuple[Any, ...]] = None
     global_num_tokens_cpu: Optional[List[int]] = None
     global_num_tokens_gpu: Optional[torch.Tensor] = None
     # Has to be None when cuda graph is captured.
@@ -1226,6 +1227,105 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 dim=0,
             )
 
+    def _prepare_ragged_target_verify_mlp_sync(self, num_tokens: int) -> Optional[int]:
+        spec_info = self.spec_info
+        layout = (
+            getattr(spec_info, "ragged_verify_layout", None)
+            if spec_info is not None
+            else None
+        )
+        if layout is None:
+            return None
+
+        bs = int(layout.verify_lens.shape[0])
+        if bs <= 0:
+            raise RuntimeError("Ragged TARGET_VERIFY requires at least one row.")
+        if self.seq_lens.shape[0] != bs:
+            raise RuntimeError(
+                "Ragged TARGET_VERIFY layout/request mismatch before MLP sync: "
+                f"layout.bs={bs}, seq_lens.shape[0]={self.seq_lens.shape[0]}."
+            )
+        if layout.qo_indptr_device.shape[0] != bs + 1:
+            raise RuntimeError(
+                "Ragged TARGET_VERIFY has an invalid qo_indptr shape: "
+                f"expected {bs + 1}, got {layout.qo_indptr_device.shape[0]}."
+            )
+        if int(layout.graph_num_tokens) > num_tokens:
+            raise RuntimeError(
+                "Ragged TARGET_VERIFY graph tokens exceed the MLP-sync token "
+                f"buffer: graph_num_tokens={layout.graph_num_tokens}, "
+                f"num_tokens={num_tokens}."
+            )
+
+        if self._target_verify_metadata_backup is not None:
+            raise RuntimeError(
+                "Ragged TARGET_VERIFY MLP-sync metadata was prepared twice "
+                "without being restored."
+            )
+        self._target_verify_metadata_backup = (
+            self.extend_num_tokens,
+            self.extend_seq_lens,
+            self.extend_prefix_lens,
+            self.extend_start_loc,
+            self.extend_prefix_lens_cpu,
+            self.extend_seq_lens_cpu,
+            self.extend_logprob_start_lens_cpu,
+        )
+
+        # These tensors are the graph-stable ragged geometry. In particular,
+        # qo_indptr is refreshed in-place before every replay; deriving start
+        # locations from it avoids retaining a stale capture-time tensor.
+        self.extend_num_tokens = int(layout.graph_num_tokens)
+        self.extend_seq_lens = layout.verify_lens
+        self.extend_prefix_lens = self.seq_lens
+        self.extend_start_loc = layout.qo_indptr_device[:-1]
+
+        verify_lens_cpu = layout.verify_lens_cpu
+        if verify_lens_cpu is not None:
+            if len(verify_lens_cpu) != bs:
+                raise RuntimeError(
+                    "Ragged TARGET_VERIFY CPU/device layout mismatch: "
+                    f"len(verify_lens_cpu)={len(verify_lens_cpu)}, bs={bs}."
+                )
+            self.extend_seq_lens_cpu = [int(x) for x in verify_lens_cpu]
+            if self.seq_lens_cpu is not None and len(self.seq_lens_cpu) == bs:
+                # DFlash temporarily exposes total lengths through the CPU
+                # mirror while the device seq_lens tensor remains the prefix.
+                self.extend_prefix_lens_cpu = [
+                    int(total) - int(extend)
+                    for total, extend in zip(
+                        self.seq_lens_cpu, self.extend_seq_lens_cpu
+                    )
+                ]
+                self.extend_logprob_start_lens_cpu = self.extend_prefix_lens_cpu
+            else:
+                self.extend_prefix_lens_cpu = None
+                self.extend_logprob_start_lens_cpu = None
+        else:
+            # Never read verify_lens back from the GPU on the hot path. CUDA
+            # Graph replay updates the device layout in place and intentionally
+            # has no fresh CPU mirror.
+            self.extend_prefix_lens_cpu = None
+            self.extend_seq_lens_cpu = None
+            self.extend_logprob_start_lens_cpu = None
+
+        return bs
+
+    def _restore_target_verify_mlp_sync_metadata(self) -> None:
+        backup = self._target_verify_metadata_backup
+        if backup is None:
+            return
+        (
+            self.extend_num_tokens,
+            self.extend_seq_lens,
+            self.extend_prefix_lens,
+            self.extend_start_loc,
+            self.extend_prefix_lens_cpu,
+            self.extend_seq_lens_cpu,
+            self.extend_logprob_start_lens_cpu,
+        ) = backup
+        self._target_verify_metadata_backup = None
+
     def prepare_mlp_sync_batch(self, model_runner: ModelRunner):
         from sglang.srt.batch_overlap.two_batch_overlap import TboForwardBatchPreparer
 
@@ -1342,8 +1442,75 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                 if self.forward_mode.is_idle():
                     self._original_forward_mode = self.forward_mode
                     self.forward_mode = ForwardMode.TARGET_VERIFY
-                # Invert the spec_scale_global_num_tokens scaling.
-                bs = self.batch_size = num_tokens // self.spec_info.num_tokens_per_req
+
+                ragged_bs = (
+                    self._prepare_ragged_target_verify_mlp_sync(num_tokens)
+                    if self.forward_mode.is_target_verify()
+                    else None
+                )
+                if ragged_bs is not None:
+                    # Ragged verify geometry is carried explicitly by
+                    # RaggedVerifyLayout. num_tokens_per_req is an accounting
+                    # width and must not be used to reconstruct request rows.
+                    bs = self.batch_size = ragged_bs
+                else:
+                    tokens_per_req = self.spec_info.num_tokens_per_req
+                    if tokens_per_req <= 0 or num_tokens % tokens_per_req != 0:
+                        raise RuntimeError(
+                            "Uniform speculative MLP sync requires num_tokens to "
+                            "be divisible by num_tokens_per_req, got "
+                            f"num_tokens={num_tokens}, "
+                            f"num_tokens_per_req={tokens_per_req}."
+                        )
+                    bs = self.batch_size = num_tokens // tokens_per_req
+
+                if self.forward_mode.is_target_verify() and ragged_bs is None:
+                    dev = self.seq_lens.device
+                    num_token_non_padded_cpu = (
+                        self.num_token_non_padded_cpu
+                        if self.num_token_non_padded_cpu is not None
+                        else num_tokens
+                    )
+                    assert num_token_non_padded_cpu % tokens_per_req == 0
+                    num_reqs_non_padded = num_token_non_padded_cpu // tokens_per_req
+
+                    self.extend_num_tokens = num_token_non_padded_cpu
+                    self.extend_seq_lens = torch.zeros(
+                        (bs,),
+                        dtype=torch.int32,
+                        device=dev,
+                    )
+                    self.extend_seq_lens[:num_reqs_non_padded] = tokens_per_req
+
+                    self.extend_prefix_lens = torch.zeros(
+                        (bs,),
+                        dtype=self.seq_lens.dtype,
+                        device=dev,
+                    )
+                    self.extend_prefix_lens[:num_reqs_non_padded] = (
+                        self.seq_lens[:num_reqs_non_padded] - tokens_per_req
+                    )
+
+                    self.extend_start_loc = torch.zeros(
+                        (bs,),
+                        dtype=torch.int32,
+                        device=dev,
+                    )
+                    self.extend_start_loc[:num_reqs_non_padded] = torch.arange(
+                        0,
+                        num_token_non_padded_cpu,
+                        tokens_per_req,
+                        dtype=torch.int32,
+                        device=dev,
+                    )
+                    if num_reqs_non_padded < bs:
+                        self.extend_start_loc[num_reqs_non_padded:] = (
+                            num_token_non_padded_cpu
+                        )
+
+                    self.extend_prefix_lens_cpu = self.extend_prefix_lens.cpu().tolist()
+                    self.extend_seq_lens_cpu = self.extend_seq_lens.cpu().tolist()
+                    self.extend_logprob_start_lens_cpu = self.extend_prefix_lens_cpu
             elif self.is_extend_in_batch and dp_padding_mode.is_max_len():
                 self._original_forward_mode = self.forward_mode
                 self.forward_mode = ForwardMode.EXTEND
@@ -1569,7 +1736,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     ]
                 logits_output.hidden_states = logits_output.hidden_states[:num_tokens]
             elif self.forward_mode.is_target_verify():  # verify
-                num_tokens = bs * self.spec_info.draft_token_num
+                ragged_layout = getattr(self.spec_info, "ragged_verify_layout", None)
+                if ragged_layout is not None:
+                    num_tokens = (
+                        int(ragged_layout.total_verify_tokens)
+                        if ragged_layout.total_verify_tokens is not None
+                        else int(ragged_layout.graph_num_tokens)
+                    )
+                else:
+                    num_tokens = bs * self.spec_info.num_tokens_per_req
                 if logits_output.next_token_logits is not None:
                     logits_output.next_token_logits = logits_output.next_token_logits[
                         :num_tokens
@@ -1605,6 +1780,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             ]
             if logits_output.hidden_states is not None:
                 logits_output.hidden_states = logits_output.hidden_states[:num_tokens]
+
+        self._restore_target_verify_mlp_sync_metadata()
 
     @property
     def can_run_tbo(self):

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -1523,6 +1523,25 @@ class MiniMaxM3SparseForCausalLM(nn.Module):
         else:
             self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
+        # forward checks the per-layer ``_is_layer_to_capture`` flag, not the id
+        # list, so set it explicitly (mirrors qwen3_next/qwen2_moe).
+        for layer_id in self.model.layers_to_capture:
+            if 0 <= layer_id < len(self.model.layers):
+                setattr(self.model.layers[layer_id], "_is_layer_to_capture", True)
+
+    def set_dspark_layers_to_capture(self, layer_ids: List[int]) -> None:
+        if not self.pp_group.is_last_rank:
+            return
+        if layer_ids is None:
+            raise ValueError(
+                "DSPARK requires explicit layer_ids for aux hidden capture."
+            )
+        self.capture_aux_hidden_states = True
+        self.model.layers_to_capture = [val + 1 for val in layer_ids]
+        for layer_id in self.model.layers_to_capture:
+            if 0 <= layer_id < len(self.model.layers):
+                setattr(self.model.layers[layer_id], "_is_layer_to_capture", True)
+
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 

--- a/python/sglang/srt/models/minimax_m3_vl.py
+++ b/python/sglang/srt/models/minimax_m3_vl.py
@@ -131,6 +131,7 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
         )
 
         self.logits_processor = LogitsProcessor(text_config)
+        self.capture_aux_hidden_states = False
 
     def _determine_num_fused_shared_experts(self) -> None:
         text_config = self.config.text_config
@@ -192,6 +193,19 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
             text_config
         )
 
+    def set_dspark_layers_to_capture(self, layer_ids: List[int]) -> None:
+        if not self.pp_group.is_last_rank:
+            return
+        if layer_ids is None:
+            raise ValueError(
+                "DSPARK requires explicit layer_ids for aux hidden capture."
+            )
+        self.capture_aux_hidden_states = True
+        self.model.layers_to_capture = [val + 1 for val in layer_ids]
+        for layer_id in self.model.layers_to_capture:
+            if self.model.start_layer <= layer_id < self.model.end_layer:
+                setattr(self.model.layers[layer_id], "_is_layer_to_capture", True)
+
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         return MultiModalityDataPaddingPatternMultimodalTokens().pad_input_tokens(
             input_ids, mm_inputs
@@ -226,12 +240,20 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
             pp_proxy_tensors=pp_proxy_tensors,
         )
 
+        # EAGLE3/DSpark: when layers_to_capture is set, MiniMaxM3Model.forward
+        # returns (hidden_states, aux_hidden_states) once aux is non-empty; on
+        # idle/warmup forwards with no captured tokens it returns a bare tensor.
+        aux_hidden_states = None
+        if self.capture_aux_hidden_states and isinstance(hidden_states, tuple):
+            hidden_states, aux_hidden_states = hidden_states
+
         if self.pp_group.is_last_rank and not get_embedding:
             return self.logits_processor(
                 input_ids,
                 hidden_states,
                 self.lm_head,
                 forward_batch,
+                aux_hidden_states,
             )
         return hidden_states
 

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -50,9 +50,6 @@ elif is_hip():
     from sglang.kernels.ops.sampling.renorm_triton import (
         top_k_renorm_probs_triton as top_k_renorm_prob,
     )
-    from sglang.kernels.ops.sampling.renorm_triton import (
-        top_p_renorm_probs_triton as top_p_renorm_prob,
-    )
 
     _DFLASH_SAMPLING_VERIFY_AVAILABLE = True
 else:
@@ -326,6 +323,21 @@ def get_dflash_attention_sliding_window_size(config: Any) -> Optional[int]:
     sliding_window = _cfg_get(
         text_config, "sliding_window", _cfg_get(config, "sliding_window")
     )
+
+    if sliding_window is None:
+        try:
+            import json
+            from pathlib import Path
+
+            model_path = _cfg_get(config, "_name_or_path")
+            if model_path:
+                config_path = Path(model_path) / "config.json"
+                if config_path.exists():
+                    raw_config = json.loads(config_path.read_text())
+                    sliding_window = raw_config.get("sliding_window")
+        except Exception:
+            sliding_window = None
+
     if sliding_window is None:
         raise ValueError(
             "DFLASH sliding_attention layers require config.sliding_window."


### PR DESCRIPTION
## Summary

This PR adds MiniMax-M3 DSpark speculative decoding support with MiniMax-M3 as the target model and MiniMax-M3-DSpark as the draft model.

MiniMax-M3-DSpark is a draft model and cannot be served standalone. When it is paired with MiniMax-M3, several integration points are required across auxiliary hidden-state capture, VL wrapper forwarding, target-verify metadata, MiniMax sparse attention geometry, DP padding handling, and DFLASH/DSPARK config loading.

This PR wires those pieces together and validates two-node TP16 serving for MiniMax-M3 + MiniMax-M3-DSpark. It also keeps the implementation compatible with the latest MiniMax-M3 NPU and EAGLE3 changes on `main`.

## Modifications

### MiniMax-M3 target model

- Add `set_dspark_layers_to_capture` to `MiniMaxM3SparseForCausalLM`.
- Reuse the existing layer-capture setup shared with EAGLE3 so DSpark and EAGLE3 mark `_is_layer_to_capture` consistently.
- Require explicit DSpark layer IDs, since DSpark needs deterministic auxiliary hidden-state capture points.
- Preserve compatibility with the latest MiniMax-M3 NPU and EAGLE3 changes from `main`.

### MiniMax-M3 VL wrapper

- Add `set_dspark_layers_to_capture` to the VL wrapper.
- Reuse the same capture setup as EAGLE3 for layer marking.
- Forward `aux_hidden_states` to the logits processor when auxiliary capture is enabled.
- Keep the tuple guard for warmup/idle forwards, where the inner language model may return a plain hidden-state tensor instead of `(hidden_states, aux_hidden_states)`.

### ForwardBatch TARGET_VERIFY metadata

- Initialize TARGET_VERIFY `extend_*` metadata in `ForwardBatch` instead of synthesizing it inside the MiniMax sparse attention backend.
- Assign zero-length verify rows for DP-padded requests so `sum(extend_seq_lens_cpu)` reflects the real non-padded verify token count.
- Add `target_verify_q_cap()` to provide a capture-safe fixed query bound for CUDA Graph replay.
- Add `build_uniform_target_verify_layout()` to build uniform target-verify layouts with both device tensors and host-side metadata.
- Avoid CUDA Graph capture-time device-to-host sync and CPU-to-CUDA copies by carrying `verify_lens_cpu` and `total_verify_tokens`.

### MiniMax sparse attention

- Consume TARGET_VERIFY geometry from `ForwardBatch`.
- Support both ragged target-verify layouts and uniform CUDA Graph capture layouts through `build_ragged_target_verify_geometry`.
- Resolve extend metadata through a shared path that returns `cu_seqlens`, cache sequence lengths, prefix lengths, and host-side per-request verify lengths.
- Trim DP-padded `q` and `idx_q` rows before entering the sparse kernel.
- Reject DP-padded TARGET_VERIFY requests when per-request verify lengths are unavailable, instead of falling back to `batch_size * verify_len`.
- Keep the latest NPU sparse attention paths, metadata cache, lazy GPU sparse-kernel import, and EAGLE3-compatible behavior from `main`.

### DFLASH / DSPARK config handling

- Add a fallback for reading `sliding_window` from the raw `config.json` when the loaded Transformers config exposes it as `None`.
- Preserve MiniMax-M3-DSpark compatibility with DFLASH/DSPARK draft-model loading.

## Error cases fixed

This PR fixes the following MiniMax-M3 + MiniMax-M3-DSpark serving failures:

```text
ValueError: DFLASH sliding_attention layers require config.sliding_window.
```

```text
ValueError: Model MiniMaxM3SparseForConditionalGeneration implements neither set_dspark_layers_to_capture nor set_dflash_layers_to_capture, one of which is required for DFLASH/DSPARK.
```

```text
AttributeError: 'NoneType' object has no attribute 'device'
```

```text
ValueError: DFLASH target_hidden feature dim mismatch. Expected shape [N, 36864] (num_context_features=6, hidden_size=6144), but got shape=(..., 6144).
```

```text
RuntimeError: CUDA error: operation failed due to a previous error during capture.
```

It also fixes two target-verify correctness issues:

- DP-padded TARGET_VERIFY batches no longer use `batch_size * verify_len` as the real sparse-kernel token count.
- Ragged and uniform target-verify paths now use shared per-request geometry, so padded rows are trimmed before the MiniMax sparse kernel.

## Validation

### Static checks

```bash
python3 -m py_compile \
  python/sglang/srt/layers/attention/minimax_sparse_backend.py
  python/sglang/srt/model_executor/forward_batch_info.py
  python/sglang/srt/speculative/dflash_utils.py
  python/sglang/srt/models/minimax_m3_vl.py
  python/sglang/srt/models/minimax_m3.py
```

### Two-node TP16 serving

Validated with MiniMax-M3 as the target model and MiniMax-M3-DSpark as the DSPARK draft model:

```bash
python3 -m sglang.launch_server \
  --model-path /models/MiniMax-M3 \
  --served-model-name MiniMax-M3 \
  --reasoning-parser auto \
  --tool-call-parser auto \
  --trust-remote-code \
  --tp-size 16 \
  --nnodes 2 \
  --node-rank <0-or-1> \
  --dist-init-addr 192.168.1.81:20000 \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path /models/MiniMax-M3-DSpark \
  --speculative-dspark-block-size 8 \
  --chunked-prefill-size 8192 \
  --mem-fraction-static 0.80 \
  --dtype bfloat16 \
  --host 0.0.0.0 \
  --port 31000
```
### End-to-end serving results
| Metric | Input 8K / Output 512 | Input 32K / Output 512 |
|---|---:|---:|
| Successful requests | 256 | 256 |
| Request throughput | 0.14 req/s | 0.05 req/s |
| Input token throughput | 1140.76 tok/s | 1518.18 tok/s |
| Output token throughput | 73.01 tok/s | 24.29 tok/s |
| Peak output throughput | 80.00 tok/s | 75.00 tok/s |
| Total token throughput | 1213.76 tok/s | 1542.47 tok/s |
| Effective concurrency | 15.76 | 15.91 |
| DSpark accept length | 3.39 | 3.40 |
| Mean E2E latency | 110538.41 ms | 335299.96 ms |
| Median E2E latency | 97803.34 ms | 286638.45 ms |
| P99 E2E latency | 266417.01 ms | 876994.82 ms |
| Mean TTFT | 7546.60 ms | 54129.68 ms |
| Median TTFT | 5068.49 ms | 42576.83 ms |
| P99 TTFT | 64566.62 ms | 239261.61 ms |
| Mean TPOT | 201.55 ms | 550.24 ms |
| Median TPOT | 177.17 ms | 444.06 ms |
| P99 TPOT | 511.15 ms | 1607.82 ms |

### Accuracy

| Benchmark | Examples | Sampling | Repeats | Score | Latency |
|---|---:|---|---:|---:|---:|
| GSM8K | 1,314 | Default evaluation settings | 8 | 0.970 mean | 796.733 s mean |
| GPQA | 32 | `temperature=1.0`, `top_p=0.95`, `max_tokens=128000` | 8 | 0.992 mean | 11,345.289 s mean |






<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #32730306664](https://github.com/bytedance-iaas/sglang/actions/runs/32730306664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #32730306116](https://github.com/bytedance-iaas/sglang/actions/runs/32730306116)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->