### PR TITLE
[HiCache][DSV4] Keep the EIC write path alive across exceptions

### DIFF
--- a/python/sglang/srt/managers/eic_cache_controller.py
+++ b/python/sglang/srt/managers/eic_cache_controller.py
@@ -189,12 +189,14 @@ class EICCacheController(HiCacheController):
 
         def safe_empty_cache():
             self.write_wait_event.set()
-            write_stream = self.write_stream
-            write_event = torch.cuda.Event()
-            write_event.record(write_stream)
-            write_event.synchronize()
-            original_empty_cache()
-            self.write_wait_event.clear()
+            try:
+                write_stream = self.write_stream
+                write_event = torch.cuda.Event()
+                write_event.record(write_stream)
+                write_event.synchronize()
+                original_empty_cache()
+            finally:
+                self.write_wait_event.clear()
 
         torch.cuda.empty_cache = safe_empty_cache
 
@@ -208,10 +210,11 @@ class EICCacheController(HiCacheController):
 
         def synced_forward(*args, **kwargs):
             self.write_wait_event.set()
-            self.write_stream.synchronize()
-            result = original_forward(*args, **kwargs)
-            self.write_wait_event.clear()
-            return result
+            try:
+                self.write_stream.synchronize()
+                return original_forward(*args, **kwargs)
+            finally:
+                self.write_wait_event.clear()
 
         ModelRunner.forward = synced_forward
         logger.info("Hooked model forward with synchronized write stream.")
@@ -456,8 +459,10 @@ class EICCacheController(HiCacheController):
                 try:
                     operation = self.load_queue.get(block=True, timeout=1)
                     self.load_wait_event.set()
-                    self.load_from_eic(operation)
-                    self.load_wait_event.clear()
+                    try:
+                        self.load_from_eic(operation)
+                    finally:
+                        self.load_wait_event.clear()
                 except Empty:
                     continue
                 except Exception as e:

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -900,6 +900,13 @@ class SchedulerMetricsReporter:
             self.scheduler.tree_cache, "token_to_kv_pool_host", None
         ) or getattr(self.scheduler.tree_cache, "full_kv_pool_host", None)
         assert host_pool is not None, "Host pool not found"
+        group = getattr(host_pool, "host_pool_group", None)
+        if group is not None:
+            host_pool = next(
+                e.host_pool
+                for e in group.entry_map.values()
+                if e.is_primary_index_anchor
+            )
         self.stats.hicache_host_used_tokens = (
             host_pool.size - host_pool.available_size()
         )

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1528,11 +1528,11 @@ class EICPagedHiRadixCache(EICHiRadixCache):
 
     def init_hyper_params(self, config):
         super().init_hyper_params(config)
-        floor = 1 << 14  # 16K tokens
-        cfg_val = config.get("load_remote_threshold", floor)
-        self.load_remote_threshold = max(cfg_val, floor)
+        self.load_remote_threshold = max(
+            config.get("load_remote_threshold", 1 << 14), self.page_size
+        )
         logger.info(
-            f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold} (cfg_val={cfg_val}, floor={floor})"
+            f"EICPagedHiRadixCache load_remote_threshold set to {self.load_remote_threshold}"
         )
         self.eic_check_max_num = config.get("eic_check_max_num", -1)
         logger.info(

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -387,14 +387,18 @@ class EICKVClient:
         logger.info(f"start write thread thread_id {threading.get_ident()}")
         while True:
             keys, values, copy_event = self.write_queue.get()
-            if copy_event is not None:
-                copy_event.synchronize()
-            self._async_set_impl(keys, values)
-            for value in values:
-                if self.kv_cache_write_mem_pool.check_data_ptr_allocated(
-                    value.data_ptr()
-                ):
-                    self.kv_cache_write_mem_pool.free_to_mempool(value.data_ptr())
+            try:
+                if copy_event is not None:
+                    copy_event.synchronize()
+                self._async_set_impl(keys, values)
+            except Exception:
+                logger.exception("eic async write failed, dropping %d keys", len(keys))
+            finally:
+                for value in values:
+                    if self.kv_cache_write_mem_pool.check_data_ptr_allocated(
+                        value.data_ptr()
+                    ):
+                        self.kv_cache_write_mem_pool.free_to_mempool(value.data_ptr())
 
     def async_batch_set(
         self,

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -978,6 +978,20 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(cache.writing_check.call_count, 2)  # bounded spins
         self.assertEqual(len(cache.ongoing_write_through), 51)  # never drained
 
+    def test_load_remote_threshold(self):
+        def th(cfg):
+            cache = object.__new__(EICPagedHiRadixCache)
+            cache.page_size = 16
+            with mock.patch.object(
+                EICPagedHiRadixCache.__bases__[0], "init_hyper_params", lambda *a: None
+            ):
+                EICPagedHiRadixCache.init_hyper_params(cache, cfg)
+            return cache.load_remote_threshold
+
+        self.assertEqual(th({}), 1 << 14)
+        self.assertEqual(th({"load_remote_threshold": 8192}), 8192)  # was floored
+        self.assertEqual(th({"load_remote_threshold": 4}), 16)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -992,6 +992,34 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(th({"load_remote_threshold": 8192}), 8192)  # was floored
         self.assertEqual(th({"load_remote_threshold": 4}), 16)
 
+    def test_hicache_host_stats_use_the_anchor_pool(self):
+        from sglang.srt.managers.scheduler_components.metrics_reporter import (
+            SchedulerMetricsReporter,
+        )
+
+        anchor = SimpleNamespace(size=32960, available_size=lambda: 30000)
+        entries = {
+            "kv": SimpleNamespace(host_pool=anchor, is_primary_index_anchor=True),
+            "swa": SimpleNamespace(
+                host_pool=SimpleNamespace(size=1, available_size=lambda: 1),
+                is_primary_index_anchor=False,
+            ),
+        }
+        host = SimpleNamespace(
+            size=1054208,
+            available_size=lambda: 1054208,
+            host_pool_group=SimpleNamespace(entry_map=entries),
+        )
+        rep = object.__new__(SchedulerMetricsReporter)
+        rep.stats = SimpleNamespace()
+        rep.scheduler = SimpleNamespace(
+            enable_hierarchical_cache=True,
+            tree_cache=SimpleNamespace(token_to_kv_pool_host=host),
+        )
+        SchedulerMetricsReporter._log_hicache_stats(rep)
+        self.assertEqual(rep.stats.hicache_host_total_tokens, 32960)
+        self.assertEqual(rep.stats.hicache_host_used_tokens, 2960)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -1020,6 +1020,26 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(rep.stats.hicache_host_total_tokens, 32960)
         self.assertEqual(rep.stats.hicache_host_used_tokens, 2960)
 
+    def test_write_thread_frees_slots_when_mset_raises(self):
+        from sglang.srt.mem_cache.eic_memory_pool import EICKVClient
+
+        freed = []
+        c = object.__new__(EICKVClient)
+        c.write_queue = Queue()
+        c.kv_cache_write_mem_pool = SimpleNamespace(
+            check_data_ptr_allocated=lambda p: True,
+            free_to_mempool=freed.append,
+        )
+        c._async_set_impl = mock.Mock(side_effect=RuntimeError("backend down"))
+        values = [torch.zeros(2), torch.zeros(2)]
+        c.write_queue.put((["a", "b"], values, None))
+        c.write_queue.put(None)
+
+        with self.assertRaises(TypeError):
+            EICKVClient._write_thread(c)
+
+        self.assertEqual(freed, [v.data_ptr() for v in values])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Three spots on the EIC path acquire something — a flag, a pool slot — and release it on
the happy path only. **None is currently firing**: 2h of sustained load (59271 chat requests
+ 2 agent phases) logged 0 thread exceptions, 0 write drops, 0 container restarts. So this
is hardening, not a live bug. It is worth doing anyway because each one fails *silently*
rather than crashing, which is the expensive kind to diagnose.

## 1. `_write_thread` had no exception guard

`eic_memory_pool.py:386`. This is the only consumer — `_write_thread_num` is hardcoded `1`
at `:360` — and its loop body is the **only** place write-buffer slots are returned to the
pool (`free_to_mempool`, `:397`).

Any raise from `_async_set_impl` killed the thread permanently: an `mset` throw from the C++
binding, or a CUDA error in `copy_event.synchronize()`. After that `left_count()` is stuck at
0, so every subsequent `async_batch_set` takes the drop branch added in #744:

```
eic async write pool exhausted, dropping N keys (total dropped batches: M)
```

…logged once, then every 128th drop. **EIC stops being written while the service stays
healthy** — no crash, no error rate, just a cache hit rate that decays toward zero. The
controller's own write and load threads already `catch Exception` and keep looping
(`eic_cache_controller.py:438, :463`); this thread was the one that did not.

Now the body is `try/except` and the slot free moved to `finally`, so a failed batch is
dropped — a benign cache miss, recomputed later — and the thread survives.

## 2. `safe_empty_cache` / `synced_forward` could leave the write gate closed

`eic_cache_controller.py:190` and `:209`. Both `set()` `write_wait_event`, then call the
wrapped function with no `finally`. On a raise the flag is never cleared, and
`write_operation_shared:340` spins on exactly that flag:

```python
while self.write_wait_event.is_set():
    time.sleep(0.01)
```

→ the entire EIC write path deadlocks. `safe_empty_cache` is the reachable one;
`synced_forward` matters less in practice, since a forward-pass exception has no recovery
path and takes the process down anyway. Both now clear in `finally`.

## 3. `load_thread_func_direct` leaked `load_wait_event`

`:456`. `set()` at `:458`, `clear()` at `:460`, and the surrounding `except Exception`
swallows anything `load_from_eic` raises — so the flag stays set forever. It gates the deepep
dispatch hook (`syned_dispatch`, `:226`), so with that hook installed MoE dispatch would spin.
Harmless in this deployment (0 occurrences of `Hooked deepep dispatch` in the logs — the hook
is not installed), latent everywhere it is. Cleared in `finally`.

Not changed: `syned_dispatch` itself only *waits* on the flag, it never sets one, so it needs
no guard.

## Test

One regression test, for (1) — the silent-death path: assert the write slots are still freed
when `_async_set_impl` raises. (2) and (3) are `finally` on a flag the existing tests already
exercise.

`test_eic_hicache_regression.py`: **39 passed** on the deployed DSV4 image.

## Measured context

The run that motivated this, at `load_remote_threshold=16384` (write_through, TP8/DP8,
`page_size=256`):

| | chat steady | agent (33 rounds) |
|---|---|---|
| requests | 59271 ok / **0 failed** | 20 ok / **0 failed** |
| throughput | 32.9 req/s, 813K tok/s in | — |
| TTFT p50 | **911 ms** (p99 1625) | 2144 ms @ 134656 tok input |
| hit rate | client **0.9948** | **0.97** at 128K history |

Per-batch logs: **all 7563 batches at total hit rate 0.99**, of which 3660 (48%) are
`0.99/0.00/0.99` — device tier contributing nothing, the whole prefix served by EIC. EIC is
healthy under load; these three are about what happens the first time it is not.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->