### PR TITLE
fix(hicache): gate shared CP storage by pool capability

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
@@ -236,6 +236,10 @@ class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
     accessors instead).
     """
 
+    # Unlike the CUDA/HIP DSV4 paths, the Ascend backend writes CP-local KV
+    # directly into this pool without materializing global token order first.
+    supports_hicache_shared_cp_storage = False
+
     def __init__(self, *args, **kwargs):
         c128_page_size = get_schedule().c128_page_size
         if c128_page_size <= 0 or c128_page_size % 16 != 0:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -720,6 +720,13 @@ class HiCacheController:
         use_shared_cp_storage = (
             storage_backend == "file"
             and is_compressed_mla_model
+            and bool(
+                getattr(
+                    self.mem_pool_device,
+                    "supports_hicache_shared_cp_storage",
+                    False,
+                )
+            )
             and attn_cp_size > 1
             and self.pp_size == 1
         )

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -508,6 +508,12 @@ class DeepSeekV4UnifiedKVPool:
 
 
 class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
+    # HiCache may use one file namespace for all CP ranks only when every rank's
+    # device pool contains the full KV cache in global token order.  The CUDA
+    # and HIP DSV4 paths materialize that representation before writing it.
+    # Platform-specific subclasses must override this when they keep CP-local KV.
+    supports_hicache_shared_cp_storage = True
+
     def __init__(
         self,
         max_num_reqs: int,

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -289,23 +289,28 @@ class TestCPSuffix(HiCacheFileLRUTestBase):
         controller.enable_storage_metrics = False
         parallel = mock.Mock(attn_tp_rank=0, attn_tp_size=1, pp_rank=0)
 
-        for backend, is_dsv4, cp_rank, cp_size, pp_size, shared in [
-            ("file", True, 0, 8, 1, True),
-            ("file", True, 7, 8, 1, True),
-            ("file", True, 0, 1, 1, False),
-            ("file", True, 7, 8, 2, False),
-            ("mooncake", True, 7, 8, 1, False),
-            ("file", False, 7, 8, 1, False),
+        for backend, is_dsv4, supports_shared_cp, cp_rank, cp_size, pp_size, shared in [
+            ("file", True, True, 0, 8, 1, True),
+            ("file", True, True, 7, 8, 1, True),
+            ("file", True, True, 0, 1, 1, False),
+            ("file", True, True, 7, 8, 2, False),
+            ("mooncake", True, True, 7, 8, 1, False),
+            ("file", True, False, 7, 8, 1, False),
+            ("file", False, False, 7, 8, 1, False),
         ]:
             with self.subTest(
                 backend=backend,
                 is_dsv4=is_dsv4,
+                supports_shared_cp=supports_shared_cp,
                 cp_rank=cp_rank,
                 cp_size=cp_size,
                 pp_size=pp_size,
             ):
                 pool_cls = DeepSeekV4TokenToKVPool if is_dsv4 else MLATokenToKVPool
                 controller.mem_pool_device = mock.Mock(spec=pool_cls)
+                controller.mem_pool_device.supports_hicache_shared_cp_storage = (
+                    supports_shared_cp
+                )
                 controller.get_attn_cp_rank_and_size = mock.Mock(
                     return_value=(cp_rank, cp_size)
                 )


### PR DESCRIPTION
## Summary

- gate DeepSeek V4 file-backed shared CP storage on an explicit KV-pool capability
- keep the existing shared `_cpfull_N` namespace for CUDA/HIP DSV4 pools
- make Ascend DSV4 fall back to per-CP-rank namespaces and ownership because its cache-write path does not materialize full KV in global token order
- extend the storage-config unit matrix with the unsupported-capability case

This is a stacked fix for sgl-project/sglang#37808 and intentionally targets its source branch. It does not disable HiCache on Ascend; it only avoids the shared single-writer CP optimization until the Ascend DSV4 backend provides equivalent full-CP KV materialization.

## Why

The source PR currently infers shared-CP safety from `isinstance(pool, DeepSeekV4TokenToKVPool)`. `DSV4NPUTokenToKVPool` inherits that class, but unlike the CUDA/HIP DSV4 path, the Ascend path stores CP-local KV directly. Selecting `_cpfull_N` and a single CP owner therefore assumes a data-layout invariant that the NPU backend does not currently guarantee.

## Validation

- `pre-commit run --files python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py python/sglang/srt/managers/cache_controller.py test/registered/unit/mem_cache/test_hicache_file_lru_unit.py`
- `git diff --check`
- `python3 -m py_compile` for all four changed files

The focused pytest file could not be collected in the local environment because `triton` is not installed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33856463603](https://github.com/bytedance-iaas/sglang/actions/runs/33856463603)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33856463358](https://github.com/bytedance-iaas/sglang/actions/runs/33856463358)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->