### PR TITLE
[HiCache][DSV4] Defer reqs whose prefix runs through an in-flight EIC load

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2617,6 +2617,8 @@ class Scheduler(
             )
             if not deferring_load_back:
                 req.init_next_round_input(tc)
+                if self.enable_eic_cache and tc.prefix_loading(req.last_node):
+                    continue
             # PP>1 gates EVERY candidate (not only needs_host_load_back): host
             # metadata is per-stage (EIC write acks fail per namespace), so the
             # needs flag itself can diverge across stages; gating all candidates

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -489,6 +489,17 @@ class EICHiRadixCache(RadixCache):
             self.dec_lock_ref(req.last_node)
 
     def cache_unfinished_req(self, req: Req, chunked=False):
+        if self.ongoing_load_back:
+            key = RadixKey(req.fill_ids, req.extra_key, is_bigram=self.is_eagle)
+            match = self.match_prefix(MatchPrefixParams(key=key))
+            if self.prefix_loading(match.last_device_node):
+                # Inserting now would swap this req's own KV for slots still
+                # landing from EIC; keep it private, as ChunkCache does, until
+                # the load settles.
+                req.prefix_indices = self.req_to_token_pool.req_to_token[
+                    req.req_pool_idx, : len(req.fill_ids)
+                ].to(dtype=torch.int64, copy=True)
+                return
         super().cache_unfinished_req(req, chunked=chunked)
         if req.last_node is not None:
             self._backup_unbacked_path(req.last_node)

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -911,6 +911,26 @@ class EICHiRadixCache(RadixCache):
             else:
                 self._queue_report(st, self._KIND_FINAL, st["d"] + complete_token)
 
+    def prefix_loading(self, node: TreeNode) -> bool:
+        # load_back publishes node.value before its DMA acks. A req adopting those
+        # slots reads KV that is still landing, and if the load fails the tail is
+        # freed under it; its insert then re-links the freed slots into the tree
+        # (a page both free and cached). Such a req must wait for the load to settle.
+        if not self.ongoing_load_back or self.pp_size > 1:
+            # ponytail: PP stages hold per-stage chains, so deferring here would fork
+            # admission across stages; PP>1 still adopts in-flight slots.
+            return False
+        loading = set()
+        for start, end, _ in self.ongoing_load_back.values():
+            while end is not start:
+                loading.add(end.id)
+                end = end.parent
+        while node is not None and node is not self.root_node:
+            if node.id in loading:
+                return True
+            node = node.parent
+        return False
+
     def _free_failed_loadback(self, node_id, complete_token):
         # Local cleanup: release the load lock and free the failed-load tail so the
         # tree never holds garbage KV. Per-stage; the tree may diverge across PP.

--- a/python/sglang/srt/mem_cache/eic_hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/eic_hiradix_cache.py
@@ -1396,6 +1396,11 @@ class EICHiRadixCache(RadixCache):
 
         while len(key) > 0 and child_key in node.children.keys():
             child = node.children[child_key]
+            if node.evicted and not child.evicted:
+                # A resident node under an evicted one (left by a failed
+                # load-back) is unusable until the gap reloads: appending it
+                # would splice KV across the gap.
+                break
             child.last_access_time = time.monotonic()
             prefix_len = child.key.match(key, page_size=self.page_size)
             if prefix_len < len(child.key):

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -5,6 +5,7 @@ import queue
 import threading
 import time
 from enum import IntEnum
+from types import SimpleNamespace
 from typing import List, Optional, Tuple
 
 import torch
@@ -513,6 +514,37 @@ class EICKVClient:
             indices = range(count)
         return tensors, host_memory_pool, indices, registered
 
+    def _refetch_failed(self, keys, objs, registered, get_option, outcome):
+        # Partial mget failures are per-key RPC timeouts on a loaded backend, and
+        # the load keeps only the prefix before the first failed key. Re-getting
+        # just the failed keys once, into their own buffers, saves the rest from
+        # recompute. A missing status counts as failed.
+        codes = list(outcome.status_codes)[: len(keys)]
+        codes += [None] * (len(keys) - len(codes))
+        failed = [i for i, c in enumerate(codes) if c != eic.StatusCode.SUCCESS]
+        retry_keys, retry_vals = eic.StringVector(), eic.IOBuffers()
+        for i in failed:
+            retry_keys.append(keys[i])
+            retry_vals.append(
+                objs[i].data_ptr(), objs[i].element_size() * objs[i].numel(), registered
+            )
+        status, _, retry_outcome = self.connection.mget(
+            retry_keys, get_option, retry_vals
+        )
+        retry_codes = list(retry_outcome.status_codes)
+        for j, i in enumerate(failed):
+            if status == eic.StatusCode.SUCCESS or (
+                status == eic.StatusCode.PARTIAL_FAILED
+                and j < len(retry_codes)
+                and retry_codes[j] == eic.StatusCode.SUCCESS
+            ):
+                codes[i] = eic.StatusCode.SUCCESS
+        recovered = sum(codes[i] == eic.StatusCode.SUCCESS for i in failed)
+        logger.info(f"eic mget refetched {len(failed)} failed keys, {recovered} recovered")
+        ok = all(c == eic.StatusCode.SUCCESS for c in codes)
+        status = eic.StatusCode.SUCCESS if ok else eic.StatusCode.PARTIAL_FAILED
+        return status, SimpleNamespace(status_codes=codes)
+
     def batch_get(
         self, keys: List[str], device_indices: torch.Tensor = None, copy_func=None
     ) -> Tuple[Optional[List[torch.Tensor]], List[bool]]:
@@ -542,6 +574,10 @@ class EICKVClient:
         status_code, data_vals, get_outcome = self.connection.mget(
             data_keys, get_option, data_vals
         )
+        if status_code == eic.StatusCode.PARTIAL_FAILED:
+            status_code, get_outcome = self._refetch_failed(
+                keys, objs, registered, get_option, get_outcome
+            )
 
         result = []
         device_copy = False

--- a/python/sglang/srt/mem_cache/eic_memory_pool.py
+++ b/python/sglang/srt/mem_cache/eic_memory_pool.py
@@ -518,10 +518,15 @@ class EICKVClient:
         # Partial mget failures are per-key RPC timeouts on a loaded backend, and
         # the load keeps only the prefix before the first failed key. Re-getting
         # just the failed keys once, into their own buffers, saves the rest from
-        # recompute. A missing status counts as failed.
+        # recompute. A missing status counts as failed. ponytail: one retry, only
+        # when at most half failed; per-key backoff if the backend flaps.
         codes = list(outcome.status_codes)[: len(keys)]
         codes += [None] * (len(keys) - len(codes))
         failed = [i for i, c in enumerate(codes) if c != eic.StatusCode.SUCCESS]
+        if 2 * len(failed) > len(keys):
+            # Most keys failing means the backend itself is down; a retry would
+            # only stall the serial load thread for another timeout round.
+            return eic.StatusCode.PARTIAL_FAILED, SimpleNamespace(status_codes=codes)
         retry_keys, retry_vals = eic.StringVector(), eic.IOBuffers()
         for i in failed:
             retry_keys.append(keys[i])

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -9,10 +9,13 @@ import torch
 from sglang.srt.managers.eic_cache_controller import (
     EICCacheController,
     EICCacheOperation,
+    get_content_hash,
 )
 from sglang.srt.mem_cache.eic_chunk_cache import EICChunkCache
 from sglang.srt.mem_cache.eic_pp_reconcile import EICPPReconciler
 from sglang.srt.mem_cache.eic_hiradix_cache import EICPagedHiRadixCache
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
+from sglang.srt.mem_cache.radix_cache import RadixKey, TreeNode
 from sglang.srt.mem_cache.unified_cache_components import ComponentType
 from sglang.srt.mem_cache.unified_radix_cache import UnifiedTreeNode
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -393,6 +396,106 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertIs(req.last_node, node_c)  # resident node at depth 14, not node_d
         req.set_extend_input_len.assert_called_once_with(20 - 14)
         self.assertEqual(req.eic_loaded_len, 10)
+
+    def _make_pool_cache(self, total, page):
+        free_ids = set(range(1, total + 1))
+
+        def alloc(n):
+            ids = sorted(free_ids)[:n]
+            free_ids.difference_update(ids)
+            return torch.tensor(ids, dtype=torch.int64)
+
+        def free(t):
+            ids = set(t.tolist())
+            self.assertFalse(ids & free_ids, "double free")
+            free_ids.update(ids)
+
+        def evict_device(dev, host):
+            free(dev)
+            return len(dev)
+
+        c = object.__new__(EICPagedHiRadixCache)
+        c.disable, c.is_eagle, c.page_size, c.device = False, False, page, "cpu"
+        c.sliding_window_size, c.pp_size = None, 1
+        c.evictable_size_ = c.protected_size_ = 0
+        c.evictable_leaves = set()
+        c.write_through_threshold = 10**9
+        c.load_back_threshold, c.load_back_check = 0, False
+        c.ongoing_load_back = {}
+        c.calculate_hash_fn = get_content_hash
+        c.cache_controller = SimpleNamespace(
+            write_policy="write_through",
+            mem_pool_device_allocator=SimpleNamespace(free=free),
+            evict_device=evict_device,
+            load_page=lambda host_indices, node_id, content_hash: alloc(
+                len(host_indices)
+            ),
+        )
+        root = TreeNode()
+        root.key, root.value, root.lock_ref = RadixKey([], None), [], 1
+        c.root_node = root
+        return c, alloc, free, free_ids
+
+    def test_failed_load_under_same_prefix_req_keeps_pool_invariant(self):
+        # Chat cc32 crash: req A's load of a shared-prefix tail T failed while req
+        # B, admitted mid-load, had matched T's in-flight slots as a GPU hit. The
+        # failed-tail free returned them to the allocator and B's insert re-linked
+        # them into T: available + evictable exceeded total by exactly T.
+        total = 64
+        c, alloc, free, free_ids = self._make_pool_cache(total, page=4)
+        key = RadixKey(list(range(32)), None)
+        c.insert(InsertParams(key=key, value=alloc(32)))
+        tail = c.root_node.children[key.child_key(4)]
+        c._split_node(tail.key, tail, 16)
+        tail.host_value = torch.arange(16)
+        c._evict_backuped(tail)  # tail [16, 32) lives only in EIC
+
+        a = c.match_prefix(MatchPrefixParams(key=key))
+        c.load_back(a.best_match_node)  # A kicks the load; DMA in flight
+        b = c.match_prefix(MatchPrefixParams(key=key))
+        self.assertTrue(c.prefix_loading(b.last_device_node))  # B defers
+        c._free_failed_loadback(tail.id, 0)  # the whole tail's mget failed
+
+        b = c.match_prefix(MatchPrefixParams(key=key))  # B retries after settle
+        self.assertFalse(c.prefix_loading(b.last_device_node))
+        b_kv = torch.cat([b.device_indices, alloc(32 - len(b.device_indices))])
+        c.inc_lock_ref(b.last_device_node)
+        prefix_len = c.insert(InsertParams(key=key, value=b_kv)).prefix_len
+        free(b_kv[len(b.device_indices) : prefix_len])
+        c.dec_lock_ref(b.last_device_node)
+
+        cached = set()
+        stack = list(c.root_node.children.values())
+        while stack:
+            n = stack.pop()
+            if n.value is not None:
+                cached.update(n.value.tolist())
+            stack.extend(n.children.values())
+        self.assertFalse(cached & free_ids)
+        self.assertEqual(
+            len(free_ids) + c.evictable_size_ + c.protected_size_, total
+        )
+
+    def test_prefix_loading_covers_split_chain_until_settled(self):
+        cache = object.__new__(EICPagedHiRadixCache)
+        cache.pp_size = 1
+        root = TreeNode()
+        cache.root_node = root
+        a = TreeNode()  # resident ancestor the load hangs from
+        a.parent = root
+        t = TreeNode()  # load chain bottom
+        t.parent = a
+        child = TreeNode()
+        child.parent = t
+        cache.ongoing_load_back = {t.id: (a, t, 256)}
+        self.assertFalse(cache.prefix_loading(a))
+        self.assertTrue(cache.prefix_loading(t))
+        self.assertTrue(cache.prefix_loading(child))
+        upper = TreeNode()  # a match split T: upper half sits between a and t
+        upper.parent, t.parent = a, upper
+        self.assertTrue(cache.prefix_loading(upper))
+        cache.ongoing_load_back.pop(t.id)  # _free_failed_loadback settled it
+        self.assertFalse(cache.prefix_loading(child))
 
     # ---- two-stage lockstep protocol tests --------------------------------
 

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -431,6 +431,7 @@ class TestEICHiCacheRegression(unittest.TestCase):
                 len(host_indices)
             ),
         )
+        c.token_to_kv_pool_allocator = SimpleNamespace(free=free)
         root = TreeNode()
         root.key, root.value, root.lock_ref = RadixKey([], None), [], 1
         c.root_node = root
@@ -463,6 +464,55 @@ class TestEICHiCacheRegression(unittest.TestCase):
         prefix_len = c.insert(InsertParams(key=key, value=b_kv)).prefix_len
         free(b_kv[len(b.device_indices) : prefix_len])
         c.dec_lock_ref(b.last_device_node)
+
+        cached = set()
+        stack = list(c.root_node.children.values())
+        while stack:
+            n = stack.pop()
+            if n.value is not None:
+                cached.update(n.value.tolist())
+            stack.extend(n.children.values())
+        self.assertFalse(cached & free_ids)
+        self.assertEqual(
+            len(free_ids) + c.evictable_size_ + c.protected_size_, total
+        )
+
+    def test_chunk_insert_through_inflight_load_keeps_pool_invariant(self):
+        # A running chunked req recomputing the same prefix reaches the in-flight
+        # tail T at its next chunk boundary. Inserting then would free its own KV
+        # and adopt T's still-landing slots; after T's load fails and the req
+        # finishes, those slots would be both free and cached.
+        total = 64
+        c, alloc, free, free_ids = self._make_pool_cache(total, page=4)
+        c.cache_controller.write_page = lambda **kw: None
+        key = RadixKey(list(range(32)), None)
+        c.insert(InsertParams(key=key, value=alloc(32)))
+        head = c.root_node.children[key.child_key(4)]
+        tail = head
+        head = c._split_node(tail.key, tail, 16)
+        tail.host_value = torch.arange(16)
+        c._evict_backuped(tail)
+
+        # The chunked req holds the shared head and its own recomputed tail.
+        own = torch.cat([head.value, alloc(16)])
+        r2t = own.view(1, -1).clone()
+        c.req_to_token_pool = SimpleNamespace(
+            req_to_token=r2t, write=lambda idx, v: r2t.__setitem__(idx, v)
+        )
+        req = SimpleNamespace(
+            fill_ids=list(range(32)), extra_key=None, req_pool_idx=0,
+            cache_protected_len=16, last_node=head, prefix_indices=own[:16],
+        )
+        c.inc_lock_ref(head)
+
+        c.load_back(c.match_prefix(MatchPrefixParams(key=key)).best_match_node)
+        c.cache_unfinished_req(req, chunked=True)  # chunk boundary mid-load
+        c._free_failed_loadback(tail.id, 0)
+
+        kv = c.req_to_token_pool.req_to_token[0, :32].to(torch.int64)
+        prefix_len = c.insert(InsertParams(key=key, value=kv)).prefix_len
+        free(kv[req.cache_protected_len : prefix_len])
+        c.dec_lock_ref(req.last_node)
 
         cached = set()
         stack = list(c.root_node.children.values())

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -526,6 +526,68 @@ class TestEICHiCacheRegression(unittest.TestCase):
             len(free_ids) + c.evictable_size_ + c.protected_size_, total
         )
 
+    def test_partial_mget_refetches_only_failed_keys(self):
+        # A partial mget (per-key RPC timeouts) used to cut the load at the first
+        # failed key, discarding every later page that did arrive. The failed keys
+        # are re-got once into their own buffers; the device copy then covers the
+        # whole batch, and a key that fails again still cuts the prefix there.
+        from sglang.srt.mem_cache import eic_memory_pool as pool_mod
+
+        S = SimpleNamespace(SUCCESS=0, FAILED=1, PARTIAL_FAILED=2)
+
+        class Buffers(list):
+            def append(self, ptr, size, registered):
+                super().append(ptr)
+
+        fake_eic = SimpleNamespace(
+            StatusCode=S, StringVector=list, IOBuffers=Buffers,
+            GetOption=lambda: SimpleNamespace(),
+        )
+        objs = [torch.zeros(2) for _ in range(4)]
+        client = object.__new__(pool_mod.EICKVClient)
+        client.eic_namespace = "ns"
+        client.allocate_eic_read_buffer = lambda n: (objs, None, list(range(n)), True)
+        client.kv_cache_read_mem_pool = SimpleNamespace(free_to_mempool=lambda p: None)
+        calls = []
+
+        def mget(keys, option, vals):
+            calls.append((list(keys), list(vals)))
+            if len(calls) == 1:
+                codes = [S.SUCCESS, S.FAILED, S.SUCCESS, S.FAILED]
+                return S.PARTIAL_FAILED, vals, SimpleNamespace(status_codes=codes)
+            return S.SUCCESS, vals, SimpleNamespace(status_codes=[S.SUCCESS] * 2)
+
+        client.connection = SimpleNamespace(mget=mget)
+        copied = []
+        with mock.patch.object(pool_mod, "eic", fake_eic):
+            _, mask = client.batch_get(
+                ["k0", "k1", "k2", "k3"], torch.arange(4),
+                copy_func=lambda dev, pool, idx: copied.append(list(idx)),
+            )
+        self.assertEqual(calls[1], (["k1", "k3"], [objs[1].data_ptr(), objs[3].data_ptr()]))
+        self.assertEqual(mask, [True] * 4)
+        self.assertEqual(copied, [[0, 1, 2, 3]])
+
+        calls.clear()
+        copied.clear()
+
+        def mget_k3_fails_again(keys, option, vals):
+            calls.append(list(keys))
+            if len(calls) == 1:
+                codes = [S.SUCCESS, S.FAILED, S.SUCCESS, S.FAILED]
+            else:
+                codes = [S.SUCCESS, S.FAILED]
+            return S.PARTIAL_FAILED, vals, SimpleNamespace(status_codes=codes)
+
+        client.connection = SimpleNamespace(mget=mget_k3_fails_again)
+        with mock.patch.object(pool_mod, "eic", fake_eic):
+            _, mask = client.batch_get(
+                ["k0", "k1", "k2", "k3"], torch.arange(4),
+                copy_func=lambda dev, pool, idx: copied.append(list(idx)),
+            )
+        self.assertEqual(mask, [True, True, True, False])
+        self.assertEqual(copied, [[0, 1, 2]])
+
     def test_prefix_loading_covers_split_chain_until_settled(self):
         cache = object.__new__(EICPagedHiRadixCache)
         cache.pp_size = 1

--- a/test/registered/unit/mem_cache/test_eic_hicache_regression.py
+++ b/test/registered/unit/mem_cache/test_eic_hicache_regression.py
@@ -588,6 +588,40 @@ class TestEICHiCacheRegression(unittest.TestCase):
         self.assertEqual(mask, [True, True, True, False])
         self.assertEqual(copied, [[0, 1, 2]])
 
+        calls.clear()
+
+        def mget_mostly_down(keys, option, vals):
+            calls.append(list(keys))
+            codes = [S.SUCCESS, S.FAILED, S.FAILED, S.FAILED]
+            return S.PARTIAL_FAILED, vals, SimpleNamespace(status_codes=codes)
+
+        client.connection = SimpleNamespace(mget=mget_mostly_down)
+        with mock.patch.object(pool_mod, "eic", fake_eic):
+            _, mask = client.batch_get(["k0", "k1", "k2", "k3"])
+        self.assertEqual(len(calls), 1)  # backend down: no retry round
+        self.assertEqual(mask, [True, False, False, False])
+
+    def test_match_stops_at_resident_node_under_evicted_gap(self):
+        # A failed load-back frees a chain node whose child was inserted while
+        # the load was in flight, leaving resident KV under an evicted gap. The
+        # match used to append that child's slots after the prefix above the gap,
+        # splicing KV from non-adjacent positions into one prefix.
+        c, alloc, free, free_ids = self._make_pool_cache(64, page=4)
+        key = RadixKey(list(range(24)), None)
+        c.insert(InsertParams(key=key, value=alloc(24)))
+        low = c.root_node.children[key.child_key(4)]
+        mid = c._split_node(low.key, low, 16)
+        top = c._split_node(mid.key, mid, 8)
+        mid.host_value = torch.arange(8)
+        free(mid.value)
+        c.evictable_size_ -= len(mid.value)
+        mid.value = None  # the gap [8, 16); `low` [16, 24) stays resident
+
+        m = c.match_prefix(MatchPrefixParams(key=key))
+        self.assertEqual(m.device_indices.tolist(), top.value.tolist())
+        self.assertIs(m.last_device_node, top)
+        self.assertEqual(m.host_hit_length, 8)
+
     def test_prefix_loading_covers_split_chain_until_settled(self):
         cache = object.__new__(EICPagedHiRadixCache)
         cache.pp_size = 1


### PR DESCRIPTION
## Why
Chat cc32 (40K shared system prompt) crashes the PD prefill with `pool memory leak detected! [full]`, over-count 18688 tokens.

## Root cause
`load_back` sets `node.value` for the loaded chain before the EIC DMA acks, so a same-prefix req admitted in that window matches the chain as a GPU hit and adopts its slots. When the mget partially fails, `_free_failed_loadback` frees the failed tail while that req still holds it; the req's insert later re-links the same slot ids into the evicted node. Those pages are then both free and cached, so `available + evictable > total`.

Evidence from repro `chat_pool_leak_repro_20260911T030909Z`, DP1:
- 11:18:41 `eic mget 256 keys failed, fail count 3`; DP0 had no mget failure and did not leak.
- 11:18:42-43 same-prefix reqs admitted with `#cached-token: 40960` while the load was in flight.
- 11:18:43 the loader admits with `#cached-token: 22272` (87 of 160 pages); the failed tail is 73 pages = 18688 tokens, the exact over-count.

## Fix
The prefill admission loop skips a req whose matched device prefix runs through a node of an in-flight load (`prefix_loading`) until the load settles. It then matches the loaded prefix, or sees the failed tail as a host hit / recompute. Scope is PP=1 (production); under PP>1 the chains are per-stage, so a skip would fork admission, and the old behavior stays.

The same adoption can happen at a chunk boundary: a running chunked req recomputing the prefix reaches the in-flight chain, and `cache_unfinished_req`'s insert+match swaps its own KV for the landing slots. For that chunk the insert is skipped and the req keeps its KV private (ChunkCache semantics); the next chunk after the load settles inserts normally.

## Partial mget refetch
Partial mget failures in the chat cc32 runs were all per-key RPC timeouts (`rpc timedout`, `EIC_RPC_ERROR_NEED_RETRY`), with no misses. But the load keeps only the prefix before the first failed key: 74 of 78 partial mgets had fewer than half their keys fail, and 45 of 87 load-backs still kept only 0 to 2048 tokens. `batch_get` now re-gets the failed keys once into their own buffers before the device copy. A key that fails again still cuts the prefix there. The cost is one extra RPC round on the load thread for the failed keys only.

## Gap in a match, refetch bound
- A failed load-back can free a chain node whose child was inserted mid-load, which leaves resident KV under an evicted gap. The match used to walk through the gap and append the child's slots, splicing non-adjacent KV into one prefix. It now stops at the gap: the gap reports as a host hit, and the child becomes reachable again once the gap reloads.
- The refetch is skipped when more than half the keys failed. A backend that is down would only stall the serial load thread for another timeout round.

## Test
- `test_failed_load_under_same_prefix_req_keeps_pool_invariant` drives the real `insert` / `match_prefix` / `load_back` / `_free_failed_loadback` path with an injected whole-tail mget failure. Without the gate (same sequence as the crash) the pool ends at `available + evictable = total + 16` with 16 pages both free and cached; with the gate it balances.
- `test_chunk_insert_through_inflight_load_keeps_pool_invariant`: the chunk-boundary path; without the second commit the in-flight slots end up both free and cached.
- `test_prefix_loading_covers_split_chain_until_settled` covers a load chain split mid-load.
- `test_partial_mget_refetches_only_failed_keys`: only the failed keys are re-got, into their own buffers; a second failure still cuts the prefix; no retry when most keys failed.
- `test_match_stops_at_resident_node_under_evicted_gap`: the match ends above the gap instead of splicing the child's slots.
- Each fails on the tree without its fix. `test_eic_hicache_regression.py` 49/49 on the H20 pod.

## Cluster A/B (chat cc32, same image/nodes/flags/driver)
| | unfixed | commits 1-2 | commits 1-3 | commits 1-4 (final) |
|---|---|---|---|---|
| partial mgets | – | 78 | 29 (2083 failed keys re-got, 2009 recovered) | 44 (1760 failed keys re-got, 1749 recovered) |
| load-back failures | about 65 | about 100 | 2 | 8 |
| failed tail freed while still held | 2 | 0 | 0 | 0 |
| pool leak | DP0 over 11776, prefill crash | none | none | none |
| TTFT P50 at 327680 / 655360 / 983040 | 2.42 / 2.40 / 12.3 s | 1.32 / 1.41 / 6.55 s | 1.53 / 1.18 / 2.98 s | 1.24 / 1.35 / 3.33 s |
| controller | native_error (leak) | native_error (2 router-to-prefill send errors, cause undetermined) | all 3 points accepted, failure_class none | all 3 points accepted, failure_class none |

The EIC backend timeout rate differs from run to run, so the TTFT deltas are not attributable to the patch alone. The load-back failure drop comes straight from the refetch log.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
