### PR TITLE
[HiCache][DSV4] Stop over-allocating EIC host pools and leaking write slots

### DIFF
--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -437,28 +437,24 @@ class EICKVClient:
                 logger.info(
                     f"async batch set cost { cost_time * 1e3}.2f ms, {len(keys)} keys"
                 )
+            return True
         else:
-            objs = []
-            if obj_inputs is not None:
-                objs = [item.cpu() for item in obj_inputs]
-            elif device_indices is not None and copy_func is not None:
-                large_tensor = torch.empty(
-                    (count,) + self.kv_cache_shape,
-                    dtype=self.kv_cache_dtype,
-                    device="cpu",
+            # Write pool exhausted: the consumer thread is behind (EIC backend slow
+            # or failing). Drop this batch instead of allocating an unbounded host
+            # tensor per call -- under a backend stall the old fallback accumulated
+            # 1000+ large mallocs in seconds and OOM-killed the rank. Dropping is a
+            # benign L2/L3 cache miss (recomputed later). Rank-safe: assign_page_data
+            # returns False without blocking, so every TP rank still reaches the
+            # write_operation_shared all_reduce, which reconciles the failed result.
+            self._write_drop_ct = getattr(self, "_write_drop_ct", 0) + 1
+            if self._write_drop_ct == 1 or self._write_drop_ct % 128 == 0:
+                logger.warning(
+                    "eic async write pool exhausted, dropping %d keys "
+                    "(total dropped batches: %d)",
+                    len(keys),
+                    self._write_drop_ct,
                 )
-                objs = [large_tensor[i] for i in range(len(keys))]
-                copy_func(device_indices, objs)
-            else:
-                logger.error(
-                    "async set impl input obj_inputs and device_indices are both None"
-                )
-                return False
-            self.write_queue.put((keys, objs, None))
-            logger.warning(
-                f"async batch set fallback to malloc, cost {(time.perf_counter() - start_time) * 1e3}.2f ms, {len(keys)} keys"
-            )
-        return True
+            return False
 
     def exists(self, key: str) -> bool:
         logger.debug(f"eic exists {key}")
@@ -683,15 +679,18 @@ class EICKVClient:
         set_option.ns = self.eic_namespace
         set_option.ttl_second = self.kv_set_ttl_option
         status_code, set_outcome = self.connection.mset(keys_vec, vals_vec, set_option)
+
+        # Free slots before any early exit: the write mempool never refills, so an
+        # mset-error bail leaks them permanently.
+        if registered:
+            for item in objs:
+                self.kv_cache_write_mem_pool.free_to_mempool(item.data_ptr())
+
         if status_code != eic.StatusCode.SUCCESS:
             logger.error(f"eic mset {len(keys)} failed, status_code {status_code}")
             return False
         else:
             logger.debug(f"eic mset {len(keys)} success")
-
-        if registered:
-            for item in objs:
-                self.kv_cache_write_mem_pool.free_to_mempool(item.data_ptr())
 
         failed = [
             (i, err_code)
@@ -1618,6 +1617,8 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
             storage_backend=None,
             pp_rank=params.pp_rank,
             pp_size=params.pp_size,
+            # EIC host pages are device-indexed; see _deepseek_v4_num_host_pages.
+            device_indexed=True,
         )
         # The assembler creates a temporary HiCache controller that registers a
         # layer-transfer counter on DSv4. Native EIC load completes before the

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -259,6 +259,7 @@ def _deepseek_v4_num_host_pages(
     kvcache: Any,
     page_size: int,
     swa_page_size: int,
+    device_indexed: bool = False,
 ) -> tuple[int, int]:
     allocator = params.token_to_kv_pool_allocator
     device_full_size = getattr(allocator, "size_full", kvcache.size)
@@ -272,6 +273,16 @@ def _deepseek_v4_num_host_pages(
             "use --hicache-ratio instead."
         )
     ratio = server_args.hicache_ratio
+    if device_indexed:
+        # EIC host pages are device-indexed, so pages beyond device_pages are
+        # unreachable; allocating ratio * device_pages just pins dead RSS (OOM on TP8).
+        if ratio > 1.0:
+            logger.warning(
+                "DeepSeek V4 EIC host pools are device-indexed; ignoring "
+                "--hicache-ratio %.2f (using 1.0).",
+                ratio,
+            )
+        return device_full_pages + 1, device_swa_pages + 1
     full_host_pages = max(int(device_full_pages * ratio), device_full_pages + 1)
     swa_host_pages = max(int(device_swa_pages * ratio), device_swa_pages + 1)
     return full_host_pages, swa_host_pages
@@ -296,6 +307,7 @@ def build_deepseek_v4_hicache_stack(
     pp_rank: int = 0,
     pp_size: int = 1,
     enable_storage_metrics: bool = False,
+    device_indexed: bool = False,
 ) -> tuple[HostPoolGroup, HybridCacheController]:
     transfer_layer_num = kvcache.end_layer - kvcache.start_layer
     full_layer_mapping = {layer_id: layer_id for layer_id in range(transfer_layer_num)}
@@ -340,6 +352,7 @@ def build_deepseek_v4_hicache_stack(
         kvcache=kvcache,
         page_size=page_size,
         swa_page_size=kvcache.swa_page_size,
+        device_indexed=device_indexed,
     )
 
     logical_host_pool = LogicalHostPool(num_host_pages * page_size, page_size)

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -682,6 +682,40 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(len(req.prefix_indices), 4)  # device-only admit
         self.assertEqual(s.ongoing_load_admit, {})
 
+    def test_device_indexed_host_pages_ignore_hicache_ratio(self):
+        # EIC shared-page mode is device-indexed, so pages beyond device_pages are
+        # unreachable: device_indexed=True must clamp to device_pages+1 regardless of
+        # --hicache-ratio, while the non-EIC path keeps honoring the ratio.
+        from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
+            _deepseek_v4_num_host_pages,
+        )
+
+        page_size = swa_page_size = 256
+        kv = SimpleNamespace(size=339968, swa_size=271872, swa_page_size=swa_page_size)
+        params = SimpleNamespace(
+            token_to_kv_pool_allocator=SimpleNamespace(size_full=339968)
+        )
+        args = SimpleNamespace(hicache_size=0, hicache_ratio=2.0)
+        kwargs = dict(
+            params=params,
+            server_args=args,
+            kvcache=kv,
+            page_size=page_size,
+            swa_page_size=swa_page_size,
+        )
+        device_full = 339968 // page_size
+        device_swa = 271872 // swa_page_size
+
+        self.assertEqual(
+            _deepseek_v4_num_host_pages(**kwargs, device_indexed=True),
+            (device_full + 1, device_swa + 1),
+        )
+        # Non-EIC host cache genuinely uses mem_pool_host.alloc(), so ratio must hold.
+        self.assertEqual(
+            _deepseek_v4_num_host_pages(**kwargs, device_indexed=False),
+            (device_full * 2, device_swa * 2),
+        )
+
     def test_finalize_asserts_on_verdict_before_ack(self):
         # I5 enforcement: a FINAL verdict may never land before the local ack
         # when a load was kicked -- silent free of in-flight DMA otherwise.
@@ -782,6 +816,54 @@ class TestEICHiCacheRegression(unittest.TestCase):
     def test_reconciler_epoch_never_reused(self):
         r = self._make_reconciler(0, self.FakeStore())
         self.assertEqual([r.bump_epoch("r"), r.bump_epoch("r")], [1, 2])
+
+    def test_async_batch_set_drops_when_write_pool_exhausted(self):
+        # Backend-failure OOM guard: when the async write pool is exhausted (the
+        # consumer thread is behind a slow/failing EIC backend), async_batch_set must
+        # DROP the batch, not allocate an unbounded host tensor per call. The old
+        # fallback accumulated 1000+ mallocs in seconds and OOM-killed the rank.
+        from sglang.srt.mem_cache.eic_memory_pool import EICKVClient
+
+        c = object.__new__(EICKVClient)
+        c.kv_cache_write_mem_pool = SimpleNamespace(left_count=lambda: 0)
+        c.write_queue = Queue()
+        copied = []
+        ret = EICKVClient.async_batch_set(
+            c,
+            keys=["a", "b", "c"],
+            obj_inputs=None,
+            device_indices=torch.arange(3),
+            copy_func=lambda idx, objs: copied.append(idx),
+        )
+        self.assertFalse(ret)  # dropped
+        self.assertTrue(c.write_queue.empty())  # nothing enqueued
+        self.assertEqual(copied, [])  # no device->host copy / malloc
+
+    def test_async_batch_set_enqueues_when_pool_has_room(self):
+        # Normal path unchanged: with pool headroom the batch allocates registered
+        # slots and is enqueued for the write thread.
+        from sglang.srt.mem_cache.eic_memory_pool import EICKVClient
+
+        c = object.__new__(EICKVClient)
+        slots = [torch.zeros(2) for _ in range(3)]
+        c.kv_cache_write_mem_pool = SimpleNamespace(
+            left_count=lambda: 8,
+            try_allocate_kv_cache=lambda shape, dtype, count: (slots[:count], None),
+        )
+        c.kv_cache_shape = (2,)
+        c.kv_cache_dtype = torch.float32
+        c.write_queue = Queue()
+        copied = []
+        ret = EICKVClient.async_batch_set(
+            c,
+            keys=["a", "b", "c"],
+            obj_inputs=None,
+            device_indices=torch.arange(3),
+            copy_func=lambda idx, objs: copied.append(idx),
+        )
+        self.assertTrue(ret)
+        self.assertEqual(c.write_queue.qsize(), 1)
+        self.assertEqual(len(copied), 1)  # copy_func invoked once
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
DSv4 host pools are sized by `--hicache-ratio`, but EIC shared-page mode addresses them by DEVICE index — the write path is `host_indices = device_indices.clone().cpu()` (`EICCacheController.write_page`) and the pools index with `int(index) // slot_page_size` — so the highest reachable page is `device_pages - 1` and sizing at `ratio * device_pages` allocates and cudaHostRegister-pins `(ratio-1)/ratio` of every host pool for pages no code path can address; separately, `_sync_set_impl` returns on an mset error before its `free_to_mempool` loop, permanently draining a fixed-size write free list so that every subsequent write falls back to an unregistered ~1 GB `torch.empty` and loses RDMA registration.

This clamps host pages to `device_pages + 1` behind an explicit `device_indexed` flag (not `enable_eic_cache`, because `_deepseek_v4_num_host_pages` is shared with the non-EIC UnifiedRadixCache stack that genuinely calls `mem_pool_host.alloc()` and for which the ratio is meaningful), and moves the slot release before the early exit.

Measured on a TP8 DSv4 prefill pod with a 400 GiB cgroup limit: with `--hicache-ratio 2.0` it idled at 291 GiB with zero traffic (73% of the limit) and a 655360-token cc32 run drove it to 399 GiB and an OOMKill, reproducibly 2/2; with the ratio ignored on this path the same pod idles at 213 GiB (rss 230 → 140 GiB, exactly half the host pools), the same run peaks at 355 GiB with zero restarts, and cache hit rates are unchanged — `test_device_indexed_host_pages_ignore_hicache_ratio` locks both halves of that behaviour and the full file is 29 passed on the deployed image.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->