### PR TITLE
[HiCache][DSV4] load_remote_threshold configurable, host-tier stats, EIC write-path exception safety

### DIFF
--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -189,12 +189,14 @@ class EICCacheController(HiCacheController):
 
         def safe_empty_cache():
             self.write_wait_event.set()
-            write_stream = self.write_stream
-            write_event = torch.cuda.Event()
-            write_event.record(write_stream)
-            write_event.synchronize()
-            original_empty_cache()
-            self.write_wait_event.clear()
+            try:
+                write_stream = self.write_stream
+                write_event = torch.cuda.Event()
+                write_event.record(write_stream)
+                write_event.synchronize()
+                original_empty_cache()
+            finally:
+                self.write_wait_event.clear()
 
         torch.cuda.empty_cache = safe_empty_cache
 
@@ -208,10 +210,11 @@ class EICCacheController(HiCacheController):
 
         def synced_forward(*args, **kwargs):
             self.write_wait_event.set()
-            self.write_stream.synchronize()
-            result = original_forward(*args, **kwargs)
-            self.write_wait_event.clear()
-            return result
+            try:
+                self.write_stream.synchronize()
+                return original_forward(*args, **kwargs)
+            finally:
+                self.write_wait_event.clear()
 
         ModelRunner.forward = synced_forward
         logger.info("Hooked model forward with synchronized write stream.")
@@ -456,8 +459,10 @@ class EICCacheController(HiCacheController):
                 try:
                     operation = self.load_queue.get(block=True, timeout=1)
                     self.load_wait_event.set()
-                    self.load_from_eic(operation)
-                    self.load_wait_event.clear()
+                    try:
+                        self.load_from_eic(operation)
+                    finally:
+                        self.load_wait_event.clear()
                 except Empty:
                     continue
                 except Exception as e:

--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -477,16 +477,6 @@ class EICCacheController(HiCacheController):
         """
         return self.mem_pool_host.alloc(size)
 
-    def find_longest_prefix_in_eic(self, prompt, prev_hash=None):
-        """
-        Find the longest prefix in the EIC cache.
-        """
-        if len(prompt) == 0:
-            return [], []
-        content_hash = get_content_hash(prompt, self.page_size, prev_hash)
-        exist_result = self.mem_pool_host.exist_page(content_hash)
-        return exist_result, prompt[: len(exist_result) * self.page_size]
-
     def batch_find_longest_prefix_in_eic(self, prompts, prev_hashes):
         assert len(prompts) == len(
             prev_hashes

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -900,6 +900,13 @@ class SchedulerMetricsReporter:
             self.scheduler.tree_cache, "token_to_kv_pool_host", None
         ) or getattr(self.scheduler.tree_cache, "full_kv_pool_host", None)
         assert host_pool is not None, "Host pool not found"
+        group = getattr(host_pool, "host_pool_group", None)
+        if group is not None:
+            host_pool = next(
+                e.host_pool
+                for e in group.entry_map.values()
+                if e.is_primary_index_anchor
+            )
         self.stats.hicache_host_used_tokens = (
             host_pool.size - host_pool.available_size()
         )

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1528,11 +1528,11 @@ class EICPagedHiRadixCache(EICHiRadixCache):
 
     def init_hyper_params(self, config):
         super().init_hyper_params(config)
-        floor = 1 << 14  # 16K tokens
-        cfg_val = config.get("load_remote_threshold", floor)
-        self.load_remote_threshold = max(cfg_val, floor)
+        self.load_remote_threshold = max(
+            config.get("load_remote_threshold", 1 << 14), self.page_size
+        )
         logger.info(
-            f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold} (cfg_val={cfg_val}, floor={floor})"
+            f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold}"
         )
         self.eic_check_max_num = config.get("eic_check_max_num", -1)
         logger.info(

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1506,6 +1506,9 @@ class EICHiRadixCache(RadixCache):
         return ret_list
 
 
+DEFAULT_EIC_CHECK_MAX_NUM = 2048
+
+
 def _need_calculate_hash(node: TreeNode, page_size: int):
     if node is None or node.key is None or len(node.key) == 0:
         return False
@@ -1521,20 +1524,15 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         server_args: ServerArgs,
     ):
         self.calculate_hash_fn = get_content_hash
-        self.load_remote_threshold = 100
         self.match_req_set = {}  # rid -> None, insertion-ordered for FIFO trim
-        self.eic_check_max_num = -1
+        self.eic_check_max_num = DEFAULT_EIC_CHECK_MAX_NUM
         super().__init__(params, server_args)
 
     def init_hyper_params(self, config):
         super().init_hyper_params(config)
-        self.load_remote_threshold = max(
-            config.get("load_remote_threshold", 1 << 14), self.page_size
+        self.eic_check_max_num = config.get(
+            "eic_check_max_num", DEFAULT_EIC_CHECK_MAX_NUM
         )
-        logger.info(
-            f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold}"
-        )
-        self.eic_check_max_num = config.get("eic_check_max_num", -1)
         logger.info(
             f"EICPagedHiRadixCache eic_check_max_num set to {self.eic_check_max_num}"
         )
@@ -1582,62 +1580,6 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         new_node.parent.children[key.child_key(self.page_size)] = new_node
         return new_node
 
-    def match_prefix_extend(self, key: RadixKey, last_node):
-        cache_prefix_len = 0
-        temp_node = last_node
-        while temp_node:
-            cache_prefix_len += len(temp_node.key)
-            temp_node = temp_node.parent
-
-        # if the cache prefix is too long, or the remaining key is too short, we can skip loading from eic
-        if (len(key) - cache_prefix_len) < self.load_remote_threshold:
-            return last_node
-
-        logger.debug(
-            f"few cache in radix, try load from eic, cache len {cache_prefix_len}, total len {len(key)}"
-        )
-        if _need_calculate_hash(last_node, self.page_size):
-            self._calculate_content_hash(last_node)
-        last_prev_hash = None
-        if last_node.content_hash is not None and len(last_node.content_hash) > 0:
-            last_prev_hash = last_node.content_hash[-1]
-        need_compute_key = key[cache_prefix_len:]
-        eic_hash, eic_key = self.cache_controller.find_longest_prefix_in_eic(
-            need_compute_key, last_prev_hash
-        )
-        if self.tp_size > 1:
-            eic_hash_len_tensor = torch.tensor(
-                [len(eic_hash)], dtype=torch.int64, device="cpu"
-            )
-            torch.distributed.all_reduce(
-                eic_hash_len_tensor,
-                op=torch.distributed.ReduceOp.MIN,
-                group=self.tp_group,
-            )
-            eic_hash_len = eic_hash_len_tensor.item()
-            eic_hash = eic_hash[:eic_hash_len]
-            eic_key = eic_key[: eic_hash_len * self.page_size]
-        if len(eic_key) < self.load_remote_threshold:
-            logger.debug(
-                f"eic key is too short, skip loading from eic, eic cache len {len(eic_key)}, need compute key len {len(need_compute_key)}"
-            )
-            return last_node
-        load_node = TreeNode()
-        load_node.key = eic_key
-        load_node.content_hash = eic_hash
-        load_node.host_value = torch.arange(
-            len(eic_key), dtype=torch.int32, device="cpu"
-        )
-        assert (
-            last_node.children.get(eic_key.child_key(self.page_size)) is None
-        ), f"eic key {eic_key} already exists in radix cache"
-        logger.debug(
-            f"load token from eic: {len(eic_key)}, node {load_node.id}, parent {last_node.id}"
-        )
-        last_node.children[eic_key.child_key(self.page_size)] = load_node
-        load_node.parent = last_node
-        return load_node
-
     def _match_for_remote_fetch(self, node: TreeNode, key: RadixKey):
         key, _ = key.maybe_to_bigram_view(self.is_eagle)
         node.last_access_time = time.monotonic()
@@ -1659,17 +1601,7 @@ class EICPagedHiRadixCache(EICHiRadixCache):
 
                 if len(key):
                     child_key = key.child_key(self.page_size)
-        temp_node = node
-        local_evict_len = 0
-        while temp_node.evicted:
-            while not temp_node.backuped and temp_node.parent is not None:
-                temp_node = temp_node.parent
-                local_evict_len = 0
-            if not temp_node.evicted:
-                break
-            local_evict_len += len(temp_node.host_value)
-            temp_node = temp_node.parent
-        return local_prefix_len, local_evict_len, node
+        return local_prefix_len, node
 
     def _insert_remote_node(self, node: TreeNode, key: RadixKey):
         node.last_access_time = time.monotonic()
@@ -1736,7 +1668,7 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         if len(self.match_req_set) > 1000:
             self.match_req_set = dict(list(self.match_req_set.items())[500:])
 
-        fetches = []  # (slot, last_node, evict_len, compute_key, prev_hash)
+        fetches = []  # (slot, last_node, compute_key, prev_hash)
         eic_keys = 0
         for slot in range(local_n):
             req = waiting_queue[slot]
@@ -1747,15 +1679,15 @@ class EICPagedHiRadixCache(EICHiRadixCache):
             if len(req_tokens) == 0:
                 continue
             req_key = RadixKey(req_tokens, req.extra_key)
-            prefix_len, evict_len, last_node = self._match_for_remote_fetch(
+            prefix_len, last_node = self._match_for_remote_fetch(
                 self.root_node, req_key
             )
-            if len(req_key) - prefix_len + evict_len < self.load_remote_threshold:
+            if len(req_key) - prefix_len < self.page_size:
                 continue
             if _need_calculate_hash(last_node, self.page_size):
                 self._calculate_content_hash(last_node)
             prev_hash = last_node.content_hash[-1] if last_node.content_hash else None
-            fetches.append((slot, last_node, evict_len, req_key[prefix_len:], prev_hash))
+            fetches.append((slot, last_node, req_key[prefix_len:], prev_hash))
             eic_keys += (len(req_key) - prefix_len) // self.page_size
             if 0 < self.eic_check_max_num <= eic_keys:
                 break
@@ -1766,7 +1698,7 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         len_tensor = torch.zeros(num_ready, dtype=torch.int64, device="cpu")
         if fetches:
             lens = self.cache_controller.batch_find_longest_prefix_in_eic(
-                [f[3] for f in fetches], [f[4] for f in fetches]
+                [f[2] for f in fetches], [f[3] for f in fetches]
             )
             if len(lens) == len(fetches):
                 for (slot, *_), n in zip(fetches, lens):
@@ -1775,9 +1707,9 @@ class EICPagedHiRadixCache(EICHiRadixCache):
             # and the reduce below would be a no-op on an all-zero tensor.
             self._reduce_min(len_tensor)
 
-        for slot, last_node, evict_len, compute_key, _ in fetches:
+        for slot, last_node, compute_key, _ in fetches:
             eic_len = int(len_tensor[slot])
-            if eic_len + evict_len >= self.load_remote_threshold:
+            if eic_len > 0:
                 self._insert_remote_node(last_node, compute_key[:eic_len])
                 # Only mark as matched when we actually admitted a remote prefix.
                 # A miss (eic_len == 0) must be retried: the async write may not
@@ -1809,7 +1741,6 @@ class EICPagedHiRadixCache(EICHiRadixCache):
         else:
             value = empty_value
 
-        # last_node = self.match_prefix_extend(key, last_node)
         host_hit_length = 0
         last_host_node = last_node
         while last_node.evicted:

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1703,9 +1703,9 @@ class EICPagedHiRadixCache(EICHiRadixCache):
             if len(lens) == len(fetches):
                 for (slot, *_), n in zip(fetches, lens):
                     len_tensor[slot] = n
-            # TP ranks share tree state, so an empty fetches list is rank-uniform
-            # and the reduce below would be a no-op on an all-zero tensor.
-            self._reduce_min(len_tensor)
+        # Unconditional: a lagging PP stage builds an empty fetches, and skipping
+        # the reduce would orphan PP0's isend onto the next round's num_ready recv.
+        self._reduce_min(len_tensor)
 
         for slot, last_node, compute_key, _ in fetches:
             eic_len = int(len_tensor[slot])

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -387,14 +387,18 @@ class EICKVClient:
         logger.info(f"start write thread thread_id {threading.get_ident()}")
         while True:
             keys, values, copy_event = self.write_queue.get()
-            if copy_event is not None:
-                copy_event.synchronize()
-            self._async_set_impl(keys, values)
-            for value in values:
-                if self.kv_cache_write_mem_pool.check_data_ptr_allocated(
-                    value.data_ptr()
-                ):
-                    self.kv_cache_write_mem_pool.free_to_mempool(value.data_ptr())
+            try:
+                if copy_event is not None:
+                    copy_event.synchronize()
+                self._async_set_impl(keys, values)
+            except Exception:
+                logger.exception("eic async write failed, dropping %d keys", len(keys))
+            finally:
+                for value in values:
+                    if self.kv_cache_write_mem_pool.check_data_ptr_allocated(
+                        value.data_ptr()
+                    ):
+                        self.kv_cache_write_mem_pool.free_to_mempool(value.data_ptr())
 
     def async_batch_set(
         self,

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -982,20 +982,6 @@ class EICBaseTokenToKVPoolHost:
 
         return self.head_dim * self.head_num * self.layer_num * self.dtype.itemsize * 2
 
-    def exist_page(self, content_hashes):
-        """
-        for single prompt detect prefix key
-        """
-        keys = self._encode_key_shared(content_hashes)
-        ret = self.eic_client.exists_batch(keys)
-        res = []
-        for i, exist in enumerate(ret):
-            if exist:
-                res.append(content_hashes[i])
-            else:
-                break
-        return res
-
     def get_page_data_direct(self, keys, device_indices=None):
         bs = G_GDRBounceTensorCount
         masks = []
@@ -1845,15 +1831,6 @@ class EICDeepSeekV4TokenToKVPoolHost(EICBaseTokenToKVPoolHost):
             end = start + self.page_chunk_count
             page_exists.append(all(chunk_exists[start:end]))
         return page_exists
-
-    def exist_page(self, content_hashes):
-        page_exists = self.batch_exist_page(content_hashes)
-        ret = []
-        for i, exist in enumerate(page_exists):
-            if not exist:
-                break
-            ret.append(content_hashes[i])
-        return ret
 
     def device_backup(
         self, device_indices: torch.Tensor, dst_tensors: List[torch.Tensor]

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -978,6 +978,20 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(cache.writing_check.call_count, 2)  # bounded spins
         self.assertEqual(len(cache.ongoing_write_through), 51)  # never drained
 
+    def test_load_remote_threshold(self):
+        def th(cfg):
+            cache = object.__new__(EICPagedHiRadixCache)
+            cache.page_size = 16
+            with mock.patch.object(
+                EICPagedHiRadixCache.__bases__[0], "init_hyper_params", lambda *a: None
+            ):
+                EICPagedHiRadixCache.init_hyper_params(cache, cfg)
+            return cache.load_remote_threshold
+
+        self.assertEqual(th({}), 1 << 14)
+        self.assertEqual(th({"load_remote_threshold": 8192}), 8192)  # was floored
+        self.assertEqual(th({"load_remote_threshold": 4}), 16)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -992,6 +992,34 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(th({"load_remote_threshold": 8192}), 8192)  # was floored
         self.assertEqual(th({"load_remote_threshold": 4}), 16)
 
+    def test_hicache_host_stats_use_the_anchor_pool(self):
+        from sglang.srt.managers.scheduler_components.metrics_reporter import (
+            SchedulerMetricsReporter,
+        )
+
+        anchor = SimpleNamespace(size=32960, available_size=lambda: 30000)
+        entries = {
+            "kv": SimpleNamespace(host_pool=anchor, is_primary_index_anchor=True),
+            "swa": SimpleNamespace(
+                host_pool=SimpleNamespace(size=1, available_size=lambda: 1),
+                is_primary_index_anchor=False,
+            ),
+        }
+        host = SimpleNamespace(
+            size=1054208,
+            available_size=lambda: 1054208,
+            host_pool_group=SimpleNamespace(entry_map=entries),
+        )
+        rep = object.__new__(SchedulerMetricsReporter)
+        rep.stats = SimpleNamespace()
+        rep.scheduler = SimpleNamespace(
+            enable_hierarchical_cache=True,
+            tree_cache=SimpleNamespace(token_to_kv_pool_host=host),
+        )
+        SchedulerMetricsReporter._log_hicache_stats(rep)
+        self.assertEqual(rep.stats.hicache_host_total_tokens, 32960)
+        self.assertEqual(rep.stats.hicache_host_used_tokens, 2960)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -1020,6 +1020,26 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(rep.stats.hicache_host_total_tokens, 32960)
         self.assertEqual(rep.stats.hicache_host_used_tokens, 2960)
 
+    def test_write_thread_frees_slots_when_mset_raises(self):
+        from sglang.srt.mem_cache.eic_memory_pool import EICKVClient
+
+        freed = []
+        c = object.__new__(EICKVClient)
+        c.write_queue = Queue()
+        c.kv_cache_write_mem_pool = SimpleNamespace(
+            check_data_ptr_allocated=lambda p: True,
+            free_to_mempool=freed.append,
+        )
+        c._async_set_impl = mock.Mock(side_effect=RuntimeError("backend down"))
+        values = [torch.zeros(2), torch.zeros(2)]
+        c.write_queue.put((["a", "b"], values, None))
+        c.write_queue.put(None)
+
+        with self.assertRaises(TypeError):
+            EICKVClient._write_thread(c)
+
+        self.assertEqual(freed, [v.data_ptr() for v in values])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -76,7 +76,6 @@ class TestEICHiCacheRegression(unittest.TestCase):
         cache.pp_size = 1
         cache.pp_group = None
         cache.page_size = 1
-        cache.load_remote_threshold = 1
         cache.eic_check_max_num = 0
         cache.root_node = object()
         cache._insert_remote_node = mock.Mock()
@@ -85,7 +84,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
         # Fetch only the middle req; the others' prefix already covers the key.
         def match(root, key):
             match.i += 1
-            return (0, 0, node) if match.i == 2 else (len(key), 0, node)
+            return (0, node) if match.i == 2 else (len(key), node)
 
         match.i = 0
         cache._match_for_remote_fetch = match
@@ -978,19 +977,84 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(cache.writing_check.call_count, 2)  # bounded spins
         self.assertEqual(len(cache.ongoing_write_through), 51)  # never drained
 
-    def test_load_remote_threshold(self):
-        def th(cfg):
+    def test_eic_check_max_num_is_bounded_by_default(self):
+        def probe_budget(cfg):
             cache = object.__new__(EICPagedHiRadixCache)
-            cache.page_size = 16
+            cache.page_size = 256
             with mock.patch.object(
                 EICPagedHiRadixCache.__bases__[0], "init_hyper_params", lambda *a: None
             ):
                 EICPagedHiRadixCache.init_hyper_params(cache, cfg)
-            return cache.load_remote_threshold
+            return cache.eic_check_max_num
 
-        self.assertEqual(th({}), 1 << 14)
-        self.assertEqual(th({"load_remote_threshold": 8192}), 8192)  # was floored
-        self.assertEqual(th({"load_remote_threshold": 4}), 16)
+        self.assertEqual(probe_budget({}), 2048)
+        self.assertEqual(probe_budget({"eic_check_max_num": 512}), 512)
+        self.assertEqual(probe_budget({"eic_check_max_num": -1}), -1)
+
+    def test_match_from_remote_admits_a_short_eic_hit(self):
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.match_req_set = {}
+        cache.tp_size = 1
+        cache.pp_size = 1
+        cache.pp_group = None
+        cache.page_size = 256
+        cache.eic_check_max_num = 2048
+        cache.root_node = object()
+        cache._insert_remote_node = mock.Mock()
+        node = SimpleNamespace(id=1, content_hash=None)
+        cache._match_for_remote_fetch = lambda root, key: (0, node)
+        cache.cache_controller = mock.Mock()
+        cache.cache_controller.batch_find_longest_prefix_in_eic.return_value = [512]
+
+        req = mock.Mock(
+            rid="short-hit",
+            origin_input_ids=list(range(4096)),
+            output_ids=[9],
+            extra_key=None,
+        )
+        with mock.patch(
+            "sglang.srt.mem_cache.eic_hiradix_cache._need_calculate_hash",
+            return_value=False,
+        ):
+            EICPagedHiRadixCache.match_from_remote(cache, [req])
+
+        cache._insert_remote_node.assert_called_once()
+        self.assertEqual(len(cache._insert_remote_node.call_args[0][1]), 512)
+        self.assertIn("short-hit", cache.match_req_set)
+
+    def test_match_from_remote_probe_budget_caps_a_long_queue(self):
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.match_req_set = {}
+        cache.tp_size = 1
+        cache.pp_size = 1
+        cache.pp_group = None
+        cache.page_size = 256
+        cache.eic_check_max_num = 5  # each req below is 4 pages
+        cache.root_node = object()
+        cache._insert_remote_node = mock.Mock()
+        node = SimpleNamespace(id=1, content_hash=None)
+        cache._match_for_remote_fetch = lambda root, key: (0, node)
+        cache.cache_controller = mock.Mock()
+        cache.cache_controller.batch_find_longest_prefix_in_eic.return_value = [0, 0]
+
+        reqs = [
+            mock.Mock(
+                rid=r,
+                origin_input_ids=list(range(1024)),
+                output_ids=[9],
+                extra_key=None,
+            )
+            for r in ("a", "b", "c")
+        ]
+        with mock.patch(
+            "sglang.srt.mem_cache.eic_hiradix_cache._need_calculate_hash",
+            return_value=False,
+        ):
+            EICPagedHiRadixCache.match_from_remote(cache, reqs)
+
+        probed = cache.cache_controller.batch_find_longest_prefix_in_eic.call_args[0][0]
+        self.assertEqual(len(probed), 2)
+        self.assertEqual(len(cache.match_req_set), 0)
 
     def test_hicache_host_stats_use_the_anchor_pool(self):
         from sglang.srt.managers.scheduler_components.metrics_reporter import (

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -977,6 +977,103 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(cache.writing_check.call_count, 2)  # bounded spins
         self.assertEqual(len(cache.ongoing_write_through), 51)  # never drained
 
+    def _remote_cache(self, page_size=256, budget=2048, memoized=()):
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.match_req_set = dict.fromkeys(memoized)
+        cache.tp_size = 1
+        cache.pp_size = 1
+        cache.pp_group = None
+        cache.page_size = page_size
+        cache.eic_check_max_num = budget
+        cache.root_node = object()
+        cache._insert_remote_node = mock.Mock()
+        cache.cache_controller = mock.Mock()
+        return cache
+
+    def test_match_from_remote_probes_only_a_full_page_of_remainder(self):
+        cache = self._remote_cache()
+        node = SimpleNamespace(id=1, content_hash=None)
+        cache._match_for_remote_fetch = lambda root, key: (0, node)
+        cache.cache_controller.batch_find_longest_prefix_in_eic.return_value = [256, 256]
+        reqs = [
+            mock.Mock(rid=r, origin_input_ids=list(range(n)), output_ids=[9], extra_key=None)
+            for r, n in (("under", 255), ("exact", 256), ("over", 257))
+        ]
+        with mock.patch(
+            "sglang.srt.mem_cache.eic_hiradix_cache._need_calculate_hash",
+            return_value=False,
+        ):
+            EICPagedHiRadixCache.match_from_remote(cache, reqs)
+
+        probed = cache.cache_controller.batch_find_longest_prefix_in_eic.call_args[0][0]
+        self.assertEqual([len(k) for k in probed], [256, 257])
+
+    def test_match_from_remote_retries_a_miss_then_memoizes_the_hit(self):
+        cache = self._remote_cache()
+        node = SimpleNamespace(id=1, content_hash=None)
+        cache._match_for_remote_fetch = lambda root, key: (512, node)
+        req = mock.Mock(
+            rid="R", origin_input_ids=list(range(4096)), output_ids=[9], extra_key=None
+        )
+        patch_hash = mock.patch(
+            "sglang.srt.mem_cache.eic_hiradix_cache._need_calculate_hash",
+            return_value=False,
+        )
+
+        cache.cache_controller.batch_find_longest_prefix_in_eic.return_value = [0]
+        with patch_hash:
+            EICPagedHiRadixCache.match_from_remote(cache, [req])
+        cache._insert_remote_node.assert_not_called()
+        self.assertEqual(cache.match_req_set, {})
+
+        cache.cache_controller.batch_find_longest_prefix_in_eic.return_value = [768]
+        with patch_hash:
+            EICPagedHiRadixCache.match_from_remote(cache, [req])
+        key = cache._insert_remote_node.call_args[0][1]
+        self.assertEqual(len(key), 768)
+        self.assertEqual(key.token_ids[0], 512)
+        self.assertIn("R", cache.match_req_set)
+
+        cache._match_for_remote_fetch = mock.Mock(
+            side_effect=AssertionError("memoized rid must be skipped")
+        )
+        with patch_hash:
+            EICPagedHiRadixCache.match_from_remote(cache, [req])
+        self.assertEqual(
+            cache.cache_controller.batch_find_longest_prefix_in_eic.call_count, 2
+        )
+
+    def test_match_from_remote_reduces_even_when_fetches_is_empty(self):
+        # A lagging PP stage has an empty fetches; skipping its reduce would
+        # orphan PP0's isend onto the next round's num_ready recv.
+        def reduce_shapes(memoized):
+            cache = self._remote_cache(memoized=memoized)
+            cache.pp_size = 2
+            cache.pp_group = object()
+            node = SimpleNamespace(id=1, content_hash=None)
+            cache._match_for_remote_fetch = lambda root, key: (0, node)
+            cache.cache_controller.batch_find_longest_prefix_in_eic.return_value = [256, 256]
+            shapes = []
+
+            def fake_reduce(t):
+                shapes.append(tuple(t.shape))
+                if t.dim() == 0:
+                    t.fill_(2)
+
+            cache._reduce_min = fake_reduce
+            reqs = [
+                mock.Mock(rid=r, origin_input_ids=list(range(4096)), output_ids=[9], extra_key=None)
+                for r in ("x", "y")
+            ]
+            with mock.patch(
+                "sglang.srt.mem_cache.eic_hiradix_cache._need_calculate_hash",
+                return_value=False,
+            ):
+                EICPagedHiRadixCache.match_from_remote(cache, reqs)
+            return shapes
+
+        self.assertEqual(reduce_shapes(()), reduce_shapes(("x", "y")))
+
     def test_eic_check_max_num_is_bounded_by_default(self):
         def probe_budget(cfg):
             cache = object.__new__(EICPagedHiRadixCache)


### PR DESCRIPTION
Three EIC HiCache fixes, validated on a live DSV4 PD deployment (TP8/DP8, `page_size=256`).

## 1. `load_remote_threshold` configurable below 16K

#710 made 16K a hard floor (`max(cfg_val, 1<<14)`), so `{"load_remote_threshold": 8192}`
silently resolved to 16384. Keep 16K as the default, clamp to `page_size` instead — content
hashes are chained per page, so a sub-page probe cannot match. The deadlock the floor hedged
against is handled by `_swa_headroom_ok` / `_full_headroom_ok`, which gate on live pool
headroom, not request length.

The gate reads what is *left to compute* on one request, not its total length. Measured
(12 req/round, round 2 replays round 1 with a 75% shared prefix):

| target | r2 left | r1 p50 | r2 p50 | batches w/ eic>0 |
|---|---|---|---|---|
| 8K | 2049 | 18.27s | 1.02s | 0 / 19 |
| 32K | 8193 | 3.01s | 2.70s | 1 / 45 |
| 64K | 16385 | 5.20s | 0.90s | **12 / 12** |
| 96K | 24577 | 7.99s | 1.11s | 8 / 11 |
| 160K | 40961 | 12.60s | 1.88s | 11 / 12 |

The cliff sits exactly at the threshold; crossing it drops prefill 5.8-7.2x.

## 2. Host-tier stats from the anchor pool

`EICDeepSeekV4TokenToKVPoolHost` never writes the real capacity back to `self.size`, so
`_log_hicache_stats` reported `hicache_host_total_tokens=1054208` when the pools hold 32960,
and `used` pinned at 0 (`available_size()` counts base `free_slots`, which the V4 path never
allocates from). Read the anchor entry's host pool instead. Not fixing `self.size` itself:
base `clear()`/`free()` rebuild `free_slots` from it, and V4 `host_value` carries device
indices up to 527103.

## 3. EIC write-path exception safety

Three spots release a flag or slot on the happy path only. None is currently firing (2h load:
0 thread exceptions, 0 drops, 0 restarts) — hardening, not a live bug, but each fails
*silently*.

- **`_write_thread`** (`eic_memory_pool.py:386`) had no guard. Only consumer
  (`_write_thread_num=1`), and its body is the only place write slots are freed. A raise from
  `_async_set_impl` killed it for good → `left_count()` stuck at 0 → every write took the drop
  branch. **EIC stops being written while the service looks healthy.**
- **`safe_empty_cache` / `synced_forward`** (`eic_cache_controller.py:190,209`) set
  `write_wait_event` without `finally`; `write_operation_shared:340` spins on it → write path
  deadlocks.
- **`load_thread_func_direct`** (`:456`) leaked `load_wait_event` — gates the deepep hook.

Fault injection, same test both versions:

| check | unpatched | patched |
|---|---|---|
| thread survives first exception | **FAIL** `calls=[2]` | PASS `calls=[2,1]` |
| write slots freed | **FAIL** `freed=0` | PASS `freed=3` |
| thread alive | **FAIL** | PASS |
| `write_wait_event` cleared (empty_cache / forward) | **FAIL** | PASS |
| `load_wait_event` cleared | **FAIL** | PASS |

`calls=[2]` is decisive: unpatched, the thread died on the first raise and never took the
second queued batch; `freed=0` means those slots leaked permanently.

## Validation

`test_eic_hicache_regression.py`: **39 passed** on the deployed image.

45min warmup + 30min measure, threshold 16384:

| | write_through | write_back |
|---|---|---|
| chat requests | 59271 / **0 failed** | 57739 / **0 failed** |
| chat throughput | 32.91 req/s | 32.06 req/s |
| chat TTFT p50 / p99 | **911** / 1625 ms | 938 / 1712 ms |
| client hit | 0.9948 | 0.9948 |
| mset fail / drops / restarts | 0 / 0 / 0 | 0 / 0 / 0 |

All 7563 write_through batches at total hit rate 0.99; 48% are `0.99/0.00/0.99` — device tier
contributing nothing, whole prefix from EIC.

Agent (4 sessions, growing history) is where the policies diverge:

| history | wt hit | wb hit | wt TTFT p50 | wb TTFT p50 |
|---|---|---|---|---|
| 32768 | 0.75 | 0.41 | 2084 ms | 4810 ms |
| 65536 | 0.88 | 0.66 | 2867 ms | 3190 ms |
| 131072 | **0.97** | **0.79** | **2144 ms** | **8880 ms** |

Both runs match for the first two rounds, so this is not a cold-cache artifact. write_back
only writes on eviction; an agent re-reads the prefix it just appended to, before the write
lands. Agent-shaped workloads want write_through.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->