### PR TITLE
[HiCache] Preserve SWA host locks across node splits

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -450,12 +450,24 @@ class SWAComponent(TreeComponent):
             child.component_data[self.component_type].host_value = child_swa_host_value[
                 split_len:
             ].clone()
+            parent_swa_data = new_parent.component_data[self.component_type]
+            child_swa_data = child.component_data[self.component_type]
+            parent_swa_data.host_lock_ref = child_swa_data.host_lock_ref
+            host_uuid = child_swa_data.metadata.pop("host_uuid", None)
+            if host_uuid is not None:
+                parent_swa_data.metadata["host_uuid"] = host_uuid
+
             host_lru = self.tree_core.host_lru_lists[self.component_type]
-            if new_parent.component_data[self.component_type].value is None:
+            if (
+                new_parent.component_data[self.component_type].value is None
+                and parent_swa_data.host_lock_ref == 0
+            ):
                 host_lru.insert_mru(new_parent)
-            if child.component_data[
-                self.component_type
-            ].value is None and not host_lru.in_list(child):
+            if (
+                child.component_data[self.component_type].value is None
+                and child_swa_data.host_lock_ref == 0
+                and not host_lru.in_list(child)
+            ):
                 host_lru.insert_mru(child)
 
         # parent inherits the swa_uuid from child for swa lock ref


### PR DESCRIPTION
This pr 38138 preserves SWA host locks across radix-tree node splits in ep_main.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34119711156](https://github.com/bytedance-iaas/sglang/actions/runs/34119711156)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34119710724](https://github.com/bytedance-iaas/sglang/actions/runs/34119710724)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->