### PR TITLE
[HiCache][DSV4] Bound the EIC evict write-through throttle, plus a pre-benchmark EIC gate

### DIFF
--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1007,6 +1007,13 @@ class EICHiRadixCache(RadixCache):
         # backlog drains at the single lockstep site (check_hicache_events) and
         # in the schedule_policy busy-wait, both PP-uniform.
         while len(self.ongoing_write_through) > 50:
+            if time.perf_counter() - start_time > 30.0:
+                logger.error(
+                    "evict write-through throttle timed out after 30s: "
+                    f"ongoing={len(self.ongoing_write_through)}; "
+                    "EIC write thread likely stalled, proceeding with eviction"
+                )
+                break
             self.writing_check()
             time.sleep(0.1)
 

--- a/scripts/eic_gate.py
+++ b/scripts/eic_gate.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""EIC 前置门：主动写读探针，确认 EIC 真的在工作。
+
+为什么需要它——现有判据 `grep "eic mset ... failed"` 有两个盲区：
+
+  1. 零尝试被误读为健康。没有流量时不会有任何 mset，日志干净，
+     但这是 UNKNOWN 不是 OK。
+  2. namespace 错配一路绿灯。key 带 namespace 前缀，配错时 mset
+     100% 成功——写进一个没人读的空间，下一轮读全 miss，而读 miss
+     长得就像正常冷启动。
+
+历史代价：四轮压测十几个小时，TTFT 223ms / 命中 94% / 吞吐 41212 tok/s
+全部建立在 mset 成功率 0% 之上，测的其实全是设备层缓存。
+
+用法（在 prefill pod 内）：
+    python3 eic_gate.py                    # 用容器内默认配置
+    python3 eic_gate.py --yaml <path>      # 指定 remote-eic.yaml
+
+退出码 0 = PASS，非 0 = FAIL/UNKNOWN。不通过不要跑压测。
+
+验证状态：配置前置检查（缺文件、空 namespace）已在本地验证能拦住；
+写读路径尚未在 pod 内实测，需要集群才能验。
+"""
+import argparse
+import os
+import sys
+
+DEFAULT_YAML = os.environ.get(
+    "REMOTE_EIC_YAML", "/sgl-workspace/config/remote-eic.yaml"
+)
+# payload 要大于 split_kv_slice_size_byte（默认 512KB）才走多 slice 路径，
+# 与真实 KV 写入同构。
+PAYLOAD_BYTES = 2 * 1024 * 1024
+NUM_KEYS = 4
+
+
+def make_payload(n):
+    # 重复 ASCII：非平凡、非极端、不撞特殊路径。
+    # 别用 0xa5 之类的高位字节——pybind11 的 mget 路径会按 UTF-8 解码，
+    # 健康的 EIC 会被误报成读失败。也别用全零，可能撞稀疏/压缩优化，
+    # 那样"写成功"的字节数含义就变了。
+    unit = b"eicgate0123456789abcdef"
+    return (unit * (n // len(unit) + 1))[:n]
+
+
+def load_cfg(path):
+    import yaml
+
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--yaml", default=DEFAULT_YAML)
+    ap.add_argument("--keys", type=int, default=NUM_KEYS)
+    ap.add_argument("--bytes", type=int, default=PAYLOAD_BYTES)
+    args = ap.parse_args()
+
+    if not os.path.exists(args.yaml):
+        print(f"EIC_GATE_FAIL: config not found: {args.yaml}")
+        print("  客户端会跑在默认配置上，那不是被测配置。")
+        return 2
+
+    cfg = load_cfg(args.yaml)
+    instance_id = cfg.get("eic_instance_id", "")
+    endpoint = cfg.get("remote_url", "")
+    namespace = cfg.get("eic_namespace", "")
+    flag_file = cfg.get("eic_flag_file")
+    log_dir = cfg.get("eic_log_dir", "/tmp/eic_gate_log")
+    trans_type = cfg.get("eic_trans_type", 2)
+    log_level = cfg.get("eic_log_level", 2)
+
+    # 门测的必须是 vLLM/SGLang 实际会用的那套身份，否则门通过不说明任何事。
+    print(f"instance_id: {instance_id}")
+    print(f"endpoint   : {endpoint}")
+    print(f"namespace  : {namespace}   <- 来自 {args.yaml}，与业务侧同源")
+    if not namespace:
+        print("EIC_GATE_FAIL: namespace 为空。key 前缀会与业务侧不一致，")
+        print("  即使 mset 全成功也是写进另一个空间。")
+        return 2
+
+    import eic
+
+    os.makedirs(log_dir, exist_ok=True)
+    conn = eic.Client()
+    opt = eic.InitOption()
+    opt.log_dir = log_dir
+    opt.log_level = eic.LogLevel(log_level)
+    opt.transport_type = eic.TransportType(trans_type)
+    if flag_file:
+        opt.flag_file = flag_file
+        print(f"flag_file  : {flag_file}")
+
+    ret = conn.init(instance_id, endpoint, opt)
+    if ret != 0:
+        print(f"EIC_GATE_FAIL: init 失败 ret={ret}")
+        return 2
+
+    payload = make_payload(args.bytes)
+    # 每次唯一 key：防已驻留数据冒充成功。固定 key 会被上一轮的残留服务，
+    # 写坏了也能"读通"。唯一 key 同时能暴露 namespace 错配的一半形态——
+    # 读回的若是别人写的旧数据，内容不会匹配。
+    tag = f"{os.getpid()}_{os.urandom(4).hex()}"
+    keys = [f"eicgate/{tag}/{i}" for i in range(args.keys)]
+
+    import torch
+
+    src = [
+        torch.frombuffer(bytearray(payload), dtype=torch.uint8) for _ in range(len(keys))
+    ]
+
+    set_opt = eic.SetOption()
+    set_opt.ns = namespace
+    kv = eic.StringVector()
+    vals = eic.IOBuffers()
+    for k, t in zip(keys, src):
+        kv.append(k)
+        vals.append(t.data_ptr(), t.numel(), False)
+
+    status, outcome = conn.mset(kv, vals, set_opt)
+    if status != eic.StatusCode.SUCCESS:
+        print(f"EIC_GATE_FAIL: mset status={status}  (尝试 {len(keys)} 个 key)")
+        print("  写入失败。查 eic_agent_byterpc.* 而不是 eic_agent.INFO——")
+        print("  连接层记录只在前者，后者只有心跳和内存管理。")
+        return 1
+    print(f"writes     : {len(keys)}/{len(keys)} ok "
+          f"({args.bytes // 1024}KB x {len(keys)})")
+
+    # 写后立即读回 + 字节比对。只看返回码不足以证明写对了地方：
+    # namespace 配错时 mset 同样返回 SUCCESS。
+    dst = [torch.zeros(args.bytes, dtype=torch.uint8) for _ in keys]
+    get_keys = eic.StringVector()
+    get_vals = eic.IOBuffers()
+    for k, t in zip(keys, dst):
+        get_keys.append(k)
+        get_vals.append(t.data_ptr(), t.numel(), False)
+    get_opt = eic.GetOption()
+    get_opt.ns = namespace
+
+    status, get_vals, get_outcome = conn.mget(get_keys, get_opt, get_vals)
+    if status != eic.StatusCode.SUCCESS:
+        print(f"EIC_GATE_FAIL: mget status={status}")
+        print("  写成功但读不回——典型成因是 namespace 与写入侧不一致。")
+        return 1
+
+    want = torch.frombuffer(bytearray(payload), dtype=torch.uint8)
+    bad = [k for k, t in zip(keys, dst) if not torch.equal(t, want)]
+    if bad:
+        print(f"EIC_GATE_FAIL: {len(bad)}/{len(keys)} 字节不匹配: {bad[:2]}")
+        print("  读回的不是刚写进去的内容。")
+        return 1
+
+    total_mb = args.bytes * len(keys) / 1024 / 1024
+    print(f"reads      : {len(keys)}/{len(keys)} served, {total_mb:.1f}MB, byte-exact")
+    print("EIC_GATE_PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -944,6 +944,40 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(c.write_queue.qsize(), 1)
         self.assertEqual(len(copied), 1)  # copy_func invoked once
 
+    def _make_evict_throttle_cache(self, backlog):
+        # Minimal cache for exercising evict()'s write-through throttle loop only.
+        # The loop runs before any tree work; evictable_leaves is the first thing
+        # the body touches, so a sentinel there proves the throttle was escaped.
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.ongoing_write_through = {i: object() for i in range(backlog)}
+        cache.writing_check = mock.Mock()
+        return cache
+
+    def test_evict_throttle_is_bounded_when_write_thread_stalls(self):
+        # The watchdog SIGQUIT crash: a hung EIC mset stops ongoing_write_through
+        # from draining, and evict()'s throttle spun forever on all PP0 ranks. PP1
+        # then blocked in broadcast, forward_ct froze, and the 300s scheduler
+        # watchdog killed all 8 ranks. The throttle must break out on a deadline.
+        cache = self._make_evict_throttle_cache(backlog=51)  # > 50, never drains
+        params = SimpleNamespace(num_tokens=1, swa_num_tokens=0)
+        escaped = RuntimeError("throttle escaped")
+
+        class Sentinel:
+            def __iter__(self):
+                raise escaped
+
+        cache.evictable_leaves = Sentinel()
+        with mock.patch(
+            "sglang.srt.mem_cache.eic_hiradix_cache.time.perf_counter",
+            # start, two spins under the deadline, then past 30s -> break
+            side_effect=[0.0, 1.0, 2.0, 40.0],
+        ), mock.patch("sglang.srt.mem_cache.eic_hiradix_cache.time.sleep"):
+            with self.assertRaises(RuntimeError) as ctx:
+                EICPagedHiRadixCache.evict(cache, params)
+        self.assertIs(ctx.exception, escaped)  # reached the body, i.e. broke out
+        self.assertEqual(cache.writing_check.call_count, 2)  # bounded spins
+        self.assertEqual(len(cache.ongoing_write_through), 51)  # never drained
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two EIC changes found while running the DSV4 PD-disaggregated capacity sweeps.

## 1. Bound the evict write-through throttle (the crash fix)

`evict()` throttles on the EIC write-through backlog with an unbounded busy-wait. When the
EIC backend stalls, `ongoing_write_through` never drains and the loop spins forever.

Observed in production (TP=8, PP=2 prefill), confirmed by py-spy at the moment the watchdog
fired:

- `write_thread_func_direct` blocked in C++ `InnerClient::mset` -> `CountDownLatch::Wait`
  (`eic_inner.cc:815`); the ack never came back
- all 4 PP0 ranks' MainThread stuck at `evict (eic_hiradix_cache.py:1011)`, which sits under
  the prefill hot path `alloc_for_extend`
- all 4 PP1 ranks stuck in `broadcast_pyobj` waiting on PP0
- `forward_ct` froze -> the 300s scheduler watchdog SIGQUIT'd all 8 ranks

Fix: break out of the throttle after 30s with a `logger.error`. The nodes in
`ongoing_write_through` were `inc_lock_ref`'d by `write_backup` and so are not evictable
anyway, which makes proceeding safe; these are in-flight write requests and must not be
dropped the way #744 drops async write-pool slots (that would lose data).

Validated on the deployed image: the timeout fired 88 times across a 3200-request run, with
0 prefill/decode restarts. Before the fix the same workload killed the server.

The backend stall is not hypothetical. A failed PCIe link on one agent node (`enable=0`,
`current_link_speed=Unknown`) took an RDMA NIC out of the DHT address list while the master
metadata still advertised it, so every mset that hashed to that shard timed out. Without
this patch that outage takes down prefill instead of only failing writes.

Regression test `test_evict_throttle_is_bounded_when_write_thread_stalls` puts a sentinel in
`evictable_leaves` that raises on iteration, so the test only passes if the throttle is
actually escaped.

## 2. Add `scripts/eic_gate.py`

A pre-benchmark probe that writes and reads back through the EIC client and compares bytes.

This exists because the passive check (grep the logs for mset failures) has two blind spots
that cost four rounds of benchmarking, roughly ten hours:

- **zero attempts read as healthy.** No traffic means no mset lines, so the log looks clean.
  That is UNKNOWN, not OK.
- **a namespace mismatch is all green.** Keys carry a namespace prefix; with the wrong one
  every mset succeeds, writing into a space nobody reads. The next round misses everything,
  and read misses look exactly like a cold start.

We published TTFT 223ms / 94% hit rate / 41212 tok/s from a run whose mset success rate was
0% -- all of it served from the device tier, with EIC storing nothing.

Probe design, each point earning its place:

- **unique keys per run** (`eicgate/{pid}_{hex}/{i}`), so resident data cannot pass as a
  successful write
- **2MB payload**, above the 512KB `split_kv_slice_size_byte` default, so it exercises the
  multi-slice path like real KV writes
- **read back and compare bytes**, which catches both corruption and a namespace mismatch
- **repeated ASCII payload**: `0xa5` fill hits a UTF-8 decode path in the pybind11 mget
  binding and reports a healthy EIC as a total read failure; an all-zero payload may hit
  sparse/compression paths and change what "bytes written" means

Exit 0 = PASS, non-zero = FAIL/UNKNOWN.

Verified in-pod against both states of the outage above: `EIC_GATE_FAIL: init failed ret=-1`
while the NIC was down, and after the node came back:

```
writes : 4/4 ok (2048KB x 4)
reads  : 4/4 served, 8.0MB, byte-exact
EIC_GATE_PASS
```

## Test

`test/registered/unit/mem_cache/test_eic_hicache_regression.py`: 36 passed, run on the
deployed DSV4 image.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->