### PR TITLE
[PP] Improve offline offload async scheduling

### DIFF
--- a/python/sglang/srt/managers/offline_pp_offload_manager.py
+++ b/python/sglang/srt/managers/offline_pp_offload_manager.py
@@ -28,6 +28,7 @@ machinery.
 import enum
 import logging
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional
 
@@ -42,6 +43,18 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _nvtx_range(message: str):
+    if not torch.cuda.is_available() or not hasattr(torch.cuda, "nvtx"):
+        yield
+        return
+    torch.cuda.nvtx.range_push(message)
+    try:
+        yield
+    finally:
+        torch.cuda.nvtx.range_pop()
 
 # Per-wave admission divisor. Runtime residency is limited by allocator
 # availability; only one wave may be PREFETCHING at a time.
@@ -163,6 +176,9 @@ class WaveStateHandle:
 
 class OfflinePPStateOffloadManager:
     """Manage offline-PP state offload (prefill) and prefetch (decode)."""
+
+    def nvtx_range(self, message: str):
+        return _nvtx_range(message)
 
     def __init__(
         self,
@@ -836,19 +852,24 @@ class OfflinePPStateOffloadManager:
                     mamba_indices = mamba_indices.clone()
                 entry.transfer_kv_indices = kv_indices
                 entry.transfer_mamba_indices = mamba_indices
-                if mamba_indices is not None:
-                    cpu_state = self.kv_cache.get_cpu_copy(
-                        kv_indices,
-                        mamba_indices,
-                        async_copy=True,
-                        pin_memory=True,
-                    )
-                else:
-                    cpu_state = self.kv_cache.get_cpu_copy(
-                        kv_indices,
-                        async_copy=True,
-                        pin_memory=True,
-                    )
+                with _nvtx_range(
+                    "offline_pp.offload_req "
+                    f"epoch={wave.epoch_id} wave={wave.wave_id} "
+                    f"tokens={entry.committed_len}"
+                ):
+                    if mamba_indices is not None:
+                        cpu_state = self.kv_cache.get_cpu_copy(
+                            kv_indices,
+                            mamba_indices,
+                            async_copy=True,
+                            pin_memory=True,
+                        )
+                    else:
+                        cpu_state = self.kv_cache.get_cpu_copy(
+                            kv_indices,
+                            async_copy=True,
+                            pin_memory=True,
+                        )
                 self._set_entry_host_state(
                     wave, entry, self.codec.encode_on_offload(cpu_state)
                 )
@@ -898,8 +919,12 @@ class OfflinePPStateOffloadManager:
         """
         if not self.is_wave_offload_ready(wave):
             return False
-        for req in wave.reqs:
-            self._free_req_device_slots(req, wave.entries[req.rid].committed_len)
+        with _nvtx_range(
+            "offline_pp.release_wave "
+            f"epoch={wave.epoch_id} wave={wave.wave_id} bs={len(wave.reqs)}"
+        ):
+            for req in wave.reqs:
+                self._free_req_device_slots(req, wave.entries[req.rid].committed_len)
         wave.state = WaveState.OFFLOADED
         wave.last_progress_tick = self._tick
         self.offloaded_queue.append(wave.wave_id)
@@ -1097,21 +1122,26 @@ class OfflinePPStateOffloadManager:
                 entry.transfer_kv_indices = restore_indices
                 entry.transfer_mamba_indices = mamba_indices
 
-                with self.device_module.stream(self.prefetch_stream):
-                    self.prefetch_stream.wait_stream(metadata_stream)
-                    if mamba_indices is not None:
-                        self.kv_cache.load_cpu_copy(
-                            cpu_state,
-                            restore_indices,
-                            mamba_indices,
-                            async_copy=True,
-                        )
-                    else:
-                        self.kv_cache.load_cpu_copy(
-                            cpu_state,
-                            restore_indices,
-                            async_copy=True,
-                        )
+                with _nvtx_range(
+                    "offline_pp.prefetch_req "
+                    f"epoch={wave.epoch_id} wave={wave.wave_id} "
+                    f"tokens={committed} alloc={alloc_len}"
+                ):
+                    with self.device_module.stream(self.prefetch_stream):
+                        self.prefetch_stream.wait_stream(metadata_stream)
+                        if mamba_indices is not None:
+                            self.kv_cache.load_cpu_copy(
+                                cpu_state,
+                                restore_indices,
+                                mamba_indices,
+                                async_copy=True,
+                            )
+                        else:
+                            self.kv_cache.load_cpu_copy(
+                                cpu_state,
+                                restore_indices,
+                                async_copy=True,
+                            )
             except Exception:
                 self.prefetch_stream.synchronize()
                 self._release_prefetched_req(req, entry)
@@ -1175,7 +1205,13 @@ class OfflinePPStateOffloadManager:
 
     def wait_prefetch_for_decode(self, wave: WaveStateHandle) -> None:
         if wave.prefetch_done_event is not None:
-            self.device_module.current_stream().wait_event(wave.prefetch_done_event)
+            with _nvtx_range(
+                "offline_pp.prefetch_wait_for_decode "
+                f"epoch={wave.epoch_id} wave={wave.wave_id}"
+            ):
+                self.device_module.current_stream().wait_event(
+                    wave.prefetch_done_event
+                )
 
     def ensure_decode_ready_for_schedule(self, free_slots: int) -> None:
         """Blocking catch-up at the decode scheduling boundary.
@@ -1323,7 +1359,11 @@ class OfflinePPStateOffloadManager:
         Safe because the authoritative state copy remains on host; only the
         in-progress device replica (and its slots) is discarded.
         """
-        self.prefetch_stream.synchronize()
+        with _nvtx_range(
+            "offline_pp.rollback_prefetch_sync "
+            f"epoch={wave.epoch_id} wave={wave.wave_id}"
+        ):
+            self.prefetch_stream.synchronize()
         for req in wave.reqs:
             entry = wave.entries[req.rid]
             if (

--- a/python/sglang/srt/managers/offline_pp_offload_manager.py
+++ b/python/sglang/srt/managers/offline_pp_offload_manager.py
@@ -64,6 +64,9 @@ RESIDENT_WAVES = 2
 # for fragmentation. Combined with the /RESIDENT_WAVES split for admission.
 ADMISSION_ALPHA = 0.95
 
+PREFILL_WAIT_REASON_UNDERFILLED_WAVE = "underfilled_wave"
+PREFILL_WAIT_REASON_WAITING_EMPTY = "waiting_empty"
+
 
 class WaveState(enum.Enum):
     PREFILLING = "prefilling"
@@ -204,6 +207,15 @@ class OfflinePPStateOffloadManager:
             server_args.offline_pp_min_prefill_waves or server_args.pp_size
         )
         self.max_prefill_waves = server_args.offline_pp_max_prefill_waves
+        # PP ranks must make identical batch/no-batch decisions. Use logical
+        # scheduler ticks for the timeout gate instead of per-process wall time.
+        self.prefill_wait_timeout_ticks = max(
+            0,
+            int(
+                getattr(server_args, "offline_pp_prefill_wait_timeout_ticks", 0)
+                or 0
+            ),
+        )
         max_host_gb = server_args.offline_pp_max_host_memory_gb
         self.host_limit_bytes = (
             int(max_host_gb * (1024**3)) if max_host_gb is not None else None
@@ -234,6 +246,10 @@ class OfflinePPStateOffloadManager:
         self.fill_stop_requested = False
         self.fill_stop_reason: Optional[str] = None
         self.inflight_prefill_mbs: set[int] = set()
+        self._prefill_wait_start_time: Optional[float] = None
+        self._prefill_wait_start_tick: Optional[int] = None
+        self._prefill_wait_reason: Optional[str] = None
+        self._prefill_wait_timeout_logged = False
         self.host_pinned_bytes = 0
         self._host_bytes_per_committed_token: Optional[float] = None
         self._host_bytes_samples = 0
@@ -241,13 +257,15 @@ class OfflinePPStateOffloadManager:
         logger.info(
             "OfflinePPStateOffloadManager enabled (hybrid=%s, layers=%d, "
             "resident_factor=%.2f, min_prefill_waves=%d, "
-            "max_prefill_waves=%s, host_limit_bytes=%s).",
+            "max_prefill_waves=%s, host_limit_bytes=%s, "
+            "prefill_wait_timeout_ticks=%d).",
             self.is_hybrid,
             self.layer_num,
             self.gpu_resident_factor,
             self.min_prefill_waves,
             self.max_prefill_waves,
             self.host_limit_bytes,
+            self.prefill_wait_timeout_ticks,
         )
         if self.host_limit_bytes is None:
             logger.warning(
@@ -421,6 +439,13 @@ class OfflinePPStateOffloadManager:
     def inflight_prefill_count(self) -> int:
         return len(self.inflight_prefill_mbs)
 
+    def pending_epoch_wave_count(self, epoch_id: Optional[int] = None) -> int:
+        epoch_id = self.current_epoch_id if epoch_id is None else epoch_id
+        count = self.active_epoch_wave_count(epoch_id)
+        if epoch_id == self.current_epoch_id:
+            count += self.inflight_prefill_count
+        return count
+
     def can_dispatch_prefill(self) -> bool:
         return self.is_filling() and not self.fill_stop_requested
 
@@ -429,6 +454,111 @@ class OfflinePPStateOffloadManager:
             bool(self.waves)
             or self.fill_stop_requested
             or self.inflight_prefill_count > 0
+            or (
+                self.is_filling()
+                and self._prefill_wait_start_tick is not None
+            )
+        )
+
+    def _prefill_wait_target_requests(
+        self, base_prefill_max_requests: Optional[int]
+    ) -> Optional[int]:
+        if base_prefill_max_requests is None:
+            return None
+        target = int(base_prefill_max_requests)
+        return target if target > 1 else None
+
+    def _prefill_wait_enabled(self, target_requests: Optional[int]) -> bool:
+        return (
+            self.prefill_wait_timeout_ticks > 0
+            and target_requests is not None
+            and target_requests > 1
+        )
+
+    def _reset_prefill_wait(self) -> None:
+        self._prefill_wait_start_time = None
+        self._prefill_wait_start_tick = None
+        self._prefill_wait_reason = None
+        self._prefill_wait_timeout_logged = False
+
+    def _prefill_wait_epoch_has_room(self) -> bool:
+        return (
+            self.max_prefill_waves is None
+            or self.pending_epoch_wave_count() < self.max_prefill_waves
+        )
+
+    def _wait_for_prefill_batch(
+        self, reason: str, waiting_queue_len: int, target_requests: int
+    ) -> bool:
+        if self._prefill_wait_start_tick is None:
+            self._prefill_wait_start_time = time.monotonic()
+            self._prefill_wait_start_tick = self._tick
+            self._prefill_wait_reason = reason
+            self._prefill_wait_timeout_logged = False
+            logger.info(
+                "OfflinePP PREFILL_WAIT_START epoch=%d reason=%s "
+                "waiting=%d target=%d timeout_ticks=%d pending_waves=%d",
+                self.current_epoch_id,
+                reason,
+                waiting_queue_len,
+                target_requests,
+                self.prefill_wait_timeout_ticks,
+                self.pending_epoch_wave_count(),
+            )
+        elif self._prefill_wait_reason != reason:
+            self._prefill_wait_reason = reason
+
+        elapsed_ticks = self._tick - self._prefill_wait_start_tick
+        if elapsed_ticks < self.prefill_wait_timeout_ticks:
+            return True
+
+        if not self._prefill_wait_timeout_logged:
+            self._prefill_wait_timeout_logged = True
+            elapsed_sec = (
+                time.monotonic() - self._prefill_wait_start_time
+                if self._prefill_wait_start_time is not None
+                else 0.0
+            )
+            logger.info(
+                "OfflinePP PREFILL_WAIT_TIMEOUT epoch=%d reason=%s "
+                "waiting=%d target=%d elapsed_sec=%.3f elapsed_ticks=%d "
+                "pending_waves=%d",
+                self.current_epoch_id,
+                reason,
+                waiting_queue_len,
+                target_requests,
+                elapsed_sec,
+                elapsed_ticks,
+                self.pending_epoch_wave_count(),
+            )
+        return False
+
+    def should_wait_for_prefill(
+        self,
+        waiting_queue_len: int,
+        has_chunked_req: bool,
+        base_prefill_max_requests: Optional[int],
+    ) -> bool:
+        target_requests = self._prefill_wait_target_requests(
+            base_prefill_max_requests
+        )
+        if not self._prefill_wait_enabled(target_requests):
+            return False
+        if has_chunked_req:
+            self._reset_prefill_wait()
+            return False
+        if waiting_queue_len >= target_requests:
+            self._reset_prefill_wait()
+            return False
+        if waiting_queue_len <= 0:
+            return False
+        if not self._prefill_wait_epoch_has_room():
+            self._reset_prefill_wait()
+            return False
+        return self._wait_for_prefill_batch(
+            PREFILL_WAIT_REASON_UNDERFILLED_WAVE,
+            waiting_queue_len,
+            target_requests,
         )
 
     def _normalize_mb_id(self, mb_id: Optional[int]) -> int:
@@ -478,19 +608,35 @@ class OfflinePPStateOffloadManager:
 
     def local_fill_stop_reason(self, waiting_queue_empty: bool) -> Optional[str]:
         wave_count = self.active_epoch_wave_count()
+        pending_wave_count = self.pending_epoch_wave_count()
+        if (
+            self.max_prefill_waves is not None
+            and pending_wave_count >= self.max_prefill_waves
+        ):
+            self._reset_prefill_wait()
+            return "max_waves"
         if wave_count == 0:
             return None
         if (
             self.host_limit_bytes is not None
             and self.host_pinned_bytes >= self.host_limit_bytes
         ):
+            self._reset_prefill_wait()
             return "host"
-        if (
-            self.max_prefill_waves is not None
-            and wave_count >= self.max_prefill_waves
-        ):
-            return "max_waves"
         if waiting_queue_empty:
+            target_requests = self._prefill_wait_target_requests(
+                getattr(self.server_args, "prefill_max_requests", None)
+            )
+            if (
+                self._prefill_wait_enabled(target_requests)
+                and self._prefill_wait_epoch_has_room()
+            ):
+                if self._wait_for_prefill_batch(
+                    PREFILL_WAIT_REASON_WAITING_EMPTY,
+                    0,
+                    target_requests,
+                ):
+                    return None
             return "waiting_empty"
         if wave_count < self.min_prefill_waves:
             return None
@@ -499,6 +645,7 @@ class OfflinePPStateOffloadManager:
     def enter_draining(self, reason: str) -> None:
         if self.epoch_state == EpochState.DRAINING:
             return
+        self._reset_prefill_wait()
         self._log_epoch("EPOCH_FILL_STOP", reason=reason)
         self.epoch_state = EpochState.DRAINING
         self._log_epoch("EPOCH_DRAIN_START", reason=reason)
@@ -539,6 +686,7 @@ class OfflinePPStateOffloadManager:
         self.fill_stop_requested = False
         self.fill_stop_reason = None
         self.inflight_prefill_mbs.clear()
+        self._reset_prefill_wait()
         self._log_epoch("EPOCH_START", reason="previous_epoch_drained")
 
     def _mamba_pool_size(self) -> Optional[int]:
@@ -673,6 +821,13 @@ class OfflinePPStateOffloadManager:
             if accepted >= req_cap:
                 limited_by = "user_cap"
                 break
+
+        if (
+            waiting_queue
+            and accepted == len(waiting_queue)
+            and accepted < req_cap
+        ):
+            limited_by = "waiting_queue"
 
         if accepted == 0 and waiting_queue:
             req = waiting_queue[0]

--- a/python/sglang/srt/managers/offline_pp_offload_manager.py
+++ b/python/sglang/srt/managers/offline_pp_offload_manager.py
@@ -64,6 +64,10 @@ RESIDENT_WAVES = 2
 # for fragmentation. Combined with the /RESIDENT_WAVES split for admission.
 ADMISSION_ALPHA = 0.95
 
+# Very short startup/internal requests are dominated by fixed per-request state.
+# Do not use them to estimate per-token host bytes for long benchmark waves.
+HOST_BYTES_OBSERVATION_MIN_TOKENS = 1024
+
 PREFILL_WAIT_REASON_UNDERFILLED_WAVE = "underfilled_wave"
 PREFILL_WAIT_REASON_WAITING_EMPTY = "waiting_empty"
 
@@ -348,6 +352,8 @@ class OfflinePPStateOffloadManager:
 
     def _observe_host_bytes(self, committed_len: int, host_bytes: int) -> None:
         if committed_len <= 0 or host_bytes <= 0:
+            return
+        if committed_len < HOST_BYTES_OBSERVATION_MIN_TOKENS:
             return
         sample = host_bytes / committed_len
         if self._host_bytes_per_committed_token is None:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2553,7 +2553,18 @@ class Scheduler(
         reqs = wave.reqs
         device = self.device
 
-        self.offline_pp_offload_manager.wait_prefetch_for_decode(wave)
+        nvtx_range = getattr(self.offline_pp_offload_manager, "nvtx_range", None)
+        nvtx_ctx = (
+            nvtx_range(
+                "offline_pp.decode_batch_prepare "
+                f"epoch={getattr(wave, 'epoch_id', 'unknown')} "
+                f"wave={wave.wave_id} bs={len(reqs)}"
+            )
+            if nvtx_range is not None
+            else nullcontext()
+        )
+        with nvtx_ctx:
+            self.offline_pp_offload_manager.wait_prefetch_for_decode(wave)
 
         batch = ScheduleBatch.init_new(
             reqs=reqs,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2491,6 +2491,13 @@ class Scheduler(
 
         # Step 2: keep prefilling only while the epoch is accepting new work.
         if mgr.can_dispatch_prefill():
+            if mgr.should_wait_for_prefill(
+                waiting_queue_len=len(self.waiting_queue),
+                has_chunked_req=self.chunked_req is not None,
+                base_prefill_max_requests=self.server_args.prefill_max_requests,
+            ):
+                return None
+
             new_batch = self.get_new_batch_prefill()
             if new_batch is not None:
                 mb_id = getattr(self, "current_pp_mb_id", None)

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -5,6 +5,7 @@ import math
 import time
 from array import array
 from collections import defaultdict, deque
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
@@ -41,6 +42,35 @@ from sglang.srt.utils import DynamicGradMode, broadcast_pyobj, point_to_point_py
 from sglang.srt.utils.common import get_device_module, is_xpu
 
 logger = logging.getLogger(__name__)
+
+
+def _offline_pp_batch_nvtx_message(
+    scheduler, batch: Optional[ScheduleBatch], mb_id: int
+):
+    mgr = getattr(scheduler, "offline_pp_offload_manager", None)
+    if mgr is None or batch is None:
+        return None
+
+    wave_id = getattr(batch, "offline_pp_wave_id", None)
+    if wave_id is not None:
+        wave = getattr(mgr, "waves", {}).get(wave_id)
+        epoch_id = getattr(wave, "epoch_id", "unknown")
+        return (
+            "offline_pp.decode_forward "
+            f"epoch={epoch_id} wave={wave_id} mb={mb_id} bs={len(batch.reqs)}"
+        )
+
+    epoch_id = getattr(batch, "offline_pp_prefill_epoch_id", None)
+    if epoch_id is not None:
+        prefill_mb_id = getattr(batch, "offline_pp_prefill_mb_id", None)
+        return (
+            "offline_pp.prefill_forward "
+            f"epoch={epoch_id} mb={prefill_mb_id} "
+            f"loop_mb={mb_id} bs={len(batch.reqs)}"
+        )
+
+    return None
+
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
@@ -1288,7 +1318,14 @@ class SchedulerPPMixin:
         mb_metadata: List[Optional[PPBatchMetadata]],
         last_rank_comm_queue: deque,
     ):
-        with torch.profiler.record_function("run_batch"):
+        nvtx_message = _offline_pp_batch_nvtx_message(self, self.cur_batch, mb_id)
+        nvtx_range = getattr(self.offline_pp_offload_manager, "nvtx_range", None)
+        nvtx_ctx = (
+            nvtx_range(nvtx_message)
+            if nvtx_message is not None and nvtx_range is not None
+            else nullcontext()
+        )
+        with torch.profiler.record_function("run_batch"), nvtx_ctx:
             with self.forward_stream_ctx:
                 self.forward_stream.wait_stream(self.schedule_stream)
                 set_time_batch(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -731,6 +731,7 @@ class ServerArgs:
     enable_offline_pp_offload: bool = False
     offline_pp_prefetch_stall_ticks: int = 64
     offline_pp_prefetch_hard_timeout_sec: float = 300.0
+    offline_pp_prefill_wait_timeout_ticks: int = 0
     offline_pp_max_host_memory_gb: Optional[float] = None
     offline_pp_min_prefill_waves: Optional[int] = None
     offline_pp_max_prefill_waves: Optional[int] = None
@@ -4265,6 +4266,10 @@ class ServerArgs:
                 raise ValueError(
                     "--offline-pp-prefetch-hard-timeout-sec must be positive."
                 )
+            if self.offline_pp_prefill_wait_timeout_ticks < 0:
+                raise ValueError(
+                    "--offline-pp-prefill-wait-timeout-ticks must be non-negative."
+                )
 
         if not (0 < self.swa_full_tokens_ratio <= 1.0):
             raise ValueError("--swa-full-tokens-ratio should be in range (0, 1.0].")
@@ -6552,6 +6557,14 @@ class ServerArgs:
             default=ServerArgs.offline_pp_prefetch_hard_timeout_sec,
             help="Wall-clock seconds a blocked offline PP prefetch wave may wait "
             "before hard deadlock protection rolls it back.",
+        )
+        parser.add_argument(
+            "--offline-pp-prefill-wait-timeout-ticks",
+            type=int,
+            default=ServerArgs.offline_pp_prefill_wait_timeout_ticks,
+            help="Logical scheduler ticks to wait in offline PP filling when "
+            "the current waiting queue is below --prefill-max-requests, or "
+            "briefly empty before the epoch is full. 0 disables prefill waiting.",
         )
         parser.add_argument(
             "--offline-pp-max-host-memory-gb",

--- a/test/registered/scheduler/test_offline_pp_offload_manager.py
+++ b/test/registered/scheduler/test_offline_pp_offload_manager.py
@@ -145,6 +145,12 @@ def _manager(*, kv_allocator=None, req_pool=None):
     mgr.gpu_resident_factor = 2.0
     mgr.min_prefill_waves = 2
     mgr.max_prefill_waves = None
+    mgr.server_args = SimpleNamespace(prefill_max_requests=8)
+    mgr.prefill_wait_timeout_ticks = 1
+    mgr._prefill_wait_start_time = None
+    mgr._prefill_wait_start_tick = None
+    mgr._prefill_wait_reason = None
+    mgr._prefill_wait_timeout_logged = False
     mgr.host_limit_bytes = None
     mgr.is_hybrid = False
     mgr.offload_stream = _FakeStream()
@@ -319,6 +325,25 @@ def test_epoch_drains_all_waves_before_next_fill():
     assert mgr.current_epoch_id == 1
 
 
+def test_fill_stop_counts_inflight_prefill_against_max_waves():
+    mgr = _manager()
+    mgr.max_prefill_waves = 2
+    mgr.new_wave([_req("r0", 2)])
+    mgr.note_prefill_dispatched(0)
+
+    assert mgr.pending_epoch_wave_count() == 2
+    assert mgr.local_fill_stop_reason(waiting_queue_empty=False) == "max_waves"
+
+
+def test_fill_stop_counts_inflight_prefill_before_wave_materializes():
+    mgr = _manager()
+    mgr.max_prefill_waves = 1
+    mgr.note_prefill_dispatched(0)
+
+    assert mgr.pending_epoch_wave_count() == 1
+    assert mgr.local_fill_stop_reason(waiting_queue_empty=False) == "max_waves"
+
+
 def test_request_draining_waits_for_inflight_prefill_to_offload():
     mgr = _manager()
     wave = mgr.new_wave([_req("r0", 2)])
@@ -375,6 +400,61 @@ def test_host_state_bytes_are_counted_and_released_when_decode_ready():
     assert mgr.host_pinned_bytes == 0
 
 
+def test_prefill_waits_for_underfilled_wave_before_timeout():
+    mgr = _manager()
+    mgr.prefill_wait_timeout_ticks = 60
+
+    assert (
+        mgr.should_wait_for_prefill(
+            waiting_queue_len=7,
+            has_chunked_req=False,
+            base_prefill_max_requests=8,
+        )
+        is True
+    )
+    assert mgr.has_offline_work() is True
+
+
+def test_prefill_wait_timeout_allows_underfilled_wave():
+    mgr = _manager()
+    mgr.prefill_wait_timeout_ticks = 2
+
+    assert mgr.should_wait_for_prefill(7, False, 8) is True
+    mgr._tick += 2
+
+    assert mgr.should_wait_for_prefill(7, False, 8) is False
+
+
+def test_prefill_wait_full_wave_resets_wait():
+    mgr = _manager()
+    mgr.prefill_wait_timeout_ticks = 60
+
+    assert mgr.should_wait_for_prefill(7, False, 8) is True
+    assert mgr.should_wait_for_prefill(8, False, 8) is False
+    assert mgr._prefill_wait_start_tick is None
+
+
+def test_waiting_empty_waits_before_draining_when_epoch_has_room():
+    mgr = _manager()
+    mgr.prefill_wait_timeout_ticks = 60
+    mgr.max_prefill_waves = 4
+    mgr.new_wave([_req("r0", 2)])
+
+    assert mgr.local_fill_stop_reason(waiting_queue_empty=True) is None
+
+
+def test_waiting_empty_drains_after_wait_timeout():
+    mgr = _manager()
+    mgr.prefill_wait_timeout_ticks = 2
+    mgr.max_prefill_waves = 4
+    mgr.new_wave([_req("r0", 2)])
+
+    assert mgr.local_fill_stop_reason(waiting_queue_empty=True) is None
+    mgr._tick += 2
+
+    assert mgr.local_fill_stop_reason(waiting_queue_empty=True) == "waiting_empty"
+
+
 def test_prefill_budget_uses_decode_tokens_for_gpu_and_prompt_bytes_for_host():
     mgr = _manager(kv_allocator=_FakeKVAllocator(size=40))
     mgr.host_limit_bytes = 200
@@ -396,6 +476,34 @@ def test_prefill_budget_uses_decode_tokens_for_gpu_and_prompt_bytes_for_host():
     assert budget.kv_decode_slots == 40
     assert budget.kv_prefetch_slots == 8
     assert budget.host_bytes_est == 80
+
+
+def test_prefill_budget_marks_waiting_queue_limited_underfill():
+    mgr = _manager(kv_allocator=_FakeKVAllocator(size=1024))
+    reqs = [_req(f"r{i}", 4) for i in range(7)]
+
+    budget = mgr.prefill_budget_for_waiting_queue(
+        reqs,
+        base_max_prefill_tokens=1024,
+        base_prefill_max_requests=8,
+    )
+
+    assert budget.prefill_max_requests == 7
+    assert budget.limited_by == "waiting_queue"
+
+
+def test_prefill_budget_resource_limit_does_not_report_waiting_queue():
+    mgr = _manager(kv_allocator=_FakeKVAllocator(size=80))
+    reqs = [_req(f"r{i}", 4, max_new_tokens=1) for i in range(8)]
+
+    budget = mgr.prefill_budget_for_waiting_queue(
+        reqs,
+        base_max_prefill_tokens=1024,
+        base_prefill_max_requests=8,
+    )
+
+    assert budget.prefill_max_requests == 7
+    assert budget.limited_by == "gpu_double_buffer"
 
 
 def test_prefill_budget_can_be_limited_by_mamba_slots():

--- a/test/registered/scheduler/test_offline_pp_offload_scheduler.py
+++ b/test/registered/scheduler/test_offline_pp_offload_scheduler.py
@@ -61,6 +61,7 @@ class _FakeOfflinePPManager:
         self.current_epoch_id = 0
         self.active_epoch_waves = False
         self.decode_ready_wave = None
+        self.wait_for_prefill = False
 
     def offload_prefilled_wave(self, reqs, source_stream=None):
         self.offloaded.append(list(reqs))
@@ -78,6 +79,11 @@ class _FakeOfflinePPManager:
 
     def can_dispatch_prefill(self):
         return self.filling and not self.fill_stop_requested
+
+    def should_wait_for_prefill(
+        self, waiting_queue_len, has_chunked_req, base_prefill_max_requests
+    ):
+        return self.wait_for_prefill
 
     def note_prefill_dispatched(self, mb_id):
         self.inflight_prefill_mbs.add(mb_id)
@@ -119,6 +125,7 @@ class _FakeOfflinePPManager:
             self.active_epoch_waves
             or self.fill_stop_requested
             or self.inflight_prefill_count > 0
+            or self.wait_for_prefill
         )
 
     def has_decoding_wave(self):
@@ -221,6 +228,7 @@ def test_filling_epoch_prefill_dispatch_is_marked_inflight():
         chunked_req=None,
         current_pp_mb_id=5,
         offline_pp_offload_manager=mgr,
+        server_args=SimpleNamespace(prefill_max_requests=8),
         get_new_batch_prefill=lambda: batch,
         token_to_kv_pool_allocator=SimpleNamespace(available_size=lambda: 1024),
     )
@@ -231,6 +239,26 @@ def test_filling_epoch_prefill_dispatch_is_marked_inflight():
     assert batch.offline_pp_prefill_mb_id == 5
     assert mgr.inflight_prefill_mbs == {5}
     assert mgr.entered_draining == []
+
+
+def test_filling_epoch_prefill_wait_blocks_partial_prefill():
+    mgr = _FakeOfflinePPManager()
+    mgr.wait_for_prefill = True
+
+    sched = SimpleNamespace(
+        last_batch=None,
+        running_batch=_EmptyBatch(),
+        waiting_queue=[_FakeReq("waiting")],
+        chunked_req=None,
+        offline_pp_offload_manager=mgr,
+        server_args=SimpleNamespace(prefill_max_requests=8),
+        get_new_batch_prefill=lambda: (_ for _ in ()).throw(
+            AssertionError("prefill wait should block prefill dispatch")
+        ),
+        token_to_kv_pool_allocator=SimpleNamespace(available_size=lambda: 1024),
+    )
+
+    assert Scheduler._get_next_batch_offline_pp(sched) is None
 
 
 def test_fill_stop_request_blocks_new_prefill_until_inflight_offloads():


### PR DESCRIPTION
## Summary

This PR improves the scheduling behavior, observability, and host-memory estimation of offline pipeline-parallel (PP) offloading.

- Add NVTX ranges for PP prefill/decode forward passes and offline PP offload, prefetch, release, decode preparation, and rollback operations.
- Add a configurable tick-based prefill wait through `--offline-pp-prefill-wait-timeout-ticks` to form fuller prefill waves while keeping scheduling decisions consistent across PP ranks.
- Count in-flight prefill microbatches toward the maximum prefill-wave limit and distinguish batches limited by the waiting queue.
- Add unit and scheduler tests covering prefill waiting, timeout handling, empty-queue draining, and in-flight wave accounting.
- Ignore host-memory observations from requests with fewer than 1024 committed tokens, preventing short startup or internal requests from skewing the per-token host-memory estimate.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #33051791434](https://github.com/bytedance-iaas/sglang/actions/runs/33051791434)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #33051791115](https://github.com/bytedance-iaas/sglang/actions/runs/33051791115)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->