### PR TITLE
ci: support injected values in manual image tags

### DIFF
--- a/.github/workflows/_docker-build-and-publish.yml
+++ b/.github/workflows/_docker-build-and-publish.yml
@@ -47,7 +47,7 @@ on:
         type: string
         default: "version"
       tag_value:
-        description: "Optional tag value injected into manual tags; required for version-mode tags"
+        description: "Optional manual tag override; required as the value in version-mode tags"
         required: false
         type: string
         default: ""

--- a/.github/workflows/_docker-build-and-publish.yml
+++ b/.github/workflows/_docker-build-and-publish.yml
@@ -47,7 +47,7 @@ on:
         type: string
         default: "version"
       tag_value:
-        description: "Tag value passed for version-mode Volcengine tags"
+        description: "Optional tag value injected into manual tags; required for version-mode tags"
         required: false
         type: string
         default: ""

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -337,6 +337,7 @@ jobs:
       publish_default_cuda_alias: ${{ matrix.publish_default_cuda_alias }}
       variant_suffix: ${{ matrix.variant_suffix }}
       tag_mode: ${{ github.event_name == 'schedule' && 'nightly' || 'manual' }}
+      tag_value: ${{ inputs.tag }}
       use_environment: prod
       artifact_name: ${{ (github.event_name == 'schedule' || inputs.compile_kernel) && matrix.artifact_name || '' }}
       extra_build_args: >-

--- a/scripts/ci/get_volcengine_image_tag.py
+++ b/scripts/ci/get_volcengine_image_tag.py
@@ -28,12 +28,16 @@ def build_tag(
 ) -> str:
     """Compose the final image tag.
 
+    Manual tags optionally include an injected value before the timestamp.
     Suffix order is fixed as ``variant`` -> ``cuda`` -> ``format`` so that the
     image format marker (e.g. ``zstd`` / ``nydus``) always trails the CUDA
-    marker: ``v<ver>.byted.<val>.<ts>[-<variant>][-cu130][-zstd]``.
+    marker: ``v<ver>.iaas.dev[.<val>].<ts>[-<variant>][-cu130][-zstd]``.
     """
     if mode == "manual":
-        tag = f"v{version}.iaas.dev.{timestamp}"
+        tag = f"v{version}.iaas.dev"
+        if tag_value:
+            tag = f"{tag}.{tag_value}"
+        tag = f"{tag}.{timestamp}"
     elif mode == "nightly":
         tag = f"v{version}.iaas.nightly.{timestamp}"
     else:
@@ -86,7 +90,8 @@ def main() -> None:
     parser.add_argument(
         "--tag-value",
         default="",
-        help="Required for version mode; inserted after .byted.",
+        help="Injected after .iaas.dev in manual mode; required for version "
+        "mode and inserted after .byted.",
     )
     parser.add_argument("--cuda-suffix", choices=["", "cu129", "cu130"], default="")
     parser.add_argument(
@@ -102,6 +107,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    validate_suffix("tag-value", args.tag_value)
     validate_suffix("variant-suffix", args.variant_suffix)
     validate_suffix("format-suffix", args.format_suffix)
 

--- a/scripts/ci/get_volcengine_image_tag.py
+++ b/scripts/ci/get_volcengine_image_tag.py
@@ -28,16 +28,14 @@ def build_tag(
 ) -> str:
     """Compose the final image tag.
 
-    Manual tags optionally include an injected value before the timestamp.
+    Manual tags use ``tag_value`` verbatim when it is provided, otherwise they
+    fall back to the generated ``v<ver>.iaas.dev.<ts>`` name.
     Suffix order is fixed as ``variant`` -> ``cuda`` -> ``format`` so that the
     image format marker (e.g. ``zstd`` / ``nydus``) always trails the CUDA
-    marker: ``v<ver>.iaas.dev[.<val>].<ts>[-<variant>][-cu130][-zstd]``.
+    marker: ``<manual-tag>[-<variant>][-cu130][-zstd]``.
     """
     if mode == "manual":
-        tag = f"v{version}.iaas.dev"
-        if tag_value:
-            tag = f"{tag}.{tag_value}"
-        tag = f"{tag}.{timestamp}"
+        tag = tag_value or f"v{version}.iaas.dev.{timestamp}"
     elif mode == "nightly":
         tag = f"v{version}.iaas.nightly.{timestamp}"
     else:
@@ -90,8 +88,8 @@ def main() -> None:
     parser.add_argument(
         "--tag-value",
         default="",
-        help="Injected after .iaas.dev in manual mode; required for version "
-        "mode and inserted after .byted.",
+        help="Used verbatim as the base tag in manual mode; required for "
+        "version mode and inserted after .byted.",
     )
     parser.add_argument("--cuda-suffix", choices=["", "cu129", "cu130"], default="")
     parser.add_argument(

--- a/scripts/ci/test_get_volcengine_image_tag.py
+++ b/scripts/ci/test_get_volcengine_image_tag.py
@@ -40,11 +40,22 @@ class GetVolcengineImageTagTest(unittest.TestCase):
                 version="0.5.17",
                 timestamp="202608121200",
                 tag_value="day0_deepseek_v4_official",
+            ),
+            "day0_deepseek_v4_official",
+        )
+
+    def test_manual_tag_with_injected_value_and_suffixes(self) -> None:
+        self.assertEqual(
+            build_tag(
+                mode="manual",
+                version="0.5.17",
+                timestamp="202608121200",
+                tag_value="day0_deepseek_v4_official",
                 variant_suffix="w4a8",
                 cuda_suffix="cu130",
                 format_suffix="nydus",
             ),
-            "v0.5.17.iaas.dev.day0_deepseek_v4_official.202608121200-w4a8-cu130-nydus",
+            "day0_deepseek_v4_official-w4a8-cu130-nydus",
         )
 
     def test_format_suffix_trails_cuda_suffix(self) -> None:

--- a/scripts/ci/test_get_volcengine_image_tag.py
+++ b/scripts/ci/test_get_volcengine_image_tag.py
@@ -33,6 +33,20 @@ class GetVolcengineImageTagTest(unittest.TestCase):
             "v0.5.17.iaas.nightly.202608121200",
         )
 
+    def test_manual_tag_with_injected_value(self) -> None:
+        self.assertEqual(
+            build_tag(
+                mode="manual",
+                version="0.5.17",
+                timestamp="202608121200",
+                tag_value="day0_deepseek_v4_official",
+                variant_suffix="w4a8",
+                cuda_suffix="cu130",
+                format_suffix="nydus",
+            ),
+            "v0.5.17.iaas.dev.day0_deepseek_v4_official.202608121200-w4a8-cu130-nydus",
+        )
+
     def test_format_suffix_trails_cuda_suffix(self) -> None:
         self.assertEqual(
             build_tag(
@@ -88,7 +102,15 @@ class GetVolcengineImageTagTest(unittest.TestCase):
             build_tag(mode="version", version="0.5.17", timestamp="202608121200")
 
     def test_validate_suffix_accepts_safe_values(self) -> None:
-        for value in ("zstd", "nydus", "cu130", "w4a8", "deepseek-v4", ""):
+        for value in (
+            "zstd",
+            "nydus",
+            "cu130",
+            "w4a8",
+            "deepseek-v4",
+            "day0_deepseek_v4_official",
+            "",
+        ):
             validate_suffix("format-suffix", value)
 
     def test_validate_suffix_rejects_unsafe_values(self) -> None:


### PR DESCRIPTION
## Motivation

Manual development-image dispatches accept a custom tag input, but the private build-dev path did not forward it to the reusable workflow. Manual tag generation also ignored tag_value, so run 32719382726 published timestamp-only tags instead of the requested day0_deepseek_v4_official tag.

## Modifications

- Forward the workflow_dispatch tag input to the reusable Volcengine image workflow.
- Use a provided manual tag value verbatim as the base image tag; retain the generated timestamp tag when no value is supplied.
- Continue appending variant, CUDA, and image-format suffixes so matrix outputs remain distinct.
- Validate injected tag values as Docker-tag-safe suffixes.
- Add regression coverage for exact manual tag overrides and suffix ordering.

Example outputs:
- Base OCI: day0_deepseek_v4_official
- CUDA alias: day0_deepseek_v4_official-cu130
- W4A8 CUDA 13 Nydus: day0_deepseek_v4_official-w4a8-cu130-nydus

## Tests

- python3 scripts/ci/test_get_volcengine_image_tag.py
- Manual CLI generation for the exact base tag and suffixed variant
- YAML parsing for both modified workflows
- git diff --check

## Accuracy Tests

Not applicable; this only changes CI image tag generation.

## Speed Tests and Profiling

Not applicable.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32821930003](https://github.com/bytedance-iaas/sglang/actions/runs/32821930003)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32821929708](https://github.com/bytedance-iaas/sglang/actions/runs/32821929708)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->