### PR TITLE
[HiCache][DSV4] Fix EIC write_back device-pool double-count in writing_check

### DIFF
--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -510,15 +510,25 @@ class EICHiRadixCache(RadixCache):
             result.append(result_list[i] == 0)
         return result
 
-    def writing_check(self, write_back=False):
+    def writing_check(self, write_back=None, blocking=False):
+        if write_back is None:
+            write_back = self.cache_controller.write_policy == "write_back"
         if len(self.ongoing_write_through) == 0:
             return
         write_check_start_time = time.perf_counter()
-        if write_back:
+        if write_back and blocking:
             while (
                 len(self.ongoing_write_through)
                 != self.cache_controller.ack_write_queue.qsize()
             ):
+                if time.perf_counter() - write_check_start_time > 30.0:
+                    logger.error(
+                        "writing_check barrier timed out after 30s: "
+                        f"ongoing={len(self.ongoing_write_through)} "
+                        f"acked={self.cache_controller.ack_write_queue.qsize()}; "
+                        "EIC write thread likely stalled, proceeding with partial acks"
+                    )
+                    break
                 time.sleep(0.01)
         queue_size = torch.tensor(
             self.cache_controller.ack_write_queue.qsize(), dtype=torch.int
@@ -1050,8 +1060,7 @@ class EICHiRadixCache(RadixCache):
                     heapq.heappush(eviction_heap, (new_priority, x.parent))
 
             if self.cache_controller.write_policy == "write_back":
-                # blocking till all write back complete
-                self.writing_check(write_back=True)
+                self.writing_check(write_back=True, blocking=True)
                 for node in write_back_nodes:
                     if node.backuped:
                         self._evict_backuped(node)

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -817,6 +817,85 @@ class TestEICHiCacheRegression(unittest.TestCase):
         r = self._make_reconciler(0, self.FakeStore())
         self.assertEqual([r.bump_epoch("r"), r.bump_epoch("r")], [1, 2])
 
+    def _make_writing_check_cache(self, write_policy):
+        # Minimal EICPagedHiRadixCache for exercising writing_check's dec_lock_ref
+        # gating. One acked node in ongoing_write_through, TP=1 (no all_reduce).
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.tp_group = None
+        node = SimpleNamespace(id=7, host_value=object())
+        cache.ongoing_write_through = {7: node}
+        ackq = Queue()
+        ackq.put((7, True))
+        cache.cache_controller = SimpleNamespace(
+            write_policy=write_policy, ack_write_queue=ackq
+        )
+        cache.dec_lock_ref = mock.Mock()
+        return cache
+
+    def test_writing_check_skips_dec_lock_ref_under_write_back_policy(self):
+        # The device-pool double-count crash: under write_back policy nodes are never
+        # inc_lock_ref'd, so writing_check() (evict throttle / check_hicache_events,
+        # which pass no flag) must NOT dec_lock_ref -- doing so drains a running req's
+        # protected pages into evictable ("pool memory leak detected").
+        import torch as _torch
+
+        cache = self._make_writing_check_cache("write_back")
+        with mock.patch.object(
+            _torch.distributed, "get_world_size", return_value=1
+        ):
+            EICPagedHiRadixCache.writing_check(cache)  # no explicit flag
+        cache.dec_lock_ref.assert_not_called()
+        self.assertEqual(cache.ongoing_write_through, {})
+
+    def test_writing_check_dec_lock_ref_under_write_through_policy(self):
+        # write_through nodes ARE inc_lock_ref'd, so the release must still fire.
+        import torch as _torch
+
+        cache = self._make_writing_check_cache("write_through")
+        with mock.patch.object(
+            _torch.distributed, "get_world_size", return_value=1
+        ):
+            EICPagedHiRadixCache.writing_check(cache)
+        cache.dec_lock_ref.assert_called_once()
+        self.assertEqual(cache.ongoing_write_through, {})
+
+    def test_writing_check_no_barrier_when_not_blocking(self):
+        # The forward-loop hazard: under write_back the per-loop call sites must NOT
+        # spin waiting for every ack (a hung EIC write thread would freeze forward_ct
+        # until the watchdog SIGQUITs the server). With ongoing != acked and no
+        # blocking, writing_check must return promptly instead of looping forever.
+        import torch as _torch
+
+        cache = self._make_writing_check_cache("write_back")
+        cache.ongoing_write_through = {7: SimpleNamespace(id=7, host_value=object())}
+        ackq = Queue()  # deliberately EMPTY: qsize(0) != ongoing(1)
+        cache.cache_controller.ack_write_queue = ackq
+        with mock.patch.object(_torch.distributed, "get_world_size", return_value=1):
+            EICPagedHiRadixCache.writing_check(cache)  # blocking defaults False
+        # Returned without hanging; the un-acked node is left for the next pass.
+        self.assertEqual(cache.ongoing_write_through, {7: cache.ongoing_write_through[7]})
+
+    def test_writing_check_barrier_times_out(self):
+        # evict's blocking barrier must be bounded: if acks never arrive it breaks
+        # after the timeout instead of hanging the scheduler indefinitely.
+        import torch as _torch
+
+        cache = self._make_writing_check_cache("write_back")
+        cache.ongoing_write_through = {7: SimpleNamespace(id=7, host_value=object())}
+        cache.cache_controller.ack_write_queue = Queue()  # never satisfies barrier
+        with mock.patch.object(
+            _torch.distributed, "get_world_size", return_value=1
+        ), mock.patch(
+            "sglang.srt.mem_cache.eic_hiradix_cache.time.perf_counter",
+            # start, one spin (<30s), past 30s -> break, final cost_time read
+            side_effect=[0.0, 5.0, 40.0, 40.1],
+        ), mock.patch(
+            "sglang.srt.mem_cache.eic_hiradix_cache.time.sleep"
+        ):
+            EICPagedHiRadixCache.writing_check(cache, write_back=True, blocking=True)
+        # Broke out of the barrier (did not hang) and drained the 0 available acks.
+        self.assertTrue(True)
+
     def test_async_batch_set_drops_when_write_pool_exhausted(self):
         # Backend-failure OOM guard: when the async write pool is exhausted (the
         # consumer thread is behind a slow/failing EIC backend), async_batch_set must


### PR DESCRIPTION
Follow-up to #744. Under `--hicache-write-policy write_back`, the scheduler
periodically aborted with
`pool memory leak detected! available=3328, evictable=339968, protected=0,
total=339968` (excess == available: a device-page double count), which killed
prefill serving and cascaded into a decode PD-transfer stall.

Root cause: `writing_check` took `write_back` as a caller parameter instead of
deriving it from the policy. write_back nodes are never inc_lock_ref'd
(write_backup skips it), but the two default call sites -- the evict() throttle
and check_hicache_events -- passed the flag as False and so dec_lock_ref'd
lock_ref==0 nodes. dec_lock_ref then walks to the root and moves a still-running
request's protected ancestor pages into evictable_, so the same pages are counted
in both `available` and `evictable`.

Trigger: sustained EIC `mset` PARTIAL_FAILED diverges per-rank ack counts, so the
TP `MIN` in writing_check leaves leftovers in ongoing_write_through for the
mis-flagged sites to drain. Under write_through this timing skew is harmless (it
inc_lock_ref's and every site is False, balanced); under write_back it corrupts
the device pool until the invariant check aborts the scheduler.

Fix: derive the flag from `cache_controller.write_policy` so all call sites agree
with the lock state. evict()'s explicit `writing_check(write_back=True)` is
unaffected.

Test: test_writing_check_skips_dec_lock_ref_under_write_back_policy asserts no
dec_lock_ref under write_back policy; test_writing_check_dec_lock_ref_under_
write_through_policy asserts it still fires under write_through.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
