### PR TITLE
fix: prevent false decode retraction with SWA

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1841,7 +1841,8 @@ def release_req(
     tree_cache: BasePrefixCache,
     hisparse_coordinator: Optional[HiSparseCoordinator],
     offload_kv: bool = True,
-) -> None:
+    abort_on_unsupported_backup: bool = False,
+) -> bool:
     if hisparse_coordinator is not None and not req.finished():
         hisparse_coordinator.retract_req(req)
 
@@ -1849,8 +1850,20 @@ def release_req(
     # restored later without recompute (see resume_retracted_reqs/load_kv_cache).
     # Callers that will recompute the KV instead (PD true-retraction rebootstrap)
     # pass offload_kv=False to skip the wasteful device->host copy.
+    backup_succeeded = True
     if server_args.disaggregation_mode == "decode" and offload_kv:
-        req.offload_kv_cache(req_to_token_pool, token_to_kv_pool_allocator)
+        try:
+            req.offload_kv_cache(req_to_token_pool, token_to_kv_pool_allocator)
+        except NotImplementedError:
+            if not abort_on_unsupported_backup:
+                raise
+            backup_succeeded = False
+            req.kv_cache_cpu = None
+            logger.error(
+                "CPU-tensor retraction backup is unsupported for request %s; "
+                "aborting the request instead of crashing the scheduler.",
+                req.rid,
+            )
     # TODO (csy): for preempted requests, we may want to insert into the tree
     release_kv_cache(req, tree_cache, is_insert=False)
     # NOTE(lsyin): we should use the newly evictable memory instantly.
@@ -1858,6 +1871,7 @@ def release_req(
     evict_from_tree_cache(tree_cache, num_tokens)
 
     req.reset_for_retract()
+    return backup_succeeded
 
 
 def retract_all(
@@ -2729,6 +2743,20 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         whether the next decode step fits in the KV pool."""
         num_tokens = self.new_tokens_required_next_decode(selected_indices)
         evict_from_tree_cache(self.tree_cache, num_tokens)
+        if self.token_to_kv_pool_allocator.available_size() >= num_tokens:
+            return True
+
+        # SWA eviction is normally done while preparing the next decode batch.
+        # When SWA is the first limiting pool, the scheduler can reach this OOM
+        # check before prepare_for_decode() releases out-of-window SWA pages.
+        if (
+            self.forward_mode is not None
+            and self.forward_mode.is_decode()
+            and self.tree_cache.supports_swa()
+        ):
+            self.maybe_evict_swa(force=True)
+            evict_from_tree_cache(self.tree_cache, num_tokens)
+
         return self.token_to_kv_pool_allocator.available_size() >= num_tokens
 
     def retract_decode(
@@ -2738,6 +2766,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         sorted_indices = self._get_decode_retraction_order(self.reqs, server_args)
 
         retracted_reqs = []
+        reqs_to_abort: List[Req] = []
         first_iter = True
         while first_iter or (
             not self.check_decode_mem(selected_indices=sorted_indices)
@@ -2749,11 +2778,26 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             first_iter = False
             idx = sorted_indices.pop()
             req = self.reqs[idx]
-            retracted_reqs.append(req)
             # release memory and don't insert into the tree because we need the space instantly
-            self.release_req(idx, len(sorted_indices), server_args)
+            if self.release_req(
+                idx,
+                len(sorted_indices),
+                server_args,
+                abort_on_unsupported_backup=True,
+            ):
+                retracted_reqs.append(req)
+            else:
+                req.to_finish = FINISH_ABORT(
+                    "Retraction KV backup is unsupported. Aborting the request.",
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                )
+                reqs_to_abort.append(req)
+                logger.warning(
+                    "retract_decode: aborted request %s because KV backup is "
+                    "unsupported",
+                    req.rid,
+                )
 
-        reqs_to_abort: List[Req] = []
         if len(sorted_indices) <= 1 and not self.check_decode_mem(
             selected_indices=sorted_indices
         ):
@@ -2767,7 +2811,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             )
             reqs_to_abort.append(last_req)
-            self.release_req(last_idx, 0, server_args)
+            self.release_req(last_idx, 0, server_args, offload_kv=False)
             logger.warning(
                 "retract_decode: aborted last request %s due to OOM", last_req.rid
             )
@@ -2822,8 +2866,15 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         )
         return sorted_indices
 
-    def release_req(self, idx: int, remaing_req_count: int, server_args: ServerArgs):
-        release_req(
+    def release_req(
+        self,
+        idx: int,
+        remaing_req_count: int,
+        server_args: ServerArgs,
+        offload_kv: bool = True,
+        abort_on_unsupported_backup: bool = False,
+    ) -> bool:
+        return release_req(
             req=self.reqs[idx],
             remaing_req_count=remaing_req_count,
             server_args=server_args,
@@ -2831,6 +2882,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             tree_cache=self.tree_cache,
             hisparse_coordinator=self.hisparse_coordinator,
+            offload_kv=offload_kv,
+            abort_on_unsupported_backup=abort_on_unsupported_backup,
         )
 
     def prepare_encoder_info_decode(self):
@@ -3204,7 +3257,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             extend_num_tokens=self.extend_num_tokens,
         )
 
-    def maybe_evict_swa(self):
+    def maybe_evict_swa(self, force: bool = False):
         if self.tree_cache.supports_swa():
             sliding_window_size = self.tree_cache.sliding_window_size
             server_args = get_server_args()
@@ -3221,7 +3274,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     # We set evict_swa condition here with two reasons:
                     # 1. In overlap scheduler, we cannot evict swa when req.decode_batch_idx == 0 since the prev extend batch is still running.
                     # 2. Evict swa every eviction_interval iterations to reduce the overhead.
-                    if swa_maintenance_step and req.decode_batch_idx >= 1:
+                    if req.decode_batch_idx >= 1 and (force or swa_maintenance_step):
                         self._evict_swa(req, req.seqlen - 1)
 
                     # DSV4-NPU only (no-op elsewhere): the small paged compress-state

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -877,8 +877,6 @@ def eagle_sample(
 
 
 def eagle_prepare_for_decode(batch: ScheduleBatch):
-    batch.maybe_evict_swa()
-
     bs = batch.batch_size()
 
     # Accumulate penalty
@@ -909,8 +907,6 @@ def eagle_prepare_for_decode(batch: ScheduleBatch):
         cur_kv_lens[i] = cur
         nxt_kv_lens[i] = nxt
         num_needed_tokens += nxt - cur
-        r.decode_batch_idx += 1
-
     cur_kv_lens_cpu = torch.tensor(cur_kv_lens, dtype=torch.int32, device="cpu")
     nxt_kv_lens_cpu = torch.tensor(nxt_kv_lens, dtype=torch.int32, device="cpu")
 

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -1024,9 +1024,7 @@ def commit_mamba_states_after_verify(
 
 
 def spec_prepare_for_decode(batch: ScheduleBatch) -> None:
-    """eagle/ngram share a stateless free function; dflash keeps stateful
-    prep on its draft input -- the dispatcher routes.
-    """
+    """Run common spec-v2 bookkeeping, then dispatch algorithm-specific prep."""
     server_args = get_server_args()
     if server_args.enable_mamba_extra_buffer_lazy():
         # Scheduler phase (outside forward isolation).
@@ -1034,6 +1032,11 @@ def spec_prepare_for_decode(batch: ScheduleBatch) -> None:
             get_exec().mamba.mamba_track_interval,
             server_args.max_speculative_num_draft_tokens,
         )
+
+    batch.maybe_evict_swa()
+    for req in batch.reqs:
+        req.decode_batch_idx += 1
+
     if batch.spec_algorithm.is_dflash_family():
         batch.spec_info.prepare_for_decode(batch)
     else:

--- a/test/registered/unit/managers/test_schedule_batch_swa_retraction.py
+++ b/test/registered/unit/managers/test_schedule_batch_swa_retraction.py
@@ -1,0 +1,151 @@
+"""Unit tests for SWA reclamation and decode retraction fail-safes."""
+
+import unittest
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import (  # noqa: E402
+    FINISH_ABORT,
+    NewTokenRatioTracker,
+    ScheduleBatch,
+    release_req,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestScheduleBatchSwaRetraction(CustomTestCase):
+    def test_check_decode_mem_forces_swa_reclamation_before_retraction(self):
+        batch = ScheduleBatch(reqs=[])
+        batch.forward_mode = MagicMock()
+        batch.forward_mode.is_decode.return_value = True
+        batch.tree_cache = MagicMock()
+        batch.tree_cache.supports_swa.return_value = True
+        batch.token_to_kv_pool_allocator = MagicMock()
+        batch.token_to_kv_pool_allocator.available_size.side_effect = [3, 8]
+        batch.new_tokens_required_next_decode = MagicMock(return_value=8)
+        batch.maybe_evict_swa = MagicMock()
+
+        with patch("sglang.srt.managers.schedule_batch.evict_from_tree_cache") as evict:
+            self.assertTrue(batch.check_decode_mem())
+
+        batch.maybe_evict_swa.assert_called_once_with(force=True)
+        self.assertEqual(evict.call_count, 2)
+
+    def test_force_swa_reclamation_ignores_periodic_interval(self):
+        req = SimpleNamespace(decode_batch_idx=1, seqlen=32)
+        batch = ScheduleBatch(reqs=[req])
+        batch.forward_mode = MagicMock()
+        batch.forward_mode.is_decode.return_value = True
+        batch.tree_cache = MagicMock(sliding_window_size=16)
+        batch.tree_cache.supports_swa.return_value = True
+        batch.forward_iter = 1
+        batch._evict_swa = MagicMock()
+
+        with (
+            patch(
+                "sglang.srt.managers.schedule_batch.envs.SGLANG_SWA_EVICTION_INTERVAL.get",
+                return_value=8,
+            ),
+            patch(
+                "sglang.srt.managers.schedule_batch.envs."
+                "SGLANG_OPT_SWA_RELEASE_LEAF_LOCK_AFTER_WINDOW.get",
+                return_value=False,
+            ),
+            patch("sglang.srt.managers.schedule_batch.get_server_args"),
+            patch("sglang.srt.managers.schedule_batch.maybe_evict_dsv4_state"),
+        ):
+            batch.maybe_evict_swa()
+            batch._evict_swa.assert_not_called()
+
+            batch.maybe_evict_swa(force=True)
+
+        batch._evict_swa.assert_called_once_with(req, req.seqlen - 1)
+
+    def test_unsupported_backup_aborts_only_retracted_request(self):
+        kept_req = MagicMock(rid="kept")
+        aborted_req = MagicMock(rid="aborted")
+        batch = ScheduleBatch(reqs=[kept_req, aborted_req])
+        batch._get_decode_retraction_order = MagicMock(return_value=[0, 1])
+        batch.check_decode_mem = MagicMock(return_value=True)
+        batch.release_req = MagicMock(return_value=False)
+        batch.filter_batch = MagicMock()
+        server_args = MagicMock()
+
+        with patch.object(
+            NewTokenRatioTracker,
+            "estimate_new_token_ratio_after_retract",
+            return_value=0.25,
+        ):
+            retracted, ratio, reqs_to_abort = batch.retract_decode(server_args)
+
+        self.assertEqual(retracted, [])
+        self.assertEqual(ratio, 0.25)
+        self.assertEqual(reqs_to_abort, [aborted_req])
+        self.assertIsInstance(aborted_req.to_finish, FINISH_ABORT)
+        self.assertEqual(
+            aborted_req.to_finish.status_code, HTTPStatus.INTERNAL_SERVER_ERROR
+        )
+        batch.release_req.assert_called_once_with(
+            1,
+            1,
+            server_args,
+            abort_on_unsupported_backup=True,
+        )
+        batch.filter_batch.assert_called_once_with(keep_indices=[0])
+
+    def test_last_request_oom_skips_unusable_backup(self):
+        req = MagicMock(rid="last")
+        batch = ScheduleBatch(reqs=[req])
+        batch._get_decode_retraction_order = MagicMock(return_value=[0])
+        batch.check_decode_mem = MagicMock(return_value=False)
+        batch.release_req = MagicMock(return_value=True)
+        batch.filter_batch = MagicMock()
+        server_args = MagicMock()
+
+        with patch.object(
+            NewTokenRatioTracker,
+            "estimate_new_token_ratio_after_retract",
+            return_value=0.0,
+        ):
+            retracted, _, reqs_to_abort = batch.retract_decode(server_args)
+
+        self.assertEqual(retracted, [])
+        self.assertEqual(reqs_to_abort, [req])
+        batch.release_req.assert_called_once_with(0, 0, server_args, offload_kv=False)
+
+    def test_release_req_handles_unsupported_backup_when_requested(self):
+        req = MagicMock(rid="unsupported")
+        req.finished.return_value = False
+        req.offload_kv_cache.side_effect = NotImplementedError
+        server_args = SimpleNamespace(disaggregation_mode="decode")
+
+        with (
+            patch("sglang.srt.managers.schedule_batch.release_kv_cache") as release,
+            patch("sglang.srt.managers.schedule_batch.evict_from_tree_cache"),
+        ):
+            backup_succeeded = release_req(
+                req=req,
+                remaing_req_count=1,
+                server_args=server_args,
+                req_to_token_pool=MagicMock(),
+                token_to_kv_pool_allocator=MagicMock(),
+                tree_cache=MagicMock(),
+                hisparse_coordinator=None,
+                abort_on_unsupported_backup=True,
+            )
+
+        self.assertFalse(backup_succeeded)
+        self.assertIsNone(req.kv_cache_cpu)
+        release.assert_called_once()
+        req.reset_for_retract.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -3,9 +3,9 @@
 Per-request accounting state (`decode_batch_idx` / `extend_batch_idx` iter
 clocks, `kv_committed_len` / `kv_allocated_len` KV watermarks,
 `spec_verify_ct`, and the `maybe_evict_swa()` call) must only be advanced by
-the reviewed owner sites in _OWNER_SITES; spec-v2 draft workers must not
-repeat any of them (the scheduler-driven free function / resolve path already
-does).
+the reviewed owner sites in _OWNER_SITES; spec-v2 algorithm-specific prep and
+draft workers must not repeat any of them (the common scheduler-driven free
+function / resolve path already does).
 A clock that runs fast fires SWA eviction in the overlap race window and
 releases the SWA prefix lock early; neither shows up in e2e CI or the idle
 leak checker, hence this AST-level guard.
@@ -40,7 +40,7 @@ _EVICT_METHOD = "maybe_evict_swa"
 # attribute (`= 0` resets exempt) or "evict" for a `maybe_evict_swa()` call.
 # Any added/removed/recounted site fails until reviewed here.
 _SB = "managers/schedule_batch.py"
-_EAGLE_DECODE = ("speculative/eagle_utils.py", "eagle_prepare_for_decode")
+_SPEC_DECODE = ("speculative/spec_utils.py", "spec_prepare_for_decode")
 _RESOLVE = (
     "managers/scheduler_components/batch_result_processor.py",
     "SchedulerBatchResultProcessor._resolve_spec_v2_tokens",
@@ -52,16 +52,19 @@ _OWNER_SITES = {
     (_SB, "ScheduleBatch.prepare_for_decode", "kv_committed_len"): 1,
     (_SB, "ScheduleBatch.prepare_for_extend", "extend_batch_idx"): 1,
     (_SB, "ScheduleBatch.prepare_for_extend", "kv_committed_len"): 1,
+    # Decode OOM fallback may force SWA maintenance before retraction.
+    (_SB, "ScheduleBatch.check_decode_mem", "evict"): 1,
     # kv_allocated_len is settled inside the owned-kv alloc functions (op28).
     ("mem_cache/allocation.py", "alloc_for_extend", "evict"): 1,
     ("mem_cache/allocation.py", "alloc_for_extend", "kv_allocated_len"): 1,
     ("mem_cache/allocation.py", "alloc_for_decode", "evict"): 1,
     ("mem_cache/allocation.py", "alloc_for_decode", "kv_allocated_len"): 1,
-    # spec v2: no pre-claim; resolve commits the full accepted run uniformly.
+    # spec v2: common preparation owns the decode clock and SWA maintenance for
+    # every algorithm; resolve commits the full accepted run uniformly.
     # kv_allocated_len for spec v2 draft decode (eagle + dflash) is settled
     # inside the owned-kv alloc_for_spec_decode function (op42).
-    (*_EAGLE_DECODE, "decode_batch_idx"): 1,
-    (*_EAGLE_DECODE, "evict"): 1,
+    (*_SPEC_DECODE, "decode_batch_idx"): 1,
+    (*_SPEC_DECODE, "evict"): 1,
     (
         "mem_cache/allocation.py",
         "alloc_for_spec_decode",

--- a/test/registered/unit/spec/test_spec_prepare_for_decode.py
+++ b/test/registered/unit/spec/test_spec_prepare_for_decode.py
@@ -1,0 +1,69 @@
+"""Unit tests for common speculative decode preparation."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.speculative.spec_utils import spec_prepare_for_decode  # noqa: E402
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestSpecPrepareForDecode(CustomTestCase):
+    def _run_prepare(self, *, is_dflash_family: bool):
+        events = []
+        req = SimpleNamespace(decode_batch_idx=4)
+        batch = SimpleNamespace(
+            reqs=[req],
+            spec_algorithm=SimpleNamespace(is_dflash_family=lambda: is_dflash_family),
+            spec_info=SimpleNamespace(),
+        )
+        batch.maybe_evict_swa = MagicMock(
+            side_effect=lambda: events.append(("evict", req.decode_batch_idx))
+        )
+        batch.spec_info.prepare_for_decode = MagicMock(
+            side_effect=lambda _: events.append(("dflash", req.decode_batch_idx))
+        )
+        eagle_prepare = MagicMock(
+            side_effect=lambda _: events.append(("eagle", req.decode_batch_idx))
+        )
+        server_args = SimpleNamespace(enable_mamba_extra_buffer_lazy=lambda: False)
+
+        with (
+            patch(
+                "sglang.srt.speculative.spec_utils.get_server_args",
+                return_value=server_args,
+            ),
+            patch(
+                "sglang.srt.speculative.eagle_utils.eagle_prepare_for_decode",
+                eagle_prepare,
+            ),
+        ):
+            spec_prepare_for_decode(batch)
+
+        return batch, eagle_prepare, events, req
+
+    def test_dflash_gets_common_swa_bookkeeping_before_prepare(self):
+        batch, eagle_prepare, events, req = self._run_prepare(is_dflash_family=True)
+
+        self.assertEqual(req.decode_batch_idx, 5)
+        self.assertEqual(events, [("evict", 4), ("dflash", 5)])
+        batch.spec_info.prepare_for_decode.assert_called_once_with(batch)
+        eagle_prepare.assert_not_called()
+
+    def test_eagle_keeps_single_common_bookkeeping_tick(self):
+        batch, eagle_prepare, events, req = self._run_prepare(is_dflash_family=False)
+
+        self.assertEqual(req.decode_batch_idx, 5)
+        self.assertEqual(events, [("evict", 4), ("eagle", 5)])
+        batch.spec_info.prepare_for_decode.assert_not_called()
+        eagle_prepare.assert_called_once_with(batch)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

In the DSPARK/DFLASH spec-v2 decode path, the common SWA maintenance call and `decode_batch_idx` tick were missing. As a result, out-of-window SWA pages accumulated until the generic decode OOM path retracted a request. The active DSV4 SWA KV pool does not implement CPU-copy backup, so retraction raised `NotImplementedError` and terminated the scheduler.

This complements #36185: host-pool-backed resumable retraction remains useful when available, while this change reclaims SWA before retraction and keeps unsupported backup from crashing the whole decode worker.

## Modifications

- Move speculative decode SWA/clock bookkeeping into `spec_prepare_for_decode()`, so EAGLE, DFLASH, and DSPARK share one owner.
- Force an SWA reclamation pass in `check_decode_mem()` before decode retraction.
- If CPU backup is unsupported, abort only the affected retracted request instead of terminating the scheduler.
- Skip the unusable CPU backup when the final request is aborted for OOM.
- Add CPU unit tests for speculative bookkeeping ownership, forced SWA reclamation, and retraction fail-safes.

## Accuracy Tests

Validated on a 2-node DSV4 DSPARK disaggregated-decode setup based on `bytedance-iaas/sglang:ep_main`:

```bash
python -m sglang.test.run_eval \  --port 8080 \  --eval-name gpqa \  --num-examples 192 \  --max-tokens 64000 \  --repeat 3 \  --top-p 0.95 \  --temperature 1.0 \  --thinking-mode deepseek-v3
```

- Completed all 3 × 192 examples without scheduler exit or retraction.
- Scores: `0.870`, `0.885`, `0.880`; mean `0.878`.
- Output throughput: `317.624 token/s`.

Unit/static validation:

- `test_decode_bookkeeping_ownership.py`: 2 passed
- `test_spec_prepare_for_decode.py`: 2 passed
- `test_schedule_batch_swa_retraction.py`: 5 passed
- `black --check`, `isort --check-only`, `py_compile`, and `git diff --check` passed

## Speed Tests and Profiling

No isolated speed comparison; the change only adds forced SWA maintenance after the normal memory check has already failed.

## Checklist

- [x] Format code according to the contribution guide.
- [x] Add unit tests for the changed scheduler/speculative paths.
- [x] Provide end-to-end GPQA accuracy and throughput results.
- [x] Follow the SGLang code style guidance.
- [ ] Documentation update (not applicable; no user-facing API change).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32817721599](https://github.com/bytedance-iaas/sglang/actions/runs/32817721599)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32817721495](https://github.com/bytedance-iaas/sglang/actions/runs/32817721495)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->