### PR TITLE
[HiCache][DSV4] Bound EIC async load-back by device pool headroom

### DIFF
--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -768,7 +768,7 @@ class EICHiRadixCache(RadixCache):
         d, hh = st["d"], st["hh"]
         node = st["best_match_node"]
         quota = span - d
-        swa_ok = self._swa_headroom_ok(quota)
+        swa_ok = self._swa_headroom_ok(quota) and self._full_headroom_ok(quota)
         if (
             quota >= max(self.load_back_threshold, 1)
             and node is not None
@@ -788,6 +788,21 @@ class EICHiRadixCache(RadixCache):
             self._admit_verdict[st["h"]] = d
         else:
             self._queue_report(st, self._KIND_FINAL, d)
+
+    def _full_headroom_ok(self, quota):
+        # The async admission gate allocates OUTSIDE add_one_req's rem_total_tokens
+        # budget, so every queued req can pin a load-back until the pool is full
+        # with #running-req: 0 and evictable_size 0 -- an unrecoverable prefill OOM
+        # (the baseline's init_load_back sits inside that budget and self-bounds).
+        # A refused load degrades to a device-only admit below, not a deadlock.
+        reserve = getattr(self, "_load_back_reserve", None)
+        if reserve is None:
+            from sglang.srt.server_args import get_global_server_args
+
+            cps = get_global_server_args().chunked_prefill_size or 0
+            reserve = self._load_back_reserve = cps if cps > 0 else self.page_size
+        alloc = self.cache_controller.mem_pool_device_allocator
+        return alloc.available_size() + self.evictable_size_ >= quota + reserve
 
     def _swa_headroom_ok(self, quota):
         swa = getattr(

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -419,6 +419,8 @@ class TestEICHiCacheRegression(unittest.TestCase):
         cache.pp_group = object() if pp_size > 1 else None
         cache.tp_size, cache.rank, cache.tp_group = 1, 0, None
         cache.load_back_threshold = 10
+        cache._load_back_reserve = 16384
+        cache.evictable_size_ = 0
         cache.root_node = FakeTreeNode(0, True, None)
         cache.ongoing_load_admit = {}
         cache.ongoing_load_back = {}
@@ -454,7 +456,8 @@ class TestEICHiCacheRegression(unittest.TestCase):
             )
         q = Queue()
         cache.cache_controller = SimpleNamespace(
-            ack_load_queue=q, mem_pool_device_allocator=SimpleNamespace()
+            ack_load_queue=q,
+            mem_pool_device_allocator=SimpleNamespace(available_size=lambda: 10**9),
         )
         return cache
 
@@ -661,6 +664,23 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(len(req.prefix_indices), 14)  # 4 device + 10 loaded
         self.assertEqual(s.freed, [(100, 10)])
         self.assertEqual(s.locks, [])
+
+    def test_gate_refuses_load_back_without_pool_headroom(self):
+        # The agent-workload OOM: the async gate allocates outside add_one_req's
+        # budget, so N queued reqs each pinned a load-back until the pool was full
+        # with 0 running reqs and 0 evictable. Below the reserve the gate must
+        # admit device-only instead of kicking another load.
+        s = self._make_stage(0, self.FakeStore(), {}, pp_size=1)
+        kicked = []
+        s.load_back = lambda node, allow_evict=None: kicked.append(
+            node
+        ) or torch.arange(16, dtype=torch.int64)
+        s.cache_controller.mem_pool_device_allocator.available_size = lambda: 6144
+        req = self._make_req("req-oom", 4, 16, load_node_id=101)
+        self.assertTrue(EICPagedHiRadixCache.check_load_back_progress(s, req))
+        self.assertEqual(kicked, [])
+        self.assertEqual(len(req.prefix_indices), 4)  # device-only admit
+        self.assertEqual(s.ongoing_load_admit, {})
 
     def test_finalize_asserts_on_verdict_before_ack(self):
         # I5 enforcement: a FINAL verdict may never land before the local ack


### PR DESCRIPTION
The EIC admission gate allocates device KV outside `add_one_req`'s `rem_total_tokens` budget, so every queued request can pin a load-back until the pool is full with `#running-req: 0` and `evictable_size 0` — an unrecoverable prefill OOM, observed on an agent workload at the 20K-history round where 23 in-flight loads x ~11776 tokens took 80% of the 339968-token pool.

This adds `_full_headroom_ok`, symmetric with the existing `_swa_headroom_ok`, requiring `available_size + evictable_size >= quota + chunked_prefill_size`; a refused load falls through to the existing device-only admit, recomputing instead of loading back.

Validation on a TP8/PP1 DSV4 PD deployment: Agent cc32 0→80K passes 672/672 with zero failures and zero restarts across two independent runs (the previously crashing 20,480 round now completes in 5.85s), and Chat cc32 five-tier x 3 runs (23,808 requests) all succeed with EIC at 1.95x/3.12x hit rate and 2.3x median TTFT over no-EIC on the two working sets that exceed the device pool, while matching no-EIC exactly on the three that fit.