### PR TITLE
docker: rewrite Ubuntu deb822 sources for HTTPS mirror

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,8 +40,11 @@ ENV PATH="${PATH}:/usr/local/nvidia/bin" \
 
 # Replace Ubuntu sources if specified
 RUN if [ -n "$UBUNTU_MIRROR" ]; then \
-    sed -i "s|http://.*archive.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list && \
-    sed -i "s|http://.*security.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list; \
+    for sources_file in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+        if [ -f "$sources_file" ]; then \
+            sed -i -E "s#https?://(archive|security)\.ubuntu\.com#$UBUNTU_MIRROR#g" "$sources_file"; \
+        fi; \
+    done; \
 fi
 
 # Python setup (combined with apt update to reduce layers)


### PR DESCRIPTION
## Summary\n\n- rewrite both legacy sources.list entries and Ubuntu 24.04 deb822 ubuntu.sources URIs\n- preserve the configurable UBUNTU_MIRROR build argument\n\n## Validation\n\n- consumed by GitHub Actions run 33481494727\n- DeepSeek V4 kernel wheel and OCI, zstd, and nydus image builds completed successfully